### PR TITLE
Add a received property-get check using a lambda to avoid temporary variables

### DIFF
--- a/Source/Docs/help/_posts/2010-03-01-received-calls.markdown
+++ b/Source/Docs/help/_posts/2010-03-01-received-calls.markdown
@@ -129,6 +129,10 @@ calculator.Mode = "TEST";
 //the compiler happy.
 var temp = calculator.Received().Mode;
 
+//Alternatively, check received call to property getter 
+//using a lambda.
+calculator.Received(c => c.Mode);
+
 //Check received call to property setter with arg of "TEST"
 calculator.Received().Mode = "TEST";
 {% endexamplecode %}

--- a/Source/NSubstitute.Acceptance.Specs/PropertyBehaviour.cs
+++ b/Source/NSubstitute.Acceptance.Specs/PropertyBehaviour.cs
@@ -91,5 +91,37 @@ namespace NSubstitute.Acceptance.Specs
             foo.Received().WriteOnly = somethingToWrite;
             Assert.Throws<ReceivedCallsException>(() => foo.Received().WriteOnly = "non-fancy writable stuff");
         }
+
+        [Test]
+        public void Check_a_property_getter_was_called_using_lambda_override()
+        {
+            var foo = Substitute.For<IFoo>();
+            _ignored = foo.Name;
+            foo.Received(f => f.Name);
+        }
+
+        [Test]
+        public void Check_a_property_getter_using_lambda_override_fails_if_not_called()
+        {
+            var foo = Substitute.For<IFoo>();
+            Assert.Throws<ReceivedCallsException>(() => foo.Received(f => f.Name));
+        }
+
+        [Test]
+        public void Check_a_property_get_count_using_lambda_override()
+        {
+            var foo = Substitute.For<IFoo>();
+            _ignored = foo.Name;
+            _ignored = foo.Name;
+            foo.Received(2, f => f.Name);
+        }
+
+        [Test]
+        public void Check_a_property_get_count_using_lambda_override_fails_if_wrong_count()
+        {
+            var foo = Substitute.For<IFoo>();
+            _ignored = foo.Name;
+            Assert.Throws<ReceivedCallsException>(() => foo.Received(2, f => f.Name));
+        }
     }
 }

--- a/Source/NSubstitute/SubstituteExtensions.cs
+++ b/Source/NSubstitute/SubstituteExtensions.cs
@@ -119,6 +119,33 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Checks this substitute has received a property get.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TProperty">The type of the property to check</typeparam>
+        /// <param name="substitute"></param>
+        /// <param name="get">A delegate which retrieves the property</param>
+        /// <returns></returns>
+        public static void Received<T, TProperty>(this T substitute, Func<T, TProperty> get) where T : class
+        {
+            get(substitute.Received());
+        }
+
+        /// <summary>
+        /// Checks this substitute has received the required number of a property get.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TProperty">The type of the property to check</typeparam>
+        /// <param name="substitute"></param>
+        /// <param name="requiredNumberOfCalls"></param>
+        /// <param name="get">A delegate which retrieves the property</param>
+        /// <returns></returns>
+        public static void Received<T, TProperty>(this T substitute, int requiredNumberOfCalls, Func<T, TProperty> get) where T : class
+        {
+            get(substitute.Received(requiredNumberOfCalls));
+        }
+
+        /// <summary>
         /// Checks this substitute has not received the following call.
         /// </summary>
         /// <typeparam name="T"></typeparam>


### PR DESCRIPTION
Added overloads to the Received extension method, to take a lambda which queries the property.
This way you can replace
`var ignored = substitute.Received(1).Name;`
with
`substitute.Received(1, s => s.Name);`
which keeps tools like ReSharper quieter.

Tests & documentation change included.
