### PR TITLE
Support for mixins + Clear methods for ICallActions & ICallResults

### DIFF
--- a/Source/NSubstitute.Specs/Proxies/CastleDynamicProxy/CastleDynamicProxyFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/CastleDynamicProxy/CastleDynamicProxyFactorySpecs.cs
@@ -25,7 +25,7 @@ namespace NSubstitute.Specs.Proxies.CastleDynamicProxy
 
             public override void Because()
             {
-                _result = (TFoo) sut.GenerateProxy(_callRouter, typeof(TFoo), _additionalInterfaces, _ctorArgs);
+                _result = (TFoo) sut.GenerateProxy(_callRouter, typeof(TFoo), _additionalInterfaces, _ctorArgs, new object[] {});
             }
 
             [Test]
@@ -120,7 +120,7 @@ namespace NSubstitute.Specs.Proxies.CastleDynamicProxy
                 var sut = new CastleDynamicProxyFactory();
 
                 Assert.Throws<SubstituteException>(
-                    () => sut.GenerateProxy(mock<ICallRouter>(), typeof(Foo), new[] { typeof(IFoo), typeof(SomeOtherClass) }, null)
+                    () => sut.GenerateProxy(mock<ICallRouter>(), typeof(Foo), new[] { typeof(IFoo), typeof(SomeOtherClass) }, null, new object[] {})
                 );
             }
 
@@ -135,7 +135,7 @@ namespace NSubstitute.Specs.Proxies.CastleDynamicProxy
                 var sut = new CastleDynamicProxyFactory();
 
                 Assert.Throws<SubstituteException>(
-                    () => sut.GenerateProxy(mock<ICallRouter>(), typeof(IFoo), null, new[] { new object() }));
+                    () => sut.GenerateProxy(mock<ICallRouter>(), typeof(IFoo), null, new[] { new object() }, new object[] {}));
             }
 
         }

--- a/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
@@ -43,7 +43,7 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             [Test]
             public void Proxy_should_forward_calls_with_generic_return_type_to_call_router_so_router_knows_exact_return_type_expected()
             {
-                var result = (Func<int, string>)sut.GenerateProxy(_callRouter, typeof(Func<int, string>), null, null);
+				var result = (Func<int, string>)sut.GenerateProxy(_callRouter, typeof(Func<int, string>), null, null, null);
                 result(12);
 
                 _callRouter.received(x =>
@@ -57,7 +57,7 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             [Test]
             public void Proxy_should_forward_action_calls_to_call_router()
             {
-                var result = (Action<int>)sut.GenerateProxy(_callRouter, typeof(Action<int>), null, null);
+                var result = (Action<int>)sut.GenerateProxy(_callRouter, typeof(Action<int>), null, null, null);
                 result(12);
                 _callRouter.received(x => x.Route(CallToMethodWithArg(DelegateCall.InvokeMethodWithObjectOrVoidReturnType, 12)));
             }
@@ -68,7 +68,7 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             [Test]
             public void Should_throw_substitute_exception()
             {
-                Assert.Throws<SubstituteException>(() => sut.GenerateProxy(_callRouter, typeof(Func<int>), new[] { typeof(IFoo) }, null));
+                Assert.Throws<SubstituteException>(() => sut.GenerateProxy(_callRouter, typeof(Func<int>), new[] { typeof(IFoo) }, null, new object[] {}));
             }
         }
 
@@ -77,7 +77,7 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             [Test]
             public void Should_throw_substitute_exception()
             {
-                Assert.Throws<SubstituteException>(() => sut.GenerateProxy(_callRouter, typeof(Func<int>), null, new[] { new object() }));
+                Assert.Throws<SubstituteException>(() => sut.GenerateProxy(_callRouter, typeof(Func<int>), null, new[] { new object() }, new object[] {}));
             }
         }
 

--- a/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/DelegateProxy/DelegateProxyFactorySpecs.cs
@@ -43,7 +43,7 @@ namespace NSubstitute.Specs.Proxies.DelegateProxy
             [Test]
             public void Proxy_should_forward_calls_with_generic_return_type_to_call_router_so_router_knows_exact_return_type_expected()
             {
-				var result = (Func<int, string>)sut.GenerateProxy(_callRouter, typeof(Func<int, string>), null, null, null);
+                var result = (Func<int, string>)sut.GenerateProxy(_callRouter, typeof(Func<int, string>), null, null, null);
                 result(12);
 
                 _callRouter.received(x =>

--- a/Source/NSubstitute.Specs/Proxies/ProxyFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/Proxies/ProxyFactorySpecs.cs
@@ -43,14 +43,14 @@ namespace NSubstitute.Specs.Proxies
 
             public override void Because()
             {
-                _result = sut.GenerateProxy(_callRouter, _delegateProxy.GetType(), _additionalInterfaces, _ctorArgs);
+                _result = sut.GenerateProxy(_callRouter, _delegateProxy.GetType(), _additionalInterfaces, _ctorArgs, new object[] {});
             }
 
             public override void Context()
             {
                 base.Context();
                 _delegateProxy = x => x.ToString();
-                _delegateFactory.stub(x => x.GenerateProxy(_callRouter, _delegateProxy.GetType(), _additionalInterfaces, _ctorArgs)).Return(_delegateProxy);
+                _delegateFactory.stub(x => x.GenerateProxy(_callRouter, _delegateProxy.GetType(), _additionalInterfaces, _ctorArgs, new object[] {})).Return(_delegateProxy);
             }
         }
         
@@ -67,14 +67,14 @@ namespace NSubstitute.Specs.Proxies
 
             public override void Because()
             {
-                _result = sut.GenerateProxy(_callRouter, _dynamicProxy.GetType(), _additionalInterfaces, _ctorArgs);
+                _result = sut.GenerateProxy(_callRouter, _dynamicProxy.GetType(), _additionalInterfaces, _ctorArgs, new object[] {});
             }
 
             public override void Context()
             {
                 base.Context();
                 _dynamicProxy = new object();
-                _dynamicProxyFactory.stub(x => x.GenerateProxy(_callRouter, _dynamicProxy.GetType(), _additionalInterfaces, _ctorArgs)).Return(_dynamicProxy);
+                _dynamicProxyFactory.stub(x => x.GenerateProxy(_callRouter, _dynamicProxy.GetType(), _additionalInterfaces, _ctorArgs, new object[] {})).Return(_dynamicProxy);
             }
         }
     }

--- a/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
@@ -14,7 +14,7 @@ namespace NSubstitute.Specs
             protected ISubstitutionContext _context;
             protected IProxyFactory _proxyFactory;
             protected ICallRouterResolver _callRouterResolver;
-			protected IMixinFactory _mixinFactory;
+            protected IMixinFactory _mixinFactory;
 
             public override void Context()
             {
@@ -23,12 +23,12 @@ namespace NSubstitute.Specs
                 _callRouterFactory = mock<ICallRouterFactory>();
                 _proxyFactory = mock<IProxyFactory>();
                 _callRouterResolver = mock<ICallRouterResolver>();
-	            _mixinFactory = mock<IMixinFactory>();
+                _mixinFactory = mock<IMixinFactory>();
             }
 
             public override SubstituteFactory CreateSubjectUnderTest()
             {
-				return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver, _mixinFactory);
+                return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver, _mixinFactory);
             }
         }
 
@@ -63,8 +63,8 @@ namespace NSubstitute.Specs
                 _proxy = new object();
                 _constructorArgs = new[] { new object() };
                 _callRouter = mock<ICallRouter>();
-				_callRouterFactory.stub(x => x.Create(It.Is(_context), It.IsAny<ISubstituteState>())).Return(_callRouter);
-				_mixinFactory.stub(x => x.Create(It.IsAny<Type>(), It.IsAny<Type[]>(), It.Is(_context), It.IsAny<ISubstituteState>())).Return(new object[0]);
+                _callRouterFactory.stub(x => x.Create(It.Is(_context), It.IsAny<ISubstituteState>())).Return(_callRouter);
+                _mixinFactory.stub(x => x.Create(It.IsAny<Type>(), It.IsAny<Type[]>(), It.Is(_context), It.IsAny<ISubstituteState>())).Return(new object[0]);
             }
 
             protected void ShouldReturnProxyWhenFactoryCalledWith(Type typeOfProxy, Type[] additionalTypes)

--- a/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/SubstituteFactorySpecs.cs
@@ -14,6 +14,7 @@ namespace NSubstitute.Specs
             protected ISubstitutionContext _context;
             protected IProxyFactory _proxyFactory;
             protected ICallRouterResolver _callRouterResolver;
+			protected IMixinFactory _mixinFactory;
 
             public override void Context()
             {
@@ -22,11 +23,12 @@ namespace NSubstitute.Specs
                 _callRouterFactory = mock<ICallRouterFactory>();
                 _proxyFactory = mock<IProxyFactory>();
                 _callRouterResolver = mock<ICallRouterResolver>();
+	            _mixinFactory = mock<IMixinFactory>();
             }
 
             public override SubstituteFactory CreateSubjectUnderTest()
             {
-                return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver);
+				return new SubstituteFactory(_context, _callRouterFactory, _proxyFactory, _callRouterResolver, _mixinFactory);
             }
         }
 
@@ -61,12 +63,13 @@ namespace NSubstitute.Specs
                 _proxy = new object();
                 _constructorArgs = new[] { new object() };
                 _callRouter = mock<ICallRouter>();
-                _callRouterFactory.stub(x => x.Create(_context, SubstituteConfig.OverrideAllCalls)).Return(_callRouter);
+				_callRouterFactory.stub(x => x.Create(It.Is(_context), It.IsAny<ISubstituteState>())).Return(_callRouter);
+				_mixinFactory.stub(x => x.Create(It.IsAny<Type>(), It.IsAny<Type[]>(), It.Is(_context), It.IsAny<ISubstituteState>())).Return(new object[0]);
             }
 
             protected void ShouldReturnProxyWhenFactoryCalledWith(Type typeOfProxy, Type[] additionalTypes)
             {
-                _proxyFactory.stub(x => x.GenerateProxy(_callRouter, typeOfProxy, additionalTypes, _constructorArgs)).Return(_proxy);
+                _proxyFactory.stub(x => x.GenerateProxy(_callRouter, typeOfProxy, additionalTypes, _constructorArgs, new object[] {})).Return(_proxy);
             }
         }
 

--- a/Source/NSubstitute/Core/CallActions.cs
+++ b/Source/NSubstitute/Core/CallActions.cs
@@ -42,6 +42,11 @@ namespace NSubstitute.Core
             }
         }
 
+	    public void Clear()
+	    {
+		    _actions.Clear();
+	    }
+
         class CallAction
         {
             public CallAction(ICallSpecification callSpecification, Action<CallInfo> action)

--- a/Source/NSubstitute/Core/CallActions.cs
+++ b/Source/NSubstitute/Core/CallActions.cs
@@ -42,10 +42,10 @@ namespace NSubstitute.Core
             }
         }
 
-	    public void Clear()
-	    {
-		    _actions.Clear();
-	    }
+        public void Clear()
+        {
+            _actions.Clear();
+        }
 
         class CallAction
         {

--- a/Source/NSubstitute/Core/CallResults.cs
+++ b/Source/NSubstitute/Core/CallResults.cs
@@ -32,11 +32,11 @@ namespace NSubstitute.Core
                     .GetResult(_callInfoFactory.Create(call));
         }
 
-	    public void ClearResults()
-	    {
-		    ResultForCallSpec _;
-		    while (_results.TryDequeue(out _)) {}
-	    }
+        public void ClearResults()
+        {
+            ResultForCallSpec _;
+            while (_results.TryDequeue(out _)) {}
+        }
 
         bool ReturnsVoidFrom(ICall call)
         {

--- a/Source/NSubstitute/Core/CallResults.cs
+++ b/Source/NSubstitute/Core/CallResults.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Linq;
 
 namespace NSubstitute.Core
@@ -5,8 +6,7 @@ namespace NSubstitute.Core
     public class CallResults : ICallResults
     {
         readonly ICallInfoFactory _callInfoFactory;
-        readonly System.Collections.Concurrent.ConcurrentQueue<ResultForCallSpec> _results 
-            = new System.Collections.Concurrent.ConcurrentQueue<ResultForCallSpec>();
+        readonly ConcurrentQueue<ResultForCallSpec> _results = new ConcurrentQueue<ResultForCallSpec>();
 
         public CallResults(ICallInfoFactory callInfoFactory)
         {
@@ -31,6 +31,12 @@ namespace NSubstitute.Core
                     .First(x => x.IsResultFor(call))
                     .GetResult(_callInfoFactory.Create(call));
         }
+
+	    public void ClearResults()
+	    {
+		    ResultForCallSpec _;
+		    while (_results.TryDequeue(out _)) {}
+	    }
 
         bool ReturnsVoidFrom(ICall call)
         {

--- a/Source/NSubstitute/Core/CallRouterFactory.cs
+++ b/Source/NSubstitute/Core/CallRouterFactory.cs
@@ -4,9 +4,8 @@ namespace NSubstitute.Core
 {
     public class CallRouterFactory : ICallRouterFactory
     {
-        public ICallRouter Create(ISubstitutionContext substitutionContext, SubstituteConfig config)
+        public ICallRouter Create(ISubstitutionContext substitutionContext, ISubstituteState substituteState)
         {
-            var substituteState = new SubstituteState(substitutionContext, config);
             return new CallRouter(substituteState, substitutionContext, new RouteFactory());
         }
     }

--- a/Source/NSubstitute/Core/EmptyMixinFactory.cs
+++ b/Source/NSubstitute/Core/EmptyMixinFactory.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace NSubstitute.Core
 {
-	public class EmptyMixinFactory : IMixinFactory
-	{
-		public object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState)
-		{
-			return new object[0];
-		}
-	}
+    public class EmptyMixinFactory : IMixinFactory
+    {
+        public object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState)
+        {
+            return new object[0];
+        }
+    }
 }

--- a/Source/NSubstitute/Core/EmptyMixinFactory.cs
+++ b/Source/NSubstitute/Core/EmptyMixinFactory.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NSubstitute.Core
+{
+	public class EmptyMixinFactory : IMixinFactory
+	{
+		public object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState)
+		{
+			return new object[0];
+		}
+	}
+}

--- a/Source/NSubstitute/Core/ICallActions.cs
+++ b/Source/NSubstitute/Core/ICallActions.cs
@@ -8,5 +8,6 @@ namespace NSubstitute.Core
         void Add(ICallSpecification callSpec);
         void InvokeMatchingActions(ICall callInfo);
         void MoveActionsForSpecToNewSpec(ICallSpecification oldCallSpecification, ICallSpecification newCallSpecification);
+	    void Clear();
     }
 }

--- a/Source/NSubstitute/Core/ICallActions.cs
+++ b/Source/NSubstitute/Core/ICallActions.cs
@@ -8,6 +8,6 @@ namespace NSubstitute.Core
         void Add(ICallSpecification callSpec);
         void InvokeMatchingActions(ICall callInfo);
         void MoveActionsForSpecToNewSpec(ICallSpecification oldCallSpecification, ICallSpecification newCallSpecification);
-	    void Clear();
+        void Clear();
     }
 }

--- a/Source/NSubstitute/Core/ICallResults.cs
+++ b/Source/NSubstitute/Core/ICallResults.cs
@@ -7,6 +7,6 @@ namespace NSubstitute.Core
         void SetResult(ICallSpecification callSpecification, IReturn result);
         bool HasResultFor(ICall call);
         object GetResult(ICall call);
-	    void ClearResults();
+        void ClearResults();
     }
 }

--- a/Source/NSubstitute/Core/ICallResults.cs
+++ b/Source/NSubstitute/Core/ICallResults.cs
@@ -7,5 +7,6 @@ namespace NSubstitute.Core
         void SetResult(ICallSpecification callSpecification, IReturn result);
         bool HasResultFor(ICall call);
         object GetResult(ICall call);
+	    void ClearResults();
     }
 }

--- a/Source/NSubstitute/Core/ICallRouterFactory.cs
+++ b/Source/NSubstitute/Core/ICallRouterFactory.cs
@@ -2,6 +2,6 @@ namespace NSubstitute.Core
 {
     public interface ICallRouterFactory
     {
-        ICallRouter Create(ISubstitutionContext substitutionContext, SubstituteConfig config);
+        ICallRouter Create(ISubstitutionContext substitutionContext, ISubstituteState substituteState);
     }
 }

--- a/Source/NSubstitute/Core/IMixinFactory.cs
+++ b/Source/NSubstitute/Core/IMixinFactory.cs
@@ -2,8 +2,8 @@ using System;
 
 namespace NSubstitute.Core
 {
-	public interface IMixinFactory
-	{
-		object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState);
-	}
+    public interface IMixinFactory
+    {
+        object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState);
+    }
 }

--- a/Source/NSubstitute/Core/IMixinFactory.cs
+++ b/Source/NSubstitute/Core/IMixinFactory.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace NSubstitute.Core
+{
+	public interface IMixinFactory
+	{
+		object[] Create(Type primaryProxyType, Type[] additionalTypes, ISubstitutionContext substitutionContext, ISubstituteState substituteState);
+	}
+}

--- a/Source/NSubstitute/Core/IProxyFactory.cs
+++ b/Source/NSubstitute/Core/IProxyFactory.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Core
 {
     public interface IProxyFactory
     {
-        object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments);
+        object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments, object[] mixins);
     }
 }

--- a/Source/NSubstitute/Core/SubstituteFactory.cs
+++ b/Source/NSubstitute/Core/SubstituteFactory.cs
@@ -10,13 +10,15 @@ namespace NSubstitute.Core
         readonly ICallRouterFactory _callRouterFactory;
         readonly IProxyFactory _proxyFactory;
         readonly ICallRouterResolver _callRouterResolver;
+		readonly IMixinFactory _mixinFactory;
 
-        public SubstituteFactory(ISubstitutionContext context, ICallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouterResolver)
+        public SubstituteFactory(ISubstitutionContext context, ICallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouterResolver, IMixinFactory mixinFactory)
         {
             _context = context;
             _callRouterFactory = callRouterFactory;
             _proxyFactory = proxyFactory;
             _callRouterResolver = callRouterResolver;
+	        _mixinFactory = mixinFactory;
         }
 
         /// <summary>
@@ -50,10 +52,14 @@ namespace NSubstitute.Core
 
         private object Create(Type[] typesToProxy, object[] constructorArguments, SubstituteConfig config)  
         {
-            var callRouter = _callRouterFactory.Create(_context, config);
+			var substituteState = new SubstituteState(_context, config);
+
+            var callRouter = _callRouterFactory.Create(_context, substituteState);
             var primaryProxyType = GetPrimaryProxyType(typesToProxy);
             var additionalTypes = typesToProxy.Where(x => x != primaryProxyType).ToArray();
-            var proxy = _proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, constructorArguments);
+			var mixins = _mixinFactory.Create(primaryProxyType, additionalTypes, _context, substituteState);
+
+			var proxy = _proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, constructorArguments, mixins);
             _callRouterResolver.Register(proxy, callRouter);
             return proxy;
         }

--- a/Source/NSubstitute/Core/SubstituteFactory.cs
+++ b/Source/NSubstitute/Core/SubstituteFactory.cs
@@ -52,7 +52,7 @@ namespace NSubstitute.Core
 
         private object Create(Type[] typesToProxy, object[] constructorArguments, SubstituteConfig config)  
         {
-			var substituteState = new SubstituteState(_context, config);
+            var substituteState = new SubstituteState(_context, config);
 
             var callRouter = _callRouterFactory.Create(_context, substituteState);
             var primaryProxyType = GetPrimaryProxyType(typesToProxy);

--- a/Source/NSubstitute/Core/SubstituteFactory.cs
+++ b/Source/NSubstitute/Core/SubstituteFactory.cs
@@ -10,7 +10,7 @@ namespace NSubstitute.Core
         readonly ICallRouterFactory _callRouterFactory;
         readonly IProxyFactory _proxyFactory;
         readonly ICallRouterResolver _callRouterResolver;
-		readonly IMixinFactory _mixinFactory;
+        readonly IMixinFactory _mixinFactory;
 
         public SubstituteFactory(ISubstitutionContext context, ICallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouterResolver, IMixinFactory mixinFactory)
         {
@@ -18,7 +18,7 @@ namespace NSubstitute.Core
             _callRouterFactory = callRouterFactory;
             _proxyFactory = proxyFactory;
             _callRouterResolver = callRouterResolver;
-	        _mixinFactory = mixinFactory;
+            _mixinFactory = mixinFactory;
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace NSubstitute.Core
             var callRouter = _callRouterFactory.Create(_context, substituteState);
             var primaryProxyType = GetPrimaryProxyType(typesToProxy);
             var additionalTypes = typesToProxy.Where(x => x != primaryProxyType).ToArray();
-			var mixins = _mixinFactory.Create(primaryProxyType, additionalTypes, _context, substituteState);
+            var mixins = _mixinFactory.Create(primaryProxyType, additionalTypes, _context, substituteState);
 
-			var proxy = _proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, constructorArguments, mixins);
+            var proxy = _proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, constructorArguments, mixins);
             _callRouterResolver.Register(proxy, callRouter);
             return proxy;
         }

--- a/Source/NSubstitute/Core/SubstitutionContext.cs
+++ b/Source/NSubstitute/Core/SubstitutionContext.cs
@@ -23,17 +23,15 @@ namespace NSubstitute.Core
 
         static SubstitutionContext()
         {
-            Current = new SubstitutionContext();
+			var dynamicProxyFactory = new CastleDynamicProxyFactory();
+			var delegateFactory = new DelegateProxyFactory();
+			var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
+			Current = new SubstitutionContext(new CallRouterFactory(), proxyFactory, new CallRouterResolver(), new EmptyMixinFactory());
         }
 
-        SubstitutionContext()
+		public SubstitutionContext(CallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouteResolver, IMixinFactory mixinFactory)
         {
-            var callRouterFactory = new CallRouterFactory();
-            var dynamicProxyFactory = new CastleDynamicProxyFactory();
-            var delegateFactory = new DelegateProxyFactory();
-            var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
-            var callRouteResolver = new CallRouterResolver();
-            _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver);
+			_substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver, mixinFactory);
         }
 
         public SubstitutionContext(ISubstituteFactory substituteFactory)

--- a/Source/NSubstitute/Core/SubstitutionContext.cs
+++ b/Source/NSubstitute/Core/SubstitutionContext.cs
@@ -23,15 +23,15 @@ namespace NSubstitute.Core
 
         static SubstitutionContext()
         {
-			var dynamicProxyFactory = new CastleDynamicProxyFactory();
-			var delegateFactory = new DelegateProxyFactory();
-			var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
-			Current = new SubstitutionContext(new CallRouterFactory(), proxyFactory, new CallRouterResolver(), new EmptyMixinFactory());
+            var dynamicProxyFactory = new CastleDynamicProxyFactory();
+            var delegateFactory = new DelegateProxyFactory();
+            var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
+            Current = new SubstitutionContext(new CallRouterFactory(), proxyFactory, new CallRouterResolver(), new EmptyMixinFactory());
         }
 
 		public SubstitutionContext(CallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouteResolver, IMixinFactory mixinFactory)
         {
-			_substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver, mixinFactory);
+            _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver, mixinFactory);
         }
 
         public SubstitutionContext(ISubstituteFactory substituteFactory)

--- a/Source/NSubstitute/Core/SubstitutionContext.cs
+++ b/Source/NSubstitute/Core/SubstitutionContext.cs
@@ -29,7 +29,7 @@ namespace NSubstitute.Core
             Current = new SubstitutionContext(new CallRouterFactory(), proxyFactory, new CallRouterResolver(), new EmptyMixinFactory());
         }
 
-		public SubstitutionContext(CallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouteResolver, IMixinFactory mixinFactory)
+        public SubstitutionContext(CallRouterFactory callRouterFactory, IProxyFactory proxyFactory, ICallRouterResolver callRouteResolver, IMixinFactory mixinFactory)
         {
             _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver, mixinFactory);
         }

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Core\CallSpecificationFactoryFactoryYesThatsRight.cs" />
     <Compile Include="Core\ConfiguredCall.cs" />
     <Compile Include="Core\DefaultForType.cs" />
+    <Compile Include="Core\EmptyMixinFactory.cs" />
     <Compile Include="Core\EventCallFormatter.cs" />
     <Compile Include="Core\Arguments\IArgumentEqualsSpecificationFactory.cs" />
     <Compile Include="Core\Extensions.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Core\ICallBaseExclusions.cs" />
     <Compile Include="Core\ICallRouterProvider.cs" />
     <Compile Include="Core\IGetCallSpec.cs" />
+    <Compile Include="Core\IMixinFactory.cs" />
     <Compile Include="Core\Maybe.cs" />
     <Compile Include="Core\ReturnObservable.cs" />
     <Compile Include="Core\SequenceChecking\InstanceTracker.cs" />

--- a/Source/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/Source/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Security.Permissions;
@@ -9,9 +10,7 @@ using NSubstitute.Exceptions;
 
 namespace NSubstitute.Proxies.CastleDynamicProxy
 {
-	using System.Collections.Generic;
-
-	public class CastleDynamicProxyFactory : IProxyFactory
+    public class CastleDynamicProxyFactory : IProxyFactory
     {
         readonly ProxyGenerator _proxyGenerator;
 
@@ -48,24 +47,24 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 
         private ProxyGenerationOptions GetOptionsToMixinCallRouter(IList<object> mixins)
         {
-			var options = new ProxyGenerationOptions(new AllMethodsExceptMixinsCallsHook(mixins));
-			foreach (var mixin in mixins)
-	        {
-				options.AddMixinInstance(mixin);
-			}
+            var options = new ProxyGenerationOptions(new AllMethodsExceptMixinsCallsHook(mixins));
+            foreach (var mixin in mixins)
+            {
+                options.AddMixinInstance(mixin);
+            }
             return options;
         }
 
         private class AllMethodsExceptMixinsCallsHook : AllMethodsHook
         {
-			private readonly HashSet<Type> mixinTypes;
+            private readonly HashSet<Type> mixinTypes;
 
-	        public AllMethodsExceptMixinsCallsHook(IEnumerable<object> mixins)
-	        {
-		        this.mixinTypes = new HashSet<Type>(mixins.Select(m => m.GetType()).SelectMany(GetAllTypes));
-	        }
+            public AllMethodsExceptMixinsCallsHook(IEnumerable<object> mixins)
+            {
+                this.mixinTypes = new HashSet<Type>(mixins.Select(m => m.GetType()).SelectMany(GetAllTypes));
+            }
 
-	        public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+            public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
             {
                 return IsNotMixinMethod(methodInfo)
                     && IsNotBaseObjectMethod(methodInfo)
@@ -82,19 +81,19 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
                 return methodInfo.GetBaseDefinition().DeclaringType != typeof (object);
             }
 
-	        private static IEnumerable<Type> GetAllTypes(Type type)
-			{
-				foreach (var i in type.GetInterfaces())
-				{
-					yield return i;
-				}
+            private static IEnumerable<Type> GetAllTypes(Type type)
+            {
+                foreach (var i in type.GetInterfaces())
+                {
+                    yield return i;
+                }
 
-				while (type != typeof(object))
-				{
-					yield return type;
-					type = type.BaseType;
-				}
-	        }
+                while (type != typeof(object))
+                {
+                    yield return type;
+                    type = type.BaseType;
+                }
+            }
         }
 
         private void VerifyNoConstructorArgumentsGivenForInterface(object[] constructorArguments)

--- a/Source/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/Source/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -8,7 +8,7 @@ namespace NSubstitute.Proxies.DelegateProxy
 {
     public class DelegateProxyFactory : IProxyFactory
     {
-        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments, object[] mixins)
         {
             if (HasItems(additionalInterfaces))
             {

--- a/Source/NSubstitute/Proxies/ProxyFactory.cs
+++ b/Source/NSubstitute/Proxies/ProxyFactory.cs
@@ -14,12 +14,12 @@ namespace NSubstitute.Proxies
             _dynamicProxyFactory = dynamicProxyFactory;
         }
 
-        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments, object[] mixins)
         {
             var isDelegate = typeToProxy.IsSubclassOf(typeof(Delegate));
             return isDelegate 
-                ? _delegateFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments)
-                : _dynamicProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments);
+                ? _delegateFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments, mixins)
+                : _dynamicProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments, mixins);
         }
     }
 }


### PR DESCRIPTION
This change addresses issues #161 and #157.
It allows to add mixins the substitute instance other than CallRouter and introduces Clear method to the ICallActions and ICallResults interfaces that allow to reset substitute instance.
