### PR TITLE
#175 implemented `ArgAt<T>(int position)`

### DIFF
--- a/Source/NSubstitute.Specs/CallInfoSpecs.cs
+++ b/Source/NSubstitute.Specs/CallInfoSpecs.cs
@@ -138,6 +138,33 @@ namespace NSubstitute.Specs
             }
         }
 
+        public class Get_typed_argumnet_at_position
+        {
+            [Test]
+            public void Throw_argument_out_of_range()
+            {
+                var sut = new CallInfo(new[] { CreateArg(1) });
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => sut.ArgAt<int>(22));
+            }
+
+            [Test]
+            public void Throw_invalid_cast_exception()
+            {
+                var sut = new CallInfo(new[] { CreateArg("It's not an int!") });
+                Assert.Throws<InvalidCastException>(() => sut.ArgAt<int>(0));
+            }
+
+            [Test]
+            public void Get_value_of_argument()
+            {
+                var sut = new CallInfo(new[] { CreateArg(1), CreateArg("ABC") });
+                var value = sut.ArgAt<string>(1);
+                Assert.That(value, Is.TypeOf<string>());
+                Assert.That(value, Is.EqualTo("ABC"));
+            }
+        }
+
         private class ByRefArgument<T> : Argument
         {
             /* Simulating how an T& argument (like Int32&) comes through to CallInfo */

--- a/Source/NSubstitute/Core/CallInfo.cs
+++ b/Source/NSubstitute/Core/CallInfo.cs
@@ -99,6 +99,34 @@ namespace NSubstitute.Core
             }
         }
 
+        /// <summary>
+        /// Gets the argument passed to this call at the specified position converted to type `T`.
+        /// This will throw if there are no arguments, if the argument is out of range or if it
+        /// cannot be converted to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the argument to retrieve</typeparam>
+        /// <param name="position"></param>
+        /// <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
+        public T ArgAt<T>(int position)
+        {
+            T arg;
+            if (position >= _callArguments.Length)
+            {
+                throw new ArgumentOutOfRangeException("position", "There is no argument at position " + position);
+            }
+            try
+            {
+                arg = (T) (_callArguments[position].Value);
+            }
+            catch (InvalidCastException)
+            {
+                throw new InvalidCastException("Couldn't convert parameter at position"
+                    + position + " to type " + typeof(T).FullName);
+            }
+            
+            return arg;
+        }
+        
         private static string DisplayTypes(IEnumerable<Type> types)
         {
             return string.Join(", ", types.Select(x => x.Name).ToArray());


### PR DESCRIPTION
#175 Make easy and safe to get typed parameter from CallInfo
Implemented `ArgAt<T>(int position)` to get the argument at the specified position converted to the specified type, with descriptive exceptions