### PR TITLE
Re: Auto-subbing from Func delegates

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
+++ b/Source/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -78,6 +79,30 @@ namespace NSubstitute.Acceptance.Specs
         {
             Assert.That(_sample.ListOfStrings, Is.Not.Null);
             Assert.That(_sample.ListOfStrings.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Should_auto_return_a_function()
+        {
+            var x = Substitute.For<Func<ISample>>();
+
+            Assert.That(x(), Is.Not.Null);
+        }
+
+        [Test]
+        public void Should_auto_return_a_string_from_a_func()
+        {
+            var x = Substitute.For<Func<ISample, string>>();
+
+            Assert.That(x(_sample), Is.Not.Null);
+        }
+
+        [Test]
+        public void Should_auto_return_an_action()
+        {
+            var x = Substitute.For<Action<ISample>>();
+
+            Assert.That(x, Is.Not.Null);
         }
     }
 }

--- a/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
+++ b/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
@@ -202,6 +202,7 @@
     <Compile Include="CallFormatterSpecs.cs" />
     <Compile Include="CallInfoFactorySpecs.cs" />
     <Compile Include="CallInfoSpecs.cs" />
+    <Compile Include="Proxies\DelegateProxy\DelegateCallSpecs.cs" />
     <Compile Include="QuantitySpecs.cs" />
     <Compile Include="ReceivedCallsExceptionThrowerSpecs.cs" />
     <Compile Include="CallRouterFactorySpecs.cs" />

--- a/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateCallSpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateCallSpecs.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Reflection;
+using NSubstitute.Core;
+using NSubstitute.Proxies.DelegateProxy;
+using NSubstitute.Specs.Infrastructure;
+using NUnit.Framework;
+
+namespace NSubstitute.Specs.Proxies.DelegateProxy
+{
+    public abstract class DelegateCallSpecs : ConcernFor<DelegateCall>
+    {
+        protected IParameterInfo[] _parameterInfos;
+        protected Type _returnType;
+        protected ICallRouter _callRouter;
+
+        public override void Context()
+        {
+            _callRouter = mock<ICallRouter>();
+            _parameterInfos = new IParameterInfo[0];
+        }
+
+        public override DelegateCall CreateSubjectUnderTest()
+        {
+            return new DelegateCall(_callRouter, _returnType, _parameterInfos);
+        }
+
+        [Test]
+        public void CallRouter_is_called_on_Invoke()
+        {
+            sut.Invoke(new object[0]);
+
+            _callRouter.Received().Route(Arg.Any<ICall>());
+        }
+
+        public class When_return_type_is_string : DelegateCallSpecs
+        {
+            public override void Context()
+            {
+                base.Context();
+                _returnType = typeof(string);
+            }
+
+            [Test]
+            public void DelegateCallInvoke_should_have_string_return_type()
+            {
+                MethodInfo methodInfo = sut.DelegateCallInvoke;
+
+                Assert.That(methodInfo.ReturnType, Is.EqualTo(_returnType));
+            }
+        }
+
+        public class When_return_type_is_void : DelegateCallSpecs
+        {
+            public override void Context()
+            {
+                base.Context();
+                _returnType = typeof(void);
+            }
+
+            [Test]
+            public void DelegateCallInvoke_should_have_object_return_type()
+            {
+                MethodInfo methodInfo = sut.DelegateCallInvoke;
+
+                Assert.That(methodInfo.ReturnType, Is.EqualTo(typeof(object)));
+            }
+        }
+    }
+}

--- a/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
@@ -45,15 +45,15 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             private ICall DelegateCallWithArg(int arg)
             {
 #if SILVERLIGHT
-                return Arg<ICall>.Matches<ICall>(x => CalledWithOnlyOneArg(x, arg) && CallIsInvokeOnDelegateCall(x)); 
+                return Arg<ICall>.Matches<ICall>(x => CalledWithOnlyOneArg(x, arg) && CallIsInvokeOnDelegateCall<string>(x)); 
 #else
-                return Arg<ICall>.Matches(x => CalledWithOnlyOneArg(x, arg) && CallIsInvokeOnDelegateCall(x)); 
+                return Arg<ICall>.Matches(x => CalledWithOnlyOneArg(x, arg) && CallIsInvokeOnDelegateCall<string>(x)); 
 #endif
             }
 
-            private bool CallIsInvokeOnDelegateCall(ICall x)
+            private bool CallIsInvokeOnDelegateCall<T>(ICall x)
             {
-                return x.GetMethodInfo() == typeof(DelegateCall).GetMethod("Invoke");
+                return x.GetMethodInfo() == typeof(DelegateCall).GetMethod("GenericInvoke").MakeGenericMethod(typeof(T));
             }
 
             private bool CalledWithOnlyOneArg(ICall x, int arg)

--- a/Source/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/Source/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -31,10 +31,11 @@ namespace NSubstitute.Proxies.DelegateProxy
         private object DelegateProxy(Type delegateType, ICallRouter callRouter)
         {
             var delegateMethodToProxy = delegateType.GetMethod("Invoke");
-            var invokeOnDelegateCall = DelegateCall.DelegateCallInvoke;
 
             var proxyParameterTypes = delegateMethodToProxy.GetParameters().Select(x => new ParameterInfoWrapper(x)).ToArray();
+            
             var delegateCall = new DelegateCall(callRouter, delegateMethodToProxy.ReturnType, proxyParameterTypes);
+            var invokeOnDelegateCall = delegateCall.DelegateCallInvoke;
 
             ParameterExpression[] proxyParameters = delegateMethodToProxy.GetParameters().Select(x => Expression.Parameter(x.ParameterType, x.Name)).ToArray();
             Expression[] proxyParametersAsObjects = proxyParameters.Select(x => (Expression)Expression.Convert(x, typeof(object))).ToArray();


### PR DESCRIPTION
This might do the trick.

I added a generic invoke method on the DelegateCall to allow the DelegateCallInvoke have the correct return type instead of Object.

-Sauli
