### PR TITLE
Spike for #150 (Allow direct use of SubstituteFactory)

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/Configure.cs
+++ b/Source/NSubstitute.Acceptance.Specs/Configure.cs
@@ -13,13 +13,32 @@ namespace NSubstitute.Acceptance.Specs
 
         [Test]
         [Pending]
-        public void AllSubstitutesWideConfiguration()
+        public void SubstituteWideConfigure()
         {
-            Substitute.Configure(call => call.GetReturnType() == typeof(int) ? RouteAction.Return(5) : RouteAction.Continue());
-
             var sub = Substitute.For<IInterface>();
+            sub.Configure(call => call.GetReturnType() == typeof(int) ? RouteAction.Return(5) : RouteAction.Continue());
 
             Assert.AreEqual(5, sub.ReturnsInt());
         }
+
+        [Test]
+        [Pending]
+        public void ExtensionBasedOnConfigure()
+        {
+            var sub = Substitute.For<IInterface>();
+            sub.ReturnDefaultForAll(5);
+
+            Assert.AreEqual(5, sub.ReturnsInt());
+        }
+    }
+
+    public static class Extensions
+    {
+        public static TSubstitute ReturnDefaultForAll<TSubstitute, TReturnType>(this TSubstitute substitute, TReturnType defaultValue)
+        {
+            substitute.Configure(call => call.GetReturnType() == typeof(TReturnType) ? RouteAction.Return(defaultValue) : RouteAction.Continue());
+            return substitute;
+        }
+
     }
 }

--- a/Source/NSubstitute.Acceptance.Specs/Configure.cs
+++ b/Source/NSubstitute.Acceptance.Specs/Configure.cs
@@ -1,0 +1,25 @@
+﻿using NSubstitute.Core;
+
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    public class Configure
+    {
+        public interface IInterface
+        {
+            int ReturnsInt();
+        }
+
+        [Test]
+        [Pending]
+        public void CanNotCreatePartialSubForInterface()
+        {
+            Substitute.Configure(call => call.GetReturnType() == typeof(int) ? RouteAction.Return(5) : RouteAction.Continue());
+
+            var sub = Substitute.For<IInterface>();
+
+            Assert.AreEqual(5, sub.ReturnsInt());
+        }
+    }
+}

--- a/Source/NSubstitute.Acceptance.Specs/Configure.cs
+++ b/Source/NSubstitute.Acceptance.Specs/Configure.cs
@@ -13,7 +13,7 @@ namespace NSubstitute.Acceptance.Specs
 
         [Test]
         [Pending]
-        public void CanNotCreatePartialSubForInterface()
+        public void AllSubstitutesWideConfiguration()
         {
             Substitute.Configure(call => call.GetReturnType() == typeof(int) ? RouteAction.Return(5) : RouteAction.Continue());
 

--- a/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -97,6 +97,7 @@
     <Compile Include="ArgumentInvocationFromMatchers.cs" />
     <Compile Include="ArgDoFromMatcher.cs" />
     <Compile Include="AutoValuesForSubs.cs" />
+    <Compile Include="Configure.cs" />
     <Compile Include="DynamicCalls.cs" />
     <Compile Include="FieldReports\Issue129_AmbiguousArgsWithOutRef.cs" />
     <Compile Include="FieldReports\Issue149_ArgMatcherInReturns.cs" />

--- a/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
@@ -26,7 +26,7 @@ namespace NSubstitute.Specs
 
             public override SubstituteFactory CreateSubjectUnderTest()
             {
-                return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver);
+                return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver, null);
             }
         }
 

--- a/Source/NSubstitute/Core/ISubstituteContext.cs
+++ b/Source/NSubstitute/Core/ISubstituteContext.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NSubstitute.Core
+{
+    // better naming
+    public interface ISubstituteContext
+    {
+        Func<ICall, RouteAction>[] CustomCallHandlers { get; }
+        void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler);
+    }
+}

--- a/Source/NSubstitute/Core/ISubstituteContextResolver.cs
+++ b/Source/NSubstitute/Core/ISubstituteContextResolver.cs
@@ -1,0 +1,7 @@
+﻿namespace NSubstitute.Core
+{
+    public interface ISubstituteContextResolver
+    {
+        ISubstituteContext ResolveFor(object substitute);
+    }
+}

--- a/Source/NSubstitute/Core/ISubstituteFactory.cs
+++ b/Source/NSubstitute/Core/ISubstituteFactory.cs
@@ -7,5 +7,6 @@ namespace NSubstitute.Core
         object Create(Type[] typesToProxy, object[] constructorArguments); 
         object CreatePartial(Type[] typesToProxy, object[] constructorArguments); 
         ICallRouter GetCallRouterCreatedFor(object substitute);
+        ISubstituteContext GetSubstituteContextFor(object substitute);
     }
 }

--- a/Source/NSubstitute/Core/ISubstituteState.cs
+++ b/Source/NSubstitute/Core/ISubstituteState.cs
@@ -1,4 +1,6 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System;
+
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -18,5 +20,6 @@ namespace NSubstitute.Core
         IAutoValueProvider[] AutoValueProviders { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         void ClearUnusedCallSpecs();
+        Func<ICall, RouteAction>[] CustomCallHandlers { get; }
     }
 }

--- a/Source/NSubstitute/Core/ISubstituteState.cs
+++ b/Source/NSubstitute/Core/ISubstituteState.cs
@@ -20,6 +20,5 @@ namespace NSubstitute.Core
         IAutoValueProvider[] AutoValueProviders { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         void ClearUnusedCallSpecs();
-        Func<ICall, RouteAction>[] CustomCallHandlers { get; }
     }
 }

--- a/Source/NSubstitute/Core/ISubstitutionContext.cs
+++ b/Source/NSubstitute/Core/ISubstitutionContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using NSubstitute.Core.Arguments;
 using NSubstitute.Routing;
 
@@ -12,6 +13,7 @@ namespace NSubstitute.Core
         ConfiguredCall LastCallShouldReturn(IReturn value, MatchArgs matchArgs);
         void LastCallRouter(ICallRouter callRouter);
         ICallRouter GetCallRouterFor(object substitute);
+        ISubstituteContext GetSubstituteContextFor(object substitute);
         void EnqueueArgumentSpecification(IArgumentSpecification spec);
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();
         void RaiseEventForNextCall(Func<ICall, object[]> getArguments);
@@ -20,7 +22,5 @@ namespace NSubstitute.Core
         void AddToQuery(object target, ICallSpecification callSpecification);
         void ClearLastCallRouter();
         IRouteFactory GetRouteFactory();
-        Func<ICall, RouteAction>[] CustomCallHandlers { get; }
-        void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler);
     }
 }

--- a/Source/NSubstitute/Core/ISubstitutionContext.cs
+++ b/Source/NSubstitute/Core/ISubstitutionContext.cs
@@ -20,5 +20,7 @@ namespace NSubstitute.Core
         void AddToQuery(object target, ICallSpecification callSpecification);
         void ClearLastCallRouter();
         IRouteFactory GetRouteFactory();
+        Func<ICall, RouteAction>[] CustomCallHandlers { get; }
+        void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler);
     }
 }

--- a/Source/NSubstitute/Core/SubstituteContext.cs
+++ b/Source/NSubstitute/Core/SubstituteContext.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NSubstitute.Core
+{
+    public class SubstituteContext : ISubstituteContext
+    {
+        readonly RobustThreadLocal<IList<Func<ICall, RouteAction>>> _customCallHandlers = new RobustThreadLocal<IList<Func<ICall, RouteAction>>>(() => new List<Func<ICall, RouteAction>>());
+
+        public Func<ICall, RouteAction>[] CustomCallHandlers { get { return _customCallHandlers.Value.ToArray(); } }
+
+        public void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler)
+        {
+            _customCallHandlers.Value.Add(customCallHandler);
+        }
+    }
+}

--- a/Source/NSubstitute/Core/SubstituteContextResolver.cs
+++ b/Source/NSubstitute/Core/SubstituteContextResolver.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NSubstitute.Core
+{
+    public class SubstituteContextResolver : ISubstituteContextResolver
+    {
+        private readonly IDictionary<object, ISubstituteContext> _substituteContextMappings = new Dictionary<object, ISubstituteContext>();
+
+        public ISubstituteContext ResolveFor(object substitute)
+        {
+            if (substitute == null) throw new ArgumentNullException();
+
+            ISubstituteContext substituteContext;
+            if (!_substituteContextMappings.TryGetValue(substitute, out substituteContext))
+            {
+                substituteContext = new SubstituteContext();
+                _substituteContextMappings.Add(substitute, substituteContext);
+            }
+
+            return substituteContext;
+        }
+    }
+}

--- a/Source/NSubstitute/Core/SubstituteFactory.cs
+++ b/Source/NSubstitute/Core/SubstituteFactory.cs
@@ -10,13 +10,15 @@ namespace NSubstitute.Core
         readonly ICallRouterFactory _callRouterFactory;
         readonly IProxyFactory _proxyFactory;
         readonly ICallRouterResolver _callRouterResolver;
+        readonly ISubstituteContextResolver _substituteContextResolver;
 
-        public SubstituteFactory(ISubstitutionContext context, ICallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouterResolver)
+        public SubstituteFactory(ISubstitutionContext context, ICallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouterResolver, ISubstituteContextResolver substituteContextResolver)
         {
             _context = context;
             _callRouterFactory = callRouterFactory;
             _proxyFactory = proxyFactory;
             _callRouterResolver = callRouterResolver;
+            _substituteContextResolver = substituteContextResolver;
         }
 
         /// <summary>
@@ -68,6 +70,11 @@ namespace NSubstitute.Core
         public ICallRouter GetCallRouterCreatedFor(object substitute)
         {
             return _callRouterResolver.ResolveFor(substitute);
+        }
+
+        public ISubstituteContext GetSubstituteContextFor(object substitute)
+        {
+            return _substituteContextResolver.ResolveFor(substitute);
         }
     }
 }

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -1,4 +1,6 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System;
+
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -17,12 +19,14 @@ namespace NSubstitute.Core
         public IConfigureCall ConfigureCall { get; private set; }
         public IEventHandlerRegistry EventHandlerRegistry { get; private set; }
         public IAutoValueProvider[] AutoValueProviders { get; private set; }
+        public Func<ICall, RouteAction>[] CustomCallHandlers { get; private set; }
 
         public SubstituteState(ISubstitutionContext substitutionContext, SubstituteConfig option)
         {
             SubstitutionContext = substitutionContext;
             SubstituteConfig = option;
             SequenceNumberGenerator = substitutionContext.SequenceNumberGenerator;
+            CustomCallHandlers = substitutionContext.CustomCallHandlers;
             var substituteFactory = substitutionContext.SubstituteFactory;
             var callInfoFactory = new CallInfoFactory();
             var callStack = new CallStack();

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -19,14 +19,12 @@ namespace NSubstitute.Core
         public IConfigureCall ConfigureCall { get; private set; }
         public IEventHandlerRegistry EventHandlerRegistry { get; private set; }
         public IAutoValueProvider[] AutoValueProviders { get; private set; }
-        public Func<ICall, RouteAction>[] CustomCallHandlers { get; private set; }
 
         public SubstituteState(ISubstitutionContext substitutionContext, SubstituteConfig option)
         {
             SubstitutionContext = substitutionContext;
             SubstituteConfig = option;
             SequenceNumberGenerator = substitutionContext.SequenceNumberGenerator;
-            CustomCallHandlers = substitutionContext.CustomCallHandlers;
             var substituteFactory = substitutionContext.SubstituteFactory;
             var callInfoFactory = new CallInfoFactory();
             var callStack = new CallStack();

--- a/Source/NSubstitute/Core/SubstitutionContext.cs
+++ b/Source/NSubstitute/Core/SubstitutionContext.cs
@@ -20,7 +20,6 @@ namespace NSubstitute.Core
         readonly RobustThreadLocal<IList<IArgumentSpecification>> _argumentSpecifications = new RobustThreadLocal<IList<IArgumentSpecification>>(() => new List<IArgumentSpecification>());
         readonly RobustThreadLocal<Func<ICall, object[]>> _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object[]>>();
         readonly RobustThreadLocal<Query> _currentQuery = new RobustThreadLocal<Query>();
-        readonly RobustThreadLocal<IList<Func<ICall, RouteAction>>> _customCallHandlers = new RobustThreadLocal<IList<Func<ICall, RouteAction>>>(() => new List<Func<ICall, RouteAction>>());
 
         static SubstitutionContext()
         {
@@ -34,7 +33,8 @@ namespace NSubstitute.Core
             var delegateFactory = new DelegateProxyFactory();
             var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
             var callRouteResolver = new CallRouterResolver();
-            _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver);
+            var substituteContextResolver = new SubstituteContextResolver();
+            _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver, substituteContextResolver);
         }
 
         public SubstitutionContext(ISubstituteFactory substituteFactory)
@@ -67,13 +67,6 @@ namespace NSubstitute.Core
 
         public IRouteFactory GetRouteFactory() { return new RouteFactory(); }
 
-        public Func<ICall, RouteAction>[] CustomCallHandlers { get { return _customCallHandlers.Value.ToArray(); } }
-
-        public void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler)
-        {
-            _customCallHandlers.Value.Add(customCallHandler);
-        }
-
         public void LastCallRouter(ICallRouter callRouter)
         {
             _lastCallRouter.Value = callRouter;
@@ -93,6 +86,11 @@ namespace NSubstitute.Core
         public ICallRouter GetCallRouterFor(object substitute)
         {
             return SubstituteFactory.GetCallRouterCreatedFor(substitute);
+        }
+
+        public ISubstituteContext GetSubstituteContextFor(object substitute)
+        {
+            return SubstituteFactory.GetSubstituteContextFor(substitute);
         }
 
         public void EnqueueArgumentSpecification(IArgumentSpecification spec)

--- a/Source/NSubstitute/Core/SubstitutionContext.cs
+++ b/Source/NSubstitute/Core/SubstitutionContext.cs
@@ -20,6 +20,7 @@ namespace NSubstitute.Core
         readonly RobustThreadLocal<IList<IArgumentSpecification>> _argumentSpecifications = new RobustThreadLocal<IList<IArgumentSpecification>>(() => new List<IArgumentSpecification>());
         readonly RobustThreadLocal<Func<ICall, object[]>> _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object[]>>();
         readonly RobustThreadLocal<Query> _currentQuery = new RobustThreadLocal<Query>();
+        readonly RobustThreadLocal<IList<Func<ICall, RouteAction>>> _customCallHandlers = new RobustThreadLocal<IList<Func<ICall, RouteAction>>>(() => new List<Func<ICall, RouteAction>>());
 
         static SubstitutionContext()
         {
@@ -65,6 +66,13 @@ namespace NSubstitute.Core
         }
 
         public IRouteFactory GetRouteFactory() { return new RouteFactory(); }
+
+        public Func<ICall, RouteAction>[] CustomCallHandlers { get { return _customCallHandlers.Value.ToArray(); } }
+
+        public void EnqueueCustomCallHandler(Func<ICall, RouteAction> customCallHandler)
+        {
+            _customCallHandlers.Value.Add(customCallHandler);
+        }
 
         public void LastCallRouter(ICallRouter callRouter)
         {

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Routing\Handlers\AddCallToQueryResultHandler.cs" />
     <Compile Include="Routing\Handlers\ClearLastCallRouterHandler.cs" />
     <Compile Include="Routing\Handlers\ClearUnusedCallSpecHandler.cs" />
+    <Compile Include="Routing\Handlers\CustomCallHandlers.cs" />
     <Compile Include="Routing\Handlers\DoNotCallBaseForCallHandler.cs" />
     <Compile Include="Routing\Handlers\ReturnAutoValueForThisAndSubsequentCallsHandler.cs" />
     <Compile Include="Routing\Handlers\RecordCallSpecificationHandler.cs" />

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -158,6 +158,8 @@
     <Compile Include="Core\ICallBaseExclusions.cs" />
     <Compile Include="Core\ICallRouterProvider.cs" />
     <Compile Include="Core\IGetCallSpec.cs" />
+    <Compile Include="Core\ISubstituteContext.cs" />
+    <Compile Include="Core\ISubstituteContextResolver.cs" />
     <Compile Include="Core\Maybe.cs" />
     <Compile Include="Core\ReturnObservable.cs" />
     <Compile Include="Core\SequenceChecking\InstanceTracker.cs" />
@@ -180,6 +182,8 @@
     <Compile Include="Core\Events\DelegateEventWrapper.cs" />
     <Compile Include="Core\Events\EventHandlerWrapper.cs" />
     <Compile Include="Core\SubstituteConfig.cs" />
+    <Compile Include="Core\SubstituteContext.cs" />
+    <Compile Include="Core\SubstituteContextResolver.cs" />
     <Compile Include="Exceptions\ArgumentIsNotOutOrRefException.cs" />
     <Compile Include="Exceptions\ArgumentSetWithIncompatibleValueException.cs" />
     <Compile Include="Exceptions\CallSequenceNotFoundException.cs" />

--- a/Source/NSubstitute/Routing/Handlers/CustomCallHandlers.cs
+++ b/Source/NSubstitute/Routing/Handlers/CustomCallHandlers.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+using NSubstitute.Core;
+
+namespace NSubstitute.Routing.Handlers
+{
+    public class CustomCallHandlers : ICallHandler
+    {
+        private readonly Func<ICall, RouteAction>[] _customCallHandlers;
+
+        public CustomCallHandlers(Func<ICall, RouteAction>[] customCallHandlers)
+        {
+            _customCallHandlers = customCallHandlers;
+        }
+
+        public RouteAction Handle(ICall call)
+        {
+            foreach (var customCallHandler in _customCallHandlers)
+            {
+                var routeAction = customCallHandler(call);
+                if (routeAction.HasReturnValue)
+                {
+                    return routeAction;
+                }
+            }
+
+            return RouteAction.Continue();
+        }
+    }
+}

--- a/Source/NSubstitute/Routing/Handlers/CustomCallHandlers.cs
+++ b/Source/NSubstitute/Routing/Handlers/CustomCallHandlers.cs
@@ -6,16 +6,16 @@ namespace NSubstitute.Routing.Handlers
 {
     public class CustomCallHandlers : ICallHandler
     {
-        private readonly Func<ICall, RouteAction>[] _customCallHandlers;
+        private readonly ISubstitutionContext _substitutionContext;
 
-        public CustomCallHandlers(Func<ICall, RouteAction>[] customCallHandlers)
+        public CustomCallHandlers(ISubstitutionContext substitutionContext)
         {
-            _customCallHandlers = customCallHandlers;
+            _substitutionContext = substitutionContext;
         }
 
         public RouteAction Handle(ICall call)
         {
-            foreach (var customCallHandler in _customCallHandlers)
+            foreach (var customCallHandler in _substitutionContext.GetSubstituteContextFor(call.Target()).CustomCallHandlers)
             {
                 var routeAction = customCallHandler(call);
                 if (routeAction.HasReturnValue)

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -73,7 +73,7 @@ namespace NSubstitute.Routing
                 , new DoActionsCallHandler(state.CallActions)
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
-                , new CustomCallHandlers(state.CustomCallHandlers)
+                , new CustomCallHandlers(state.SubstitutionContext)
                 , new ReturnAutoValueForThisAndSubsequentCallsHandler(state.AutoValueProviders, state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -73,6 +73,7 @@ namespace NSubstitute.Routing
                 , new DoActionsCallHandler(state.CallActions)
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
+                , new CustomCallHandlers(state.CustomCallHandlers)
                 , new ReturnAutoValueForThisAndSubsequentCallsHandler(state.AutoValueProviders, state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()

--- a/Source/NSubstitute/Substitute.cs
+++ b/Source/NSubstitute/Substitute.cs
@@ -87,5 +87,9 @@ namespace NSubstitute
             var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
             return (T) substituteFactory.CreatePartial(new[] {typeof (T)}, constructorArguments);
         }
+
+        public static void Configure(params Func<ICall, RouteAction>[] callConfigurers)
+        {
+        }
     }
 }

--- a/Source/NSubstitute/Substitute.cs
+++ b/Source/NSubstitute/Substitute.cs
@@ -88,8 +88,12 @@ namespace NSubstitute
             return (T) substituteFactory.CreatePartial(new[] {typeof (T)}, constructorArguments);
         }
 
-        public static void Configure(params Func<ICall, RouteAction>[] callConfigurers)
+        public static void Configure(params Func<ICall, RouteAction>[] customCallHandlers)
         {
+            foreach (var customCallHandler in customCallHandlers)
+            {
+                SubstitutionContext.Current.EnqueueCustomCallHandler(customCallHandler);
+            }
         }
     }
 }

--- a/Source/NSubstitute/Substitute.cs
+++ b/Source/NSubstitute/Substitute.cs
@@ -87,13 +87,5 @@ namespace NSubstitute
             var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
             return (T) substituteFactory.CreatePartial(new[] {typeof (T)}, constructorArguments);
         }
-
-        public static void Configure(params Func<ICall, RouteAction>[] customCallHandlers)
-        {
-            foreach (var customCallHandler in customCallHandlers)
-            {
-                SubstitutionContext.Current.EnqueueCustomCallHandler(customCallHandler);
-            }
-        }
     }
 }

--- a/Source/NSubstitute/SubstituteExtensions.cs
+++ b/Source/NSubstitute/SubstituteExtensions.cs
@@ -224,10 +224,27 @@ namespace NSubstitute
             return GetRouterForSubstitute(substitute).ReceivedCalls();
         }
 
+        public static T Configure<T>(this T substitute, params Func<ICall, RouteAction>[] customCallHandlers)
+        {
+            var substituteContext = GetSubstituteContextFor(substitute);
+            foreach (var customCallHandler in customCallHandlers)
+            {
+                substituteContext.EnqueueCustomCallHandler(customCallHandler);
+            }
+
+            return substitute;
+        }
+
         private static ICallRouter GetRouterForSubstitute<T>(T substitute)
         {
             var context = SubstitutionContext.Current;
             return context.GetCallRouterFor(substitute);
+        }
+
+        private static ISubstituteContext GetSubstituteContextFor<T>(T substitute)
+        {
+            var context = SubstitutionContext.Current;
+            return context.GetSubstituteContextFor(substitute);
         }
 
         private static IRouteFactory RouteFactory()


### PR DESCRIPTION
Hi everyone!

This is a quick spike for #150 (Allow direct use of SubstituteFactory).

I added:
- "AllSubstitutesWide" API wich looks like `Substitute.Configure(params Func<ICall, RouteAction>[] customCallHandlers)`. Also can be "oneSubstituteWide" too.
- `Func<ICall, RouteAction>[] CustomCallHandlers` to `ISubstitutionContext` which stores all custom handlers.
- `CustomCallHandlers` as a new `ICallHandler` which handles calls and return values if needed.

I don't like that `RouteAction` is exposed outside but it can be repaced with `object`.

Usage:

``` csharp
Substitute.Configure(call => call.GetReturnType() == typeof(int) ? RouteAction.Return(5) : RouteAction.Continue());
var sub = Substitute.For<IInterface>();
Assert.AreEqual(5, sub.ReturnsInt());

public interface IInterface
{
    int ReturnsInt();
}
```

Looking forward to your feedback.
