### PR TITLE
Arg invoke four arguments

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/ArgumentInvocationFromMatchers.cs
+++ b/Source/NSubstitute.Acceptance.Specs/ArgumentInvocationFromMatchers.cs
@@ -11,7 +11,10 @@ namespace NSubstitute.Acceptance.Specs
         public interface IFoo
         {
             void MethodWithCallback(string something, Action callback);
+            void MethodWithCallbackWithArguments(string something, Action<int> callback);
             void MethodWithCallbackWithArguments(string something, Action<int, string> callback);
+            void MethodWithCallbackWithArguments(string something, Action<int, string, double> callback);
+            void MethodWithCallbackWithArguments(string something, Action<int, string, double, char> callback);
             void MethodWithDelegateCallback(string something, ActionCompatibleDelegate callback);
             int MethodWithCallbackWithArgumentsAndReturnValue(string something, Action<int, string> callback);
         }
@@ -32,14 +35,31 @@ namespace NSubstitute.Acceptance.Specs
         [Test]
         public void Invoke_callback_with_arguments()
         {
-            var action = Substitute.For<Action<int, string>>();
             var sub = Substitute.For<IFoo>();
+
+            var action1 = Substitute.For<Action<int>>();
+            sub.MethodWithCallbackWithArguments("test", Arg.Invoke(1));
+            sub.MethodWithCallbackWithArguments("test", action1);
+            action1.Received().Invoke(1);
+            sub.Received().MethodWithCallbackWithArguments("test", action1);
+
+            var action2 = Substitute.For<Action<int, string>>();
             sub.MethodWithCallbackWithArguments("test", Arg.Invoke(1, "hello"));
+            sub.MethodWithCallbackWithArguments("test", action2);
+            action2.Received().Invoke(1, "hello");
+            sub.Received().MethodWithCallbackWithArguments("test", action2);
 
-            sub.MethodWithCallbackWithArguments("test", action);
+            var action3 = Substitute.For<Action<int, string, double>>();
+            sub.MethodWithCallbackWithArguments("test", Arg.Invoke(1, "hello", 3.14));
+            sub.MethodWithCallbackWithArguments("test", action3);
+            action3.Received().Invoke(1, "hello", 3.14);
+            sub.Received().MethodWithCallbackWithArguments("test", action3);
 
-            action.Received().Invoke(1, "hello");
-            sub.Received().MethodWithCallbackWithArguments("test", action);
+            var action4 = Substitute.For<Action<int, string, double, char>>();
+            sub.MethodWithCallbackWithArguments("test", Arg.Invoke(1, "hello", 3.14, '!'));
+            sub.MethodWithCallbackWithArguments("test", action4);
+            action4.Received().Invoke(1, "hello", 3.14, '!');
+            sub.Received().MethodWithCallbackWithArguments("test", action4);
         }
 
         [Test]

--- a/Source/NSubstitute/Arg.cs
+++ b/Source/NSubstitute/Arg.cs
@@ -107,7 +107,7 @@ namespace NSubstitute
         /// <returns></returns>
         public static Action<T1, T2, T3, T4> Invoke<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
-            return ArgSpecQueue.EnqueueSpecFor<Action<T1, T2, T3, T4>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3, T4>)), InvokeDelegateAction(arg1, arg2, arg3, arg3));
+            return ArgSpecQueue.EnqueueSpecFor<Action<T1, T2, T3, T4>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3, T4>)), InvokeDelegateAction(arg1, arg2, arg3, arg4));
         }
 
         /// <summary>


### PR DESCRIPTION
Arg.Invoke with four arguments previously only used the first three parameters. Arg4 was unused and arg3 was used twice.

PS. I don't know why GitHub's diff shows each line as changed. On my own computer, diff only highlighted the actually changed lines.
