### PR TITLE
Added a new argument matcher which performs a shallow property match.

### DIFF
--- a/Source/NSubstitute.Specs/Arguments/PropertyEqualsArgumentMatcherSpecs.cs
+++ b/Source/NSubstitute.Specs/Arguments/PropertyEqualsArgumentMatcherSpecs.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using NSubstitute.Core.Arguments;
+using NUnit.Framework;
+
+namespace NSubstitute.Specs.Arguments
+{
+    public class PropertyEqualsArgumentMatcherSpecs
+    {
+        #region Setup
+
+        public class TestClass
+        {
+            public TestClass(int intProperty, string stringProperty, IList<string> refProperty, int privateProperty = 0)
+            {
+                IntProperty = intProperty;
+                StringProperty = stringProperty;
+                RefProperty = refProperty;
+                PrivateProperty = privateProperty;
+            }
+
+            public int IntProperty { get; private set; }
+            public string StringProperty { get; private set; }
+            public IList<string> RefProperty { get; private set; }
+            private int PrivateProperty { get; set; }
+        }
+
+        public class TestCase
+        {
+            public TestClass TestObj1 { get; set; }
+            public TestClass TestObj2 { get; set; }
+        }
+
+        private static IEnumerable<TestCase> GetNonMatchingArguments()
+        {
+            var list = new List<string>();
+
+            yield return new TestCase
+            {
+                TestObj1 = new TestClass(1, "Test", list),
+                TestObj2 = new TestClass(2, "Test", list)
+            };
+
+            yield return new TestCase
+            {
+                TestObj1 = new TestClass(1, "Some string", list),
+                TestObj2 = new TestClass(1, "another string", list)
+            };
+
+            // Note that this a shallow comparison so any object properties must be Reference equal (list in this case)
+            yield return new TestCase
+            {
+                TestObj1 = new TestClass(1, "Test", new List<string>()),
+                TestObj2 = new TestClass(2, "Test", new List<string>())
+            };
+        }
+
+        #endregion
+
+        [Test]
+        public void Should_match_when_arguments_have_same_public_property_values()
+        {
+            var list = new List<string>();
+            var testObj1 = new TestClass(1, "Test", list);
+            var testObj2 = new TestClass(1, "Test", list);
+
+            Assert.That(new PropertyEqualsArgumentMatcher(testObj1).IsSatisfiedBy(testObj2));
+        }
+
+        [Test]
+        public void Should_match_when_only_private_properties_differ()
+        {
+            var list = new List<string>();
+            var testObj1 = new TestClass(1, "Test", list, 1);
+            var testObj2 = new TestClass(1, "Test", list, 10);
+
+            Assert.That(new PropertyEqualsArgumentMatcher(testObj1).IsSatisfiedBy(testObj2));
+        }
+
+        [Test]
+        [TestCaseSource("GetNonMatchingArguments")]
+        public void Should_not_match_when_public_properties_differ(TestCase testCase)
+        {
+            Assert.That(new PropertyEqualsArgumentMatcher(testCase.TestObj1).IsSatisfiedBy(testCase.TestObj2), Is.False);
+        }
+    }
+}

--- a/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
+++ b/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Arguments\ArgumentSpecificationFactorySpecs.cs" />
     <Compile Include="Arguments\ArrayArgumentSpecificationsFactorySpecs.cs" />
     <Compile Include="Arguments\ArrayContentsArgumentMatcherSpecs.cs" />
+    <Compile Include="Arguments\PropertyEqualsArgumentMatcherSpecs.cs" />
     <Compile Include="Arguments\SuppliedArgumentSpecificationsFactorySpecs.cs" />
     <Compile Include="Arguments\ParameterInfosFromParamsArrayFactorySpecs.cs" />
     <Compile Include="Arguments\SuppliedArgumentSpecificationsSpecs.cs" />

--- a/Source/NSubstitute/Arg.cs
+++ b/Source/NSubstitute/Arg.cs
@@ -46,6 +46,17 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Match argument that has matching public property values in <paramref name="value"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static T PropertyEquals<T>(T value)
+        {
+            return ArgSpecQueue.EnqueueSpecFor<T>(new PropertyEqualsArgumentMatcher(value));
+        }
+
+        /// <summary>
         /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
         /// </summary>
         /// <returns></returns>

--- a/Source/NSubstitute/Core/Arguments/PropertyEqualsArgumentMatcher.cs
+++ b/Source/NSubstitute/Core/Arguments/PropertyEqualsArgumentMatcher.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NSubstitute.Core.Arguments
+{
+    public class PropertyEqualsArgumentMatcher : IArgumentMatcher
+    {
+        private readonly object _value;
+
+        public PropertyEqualsArgumentMatcher(object value)
+        {
+            _value = value;
+        }
+
+        public bool IsSatisfiedBy(object argument)
+        {
+            return _value.GetType() == argument.GetType() && Equals(_value, argument, _value.GetType());
+        }
+
+        private static bool Equals(object obj1, object obj2, Type typeToCompareOn)
+        {
+            return typeToCompareOn
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .All(p => PropertiesEqual(p, obj1, obj2));
+        }
+
+        private static bool PropertiesEqual(PropertyInfo property, object obj1, object obj2)
+        {
+            var value1 = property.GetValue(obj1, null);
+            var value2 = property.GetValue(obj2, null);
+
+            return value1 == null && value2 == null
+                   || (value1 != null && value1.Equals(value2));
+        }
+    }
+}

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Core\Arguments\ISuppliedArgumentSpecifications.cs" />
     <Compile Include="Core\Arguments\ParameterInfosFromParamsArrayFactory.cs" />
     <Compile Include="Core\Arguments\ParamsArgumentSpecificationFactory.cs" />
+    <Compile Include="Core\Arguments\PropertyEqualsArgumentMatcher.cs" />
     <Compile Include="Core\Arguments\SuppliedArgumentSpecifications.cs" />
     <Compile Include="Core\Arguments\SuppliedArgumentSpecificationsFactory.cs" />
     <Compile Include="Core\CallBaseExclusions.cs" />


### PR DESCRIPTION
This might seem like a special case but I have found numerous situations in the past couple of years where I just want to match POCOs (usually something like a query object) and want to just be able to new up the matching argument in-line rather than writing a lambda. This allows for that. I'm happy to incorporate any feedback that makes this more useful.