### PR TITLE
Possible issue with check of optional parameters

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/FieldReports/PossibleIssue_ArgumentCheckOfOptionalParameter.cs
+++ b/Source/NSubstitute.Acceptance.Specs/FieldReports/PossibleIssue_ArgumentCheckOfOptionalParameter.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class PossibleIssue_ArgumentCheckOfOptionalParameter
+    {
+        public interface IInterface
+        {
+            void MethodWithOptionalParameter(object obligatory, object optional = null);
+        }
+
+        [Test]
+        public void PassArgumentCheckForOptionalParameter()
+        {
+            var substitute = Substitute.For<IInterface>();
+            substitute.MethodWithOptionalParameter(new object());
+            substitute.ReceivedWithAnyArgs().MethodWithOptionalParameter(Arg.Any<object>());
+        }
+    }
+}

--- a/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -73,6 +73,7 @@
     <Compile Include="AutoValuesForSubs.cs" />
     <Compile Include="FieldReports\CallingIntoNewSubWithinReturns.cs" />
     <Compile Include="FieldReports\Issue110_CustomExceptions.cs" />
+    <Compile Include="FieldReports\PossibleIssue_ArgumentCheckOfOptionalParameter.cs" />
     <Compile Include="ReturnsAndDoes.cs" />
     <Compile Include="ExceptionsWhenCheckingReceivedCalls.cs" />
     <Compile Include="ExceptionsWhenCheckingSequencesOfCalls.cs" />


### PR DESCRIPTION
Hi,

I found an issue that can be not an issue:)
NSubstitute expects all parameters to be specified including optional parameters.
It throws AmbiguousArgumentsException if optional parameter is not specified.
I think the case can be handled.
