### PR TITLE
Adding UIPermissionAttribute to AttributesToAvoidReplicating used with Castle Dynamic Proxy.

### DIFF
--- a/Source/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/Source/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -103,6 +103,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 #if NET4
             AttributesToAvoidReplicating.Add<System.Runtime.InteropServices.TypeIdentifierAttribute>();
 #endif
+            AttributesToAvoidReplicating.Add<UIPermissionAttribute>();
         }
     }
 }


### PR DESCRIPTION
To make it possible to substitute interfaces that exposes methods or
properties that uses System.Windows.IDataObject.
