### PR TITLE
Added more convenient setup of throwing exceptions.

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
+++ b/Source/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
@@ -73,10 +73,11 @@ namespace NSubstitute.Acceptance.Specs
         {
             int called = 0;
             _something.When(x => x.Echo(Arg.Any<int>())).Do(x => called++);
-            _something.When(x => x.Echo(Arg.Any<int>())).Throw<ArgumentException>();
+            var expectedException = _something.When(x => x.Echo(Arg.Any<int>())).Throw<ArgumentException>();
 
             Assert.That(called, Is.EqualTo(0), "Should not have been called yet");
-            Assert.Throws<ArgumentException>(() => _something.Echo(1234));
+            ArgumentException actualException = Assert.Throws<ArgumentException>(() => _something.Echo(1234));
+            Assert.That(actualException, Is.EqualTo(expectedException));
             Assert.That(called, Is.EqualTo(1));
         }
 

--- a/Source/NSubstitute/Core/WhenCalled.cs
+++ b/Source/NSubstitute/Core/WhenCalled.cs
@@ -52,9 +52,14 @@ namespace NSubstitute.Core
         /// <summary>
         /// Throw an exception of the given type when called.
         /// </summary>
-        public void Throw<TException>() where TException : Exception, new()
+        public TException Throw<TException>() where TException : Exception, new()
         {
-            Do(ci => { throw new TException(); });
+            TException exception = new TException();
+            Do(ci =>
+            {
+                throw exception;
+            });
+            return exception;
         }
 
 


### PR DESCRIPTION
Instead of `_something.When(s => s.DoStuff()).Do(ci => { throw new ArgumentException(); })`, just call `_something.When(s => s.DoStuff()).Throw<ArgumentException>()`.

Added three overloads:
1. `public void Throw(Exception exception)`
2. `public void Throw<TException>()`
3. `public void Throw(Func<CallInfo, Exception> createException)`
