### PR TITLE
Task<T> should never return null

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -149,8 +149,5 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="($(MSBuildTargets) == '') Or ($(MSBuildTargets) == 'CSharp')" />
 </Project>

--- a/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
+++ b/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
@@ -188,8 +188,5 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="($(MSBuildTargets) == '') Or ($(MSBuildTargets) == 'CSharp')" />
 </Project>


### PR DESCRIPTION
In the world of async/await, returning a default value is never done via returning `null`, it is done by returning a `Task<T>` whose Result is `null`. 

Having a default value for `Task<T>` be `null` makes mocking async methods unnecessarily complicated, because the result is guaranteed to be bad (i.e. you _must_ mock every async method called, because awaiting `null` will only lead to tears).

Instead, this PR mocks `Task` and `Task<T>` by returning an already-completed `TaskCompletionSource`, having the same effect as returning the default value, only awaited.
