### PR TITLE
#129 Ambiguous args with out/ref arg

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/FieldReports/Issue129_AmbiguousArgsWithOutRef.cs
+++ b/Source/NSubstitute.Acceptance.Specs/FieldReports/Issue129_AmbiguousArgsWithOutRef.cs
@@ -10,7 +10,6 @@ namespace NSubstitute.Acceptance.Specs.FieldReports
         }
 
         [Test]
-        [Pending, Explicit]
         public void Test()
         {
             string someType;

--- a/Source/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
+++ b/Source/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
@@ -18,7 +18,7 @@ namespace NSubstitute.Core.Arguments
             {
                 return suppliedArgumentSpecifications.Dequeue();
             }
-            if (!suppliedArgumentSpecifications.AnyFor(argument, parameterInfo.ParameterType) || parameterInfo.IsOptional)
+            if (!suppliedArgumentSpecifications.AnyFor(argument, parameterInfo.ParameterType) || parameterInfo.IsOptional || parameterInfo.IsOut)
             {
                 return _argumentEqualsSpecificationFactory.Create(argument, parameterInfo.ParameterType);
             }

--- a/Source/NSubstitute/Core/IParameterInfo.cs
+++ b/Source/NSubstitute/Core/IParameterInfo.cs
@@ -7,5 +7,6 @@ namespace NSubstitute.Core
         Type ParameterType { get; }
         bool IsParams { get; }
         bool IsOptional { get; }
+        bool IsOut { get; }
     }
 }

--- a/Source/NSubstitute/Core/ParameterInfoFromType.cs
+++ b/Source/NSubstitute/Core/ParameterInfoFromType.cs
@@ -25,5 +25,10 @@ namespace NSubstitute.Core
         {
             get { return false; }
         }
+
+        public bool IsOut
+        {
+            get { return false; }
+        }
     }
 }

--- a/Source/NSubstitute/Core/ParameterInfoWrapper.cs
+++ b/Source/NSubstitute/Core/ParameterInfoWrapper.cs
@@ -26,5 +26,10 @@ namespace NSubstitute.Core
         {
             get { return _parameterInfo.IsOptional; }
         }
+
+        public bool IsOut
+        {
+            get { return _parameterInfo.IsOut; }
+        }
     }
 }


### PR DESCRIPTION
Issue #129. Fixed by adding IsOut ParameterType exception to NonParamsArgumentSpecificationFactory.
