### PR TITLE
Added Repetitions

### DIFF
--- a/Source/NSubstitute/Core/CallNotReceivedExactlyExceptionThrower.cs
+++ b/Source/NSubstitute/Core/CallNotReceivedExactlyExceptionThrower.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NSubstitute.Exceptions;
+
+namespace NSubstitute.Core
+{
+    public class CallNotReceivedExactlyExceptionThrower : ICallNotReceivedExactlyExceptionThrower
+    {
+        private readonly ICallFormatter _callFormatter;
+
+        public CallNotReceivedExactlyExceptionThrower(ICallFormatter callFormatter)
+        {
+            _callFormatter = callFormatter;
+        }
+
+        public void Throw(ICallSpecification callSpecification, IEnumerable<ICall> actualCalls, int expectedCount)
+        {
+            var builder = new StringBuilder();
+            int actualCount = actualCalls.Count();
+            builder.AppendLine(string.Format("Expected to receive call {0} times but received {1} times:\n\t {0}", expectedCount, actualCount, callSpecification.Format(_callFormatter)));
+            if (actualCount != expectedCount)
+            {
+                builder.AppendLine(string.Format("Actually received {0} calls that resemble the expected call.", actualCalls));
+            }
+            else
+            {
+                builder.AppendLine("Actually received (non-matching arguments indicated with '*' characters):");
+                foreach (var call in actualCalls)
+                {
+                    builder.AppendFormat("\t{0}\n", _callFormatter.Format(call, callSpecification));
+                }
+            }
+            throw new CallNotReceivedException(builder.ToString());
+        }
+    }
+}

--- a/Source/NSubstitute/Core/ICallNotReceivedExactlyExceptionThrower.cs
+++ b/Source/NSubstitute/Core/ICallNotReceivedExactlyExceptionThrower.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace NSubstitute.Core
+{
+    public interface ICallNotReceivedExactlyExceptionThrower
+    {
+        void Throw(ICallSpecification callSpecification, IEnumerable<ICall> actualCalls, int expectedCount);
+    }
+}

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -40,6 +40,7 @@ namespace NSubstitute.Core
                 new ResultSetter(callStack, pendingSpecification, callResults, callSpecificationFactory, callActions),
                 new EventHandlerRegistry(),
                 new CallNotReceivedExceptionThrower(callFormatter),
+                new CallNotReceivedExactlyExceptionThrower(callFormatter),
                 new CallReceivedExceptionThrower(callFormatter),
                 new DefaultForType(),
                 new IAutoValueProvider[] { new AutoSubstituteProvider(substituteFactory), new AutoStringProvider(), new AutoArrayProvider()}

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -202,6 +202,8 @@
     <Compile Include="Core\Arguments\SuppliedArgumentSpecifications.cs" />
     <Compile Include="Core\Arguments\SuppliedArgumentSpecificationsFactory.cs" />
     <Compile Include="Core\CallFactory.cs" />
+    <Compile Include="Core\CallNotReceivedExactlyExceptionThrower.cs" />
+    <Compile Include="Core\ICallNotReceivedExactlyExceptionThrower.cs" />
     <Compile Include="Core\DefaultForType.cs" />
     <Compile Include="Core\EventCallFormatter.cs" />
     <Compile Include="Core\Arguments\IArgumentEqualsSpecificationFactory.cs" />
@@ -227,8 +229,10 @@
     <Compile Include="Routing\AutoValues\AutoStringProvider.cs" />
     <Compile Include="Routing\AutoValues\AutoSubstituteProvider.cs" />
     <Compile Include="Routing\AutoValues\IAutoValueProvider.cs" />
+    <Compile Include="Routing\Definitions\CheckCallReceivedExactlyRoute.cs" />
     <Compile Include="Routing\Definitions\RecordCallSpecificationRoute.cs" />
     <Compile Include="Routing\Handlers\ClearUnusedCallSpecHandler.cs" />
+    <Compile Include="Routing\Handlers\CheckReceivedCallExactlyHandler.cs" />
     <Compile Include="Routing\Handlers\ReturnAutoValueForThisAndSubsequentCallsHandler.cs" />
     <Compile Include="Routing\Handlers\RecordCallSpecificationHandler.cs" />
     <Compile Include="Routing\IRouteDefinition.cs" />

--- a/Source/NSubstitute/Routing/Definitions/CheckCallReceivedExactlyRoute.cs
+++ b/Source/NSubstitute/Routing/Definitions/CheckCallReceivedExactlyRoute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute.Routing.Handlers;
+
+namespace NSubstitute.Routing.Definitions
+{
+    public class CheckCallReceivedExactlyRoute : IRouteDefinition
+    {
+        public IEnumerable<Type> HandlerTypes
+        {
+            get { return new[] {
+                    typeof (ClearUnusedCallSpecHandler),
+                    typeof (CheckReceivedCallExactlyHandler), 
+                    typeof (ReturnDefaultForReturnTypeHandler)}; }
+        }
+    }
+}

--- a/Source/NSubstitute/Routing/Handlers/CheckReceivedCallExactlyHandler.cs
+++ b/Source/NSubstitute/Routing/Handlers/CheckReceivedCallExactlyHandler.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute.Core;
+
+namespace NSubstitute.Routing.Handlers
+{
+    public class CheckReceivedCallExactlyHandler : ICallHandler
+    {
+        private readonly IReceivedCalls _receivedCalls;
+        private readonly ICallSpecificationFactory _callSpecificationFactory;
+        private readonly ICallNotReceivedExactlyExceptionThrower _exceptionThrower;
+        private readonly MatchArgs _matchArgs;
+        private readonly int _exceptedCount;
+
+        public CheckReceivedCallExactlyHandler(IReceivedCalls receivedCalls, ICallSpecificationFactory callSpecificationFactory, ICallNotReceivedExactlyExceptionThrower exceptionThrower, MatchArgs matchArgs, int exceptedCount)
+        {
+            _receivedCalls = receivedCalls;
+            _callSpecificationFactory = callSpecificationFactory;
+            _exceptionThrower = exceptionThrower;
+            _matchArgs = matchArgs;
+            _exceptedCount = exceptedCount;
+        }
+
+        public RouteAction Handle(ICall call)
+        {
+            var callSpecification = _callSpecificationFactory.CreateFrom(call, _matchArgs);
+            int actualCount = _receivedCalls.FindMatchingCalls(callSpecification).Count();
+            if (actualCount != _exceptedCount)
+            {
+                _exceptionThrower.Throw(callSpecification, GetAllReceivedCallsToMethod(call), _exceptedCount);
+            }
+            return RouteAction.Continue();
+        }
+
+        private IEnumerable<ICall> GetAllReceivedCallsToMethod(ICall call)
+        {
+            var allCallsToMethodSpec = _callSpecificationFactory.CreateFrom(call, MatchArgs.Any);
+            return _receivedCalls.FindMatchingCalls(allCallsToMethodSpec);
+        }
+    }
+}

--- a/Source/NSubstitute/SubstituteExtensions.cs
+++ b/Source/NSubstitute/SubstituteExtensions.cs
@@ -57,6 +57,13 @@ namespace NSubstitute
             return substitute;
         }
 
+        public static T Received<T>(this T substitute, int expectedCount) where T : class
+        {
+            var router = GetRouterForSubstitute(substitute);
+            router.SetRoute<CheckCallReceivedExactlyRoute>(MatchArgs.AsSpecifiedInCall, expectedCount);
+            return substitute;
+        }
+
         public static T DidNotReceive<T>(this T substitute) where T : class
         {
             var router = GetRouterForSubstitute(substitute);
@@ -68,6 +75,13 @@ namespace NSubstitute
         {
             var router = GetRouterForSubstitute(substitute);
             router.SetRoute<CheckCallReceivedRoute>(MatchArgs.Any);
+            return substitute;
+        }
+
+        public static T ReceivedWithAnyArgs<T>(this T substitute, int expectedCount) where T : class
+        {
+            var router = GetRouterForSubstitute(substitute);
+            router.SetRoute<CheckCallReceivedExactlyRoute>(MatchArgs.Any, expectedCount);
             return substitute;
         }
         


### PR DESCRIPTION
Added repetitions to NSubstitute. The following syntax is now supported in NSubstitute:
 sub.Received(3).Foo()
 sub.Received(3).Foo(123, "abcd")
3 Tests have been marked to be Ignored. I suspect they are invalid tests, I would like someone to do a peer review on the validity of these tests and take necessary action (write code to pass tests or remove the tests).
