### PR TITLE
Added a CaptureTo method

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/ArgCaptureMatcher.cs
+++ b/Source/NSubstitute.Acceptance.Specs/ArgCaptureMatcher.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    public class ArgCaptureMatcher
+    {
+        private IFoo _sub;
+        private readonly object _someObject = new object();
+        string capturedA = null;
+        object capturedObject = null;
+
+        public interface IFoo
+        {
+            void Bar(string a);
+            int Zap(object c);
+        }
+
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _sub = Substitute.For<IFoo>();
+        }
+
+        [Test]
+        public void Should_capture_strings()
+        {
+            _sub.Bar(Arg.CaptureTo(() => capturedA));
+
+            _sub.Bar("abc");
+
+            Assert.That(capturedA, Is.EqualTo("abc"));
+        }
+
+
+        [Test]
+        public void Should_capture_objects()
+        {
+            _sub.Zap(Arg.CaptureTo(() => capturedObject));
+
+            _sub.Zap(_someObject);
+
+            Assert.That(capturedObject, Is.SameAs(_someObject));
+        }
+
+
+    }
+}

--- a/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/Source/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -94,6 +94,7 @@
     <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFrameworkVersion)' == 'v4.0' Or '$(TargetFrameworkVersion)' == 'v4.5' " />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgCaptureMatcher.cs" />
     <Compile Include="ArgumentInvocationFromMatchers.cs" />
     <Compile Include="ArgDoFromMatcher.cs" />
     <Compile Include="AutoValuesForSubs.cs" />


### PR DESCRIPTION
When building a system that sends complex messages around, sometimes
argument matchers can be a bit cumbersome to work with. In those cases,
it's better to capture arguments and then write specific asserts against
them.

With Arg.Do you can capture an argument, like:
Arg.Do(x => _valueToCapture = x), but it doesn't really describe the
intent. I had a lot of junior developers in my team who did not
understand this syntax. An explicit 'CaptureTo' method would be much
clearer for them.

Note, the implementation is very rough. If you like the syntax, i can
clean up the implementation.
