### PR TITLE
Add [Serializable] attribute to all exceptions

### DIFF
--- a/Source/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/Source/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class AmbiguousArgumentsException : SubstituteException
     {
         public static string SpecifyAllArguments = "Cannot determine argument specifications to use." + Environment.NewLine +

--- a/Source/NSubstitute/Exceptions/ArgumentIsNotOutOrRefException.cs
+++ b/Source/NSubstitute/Exceptions/ArgumentIsNotOutOrRefException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class ArgumentIsNotOutOrRefException : SubstituteException
     {
         const string WhatProbablyWentWrong = "Could not set argument {0} ({1}) as it is not an out or ref argument.";

--- a/Source/NSubstitute/Exceptions/ArgumentNotFoundException.cs
+++ b/Source/NSubstitute/Exceptions/ArgumentNotFoundException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions

--- a/Source/NSubstitute/Exceptions/ArgumentNotFoundException.cs
+++ b/Source/NSubstitute/Exceptions/ArgumentNotFoundException.cs
@@ -2,6 +2,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class ArgumentNotFoundException : SubstituteException
     {
         public ArgumentNotFoundException(string message) : base(message) { }

--- a/Source/NSubstitute/Exceptions/ArgumentSetWithIncompatibleValueException.cs
+++ b/Source/NSubstitute/Exceptions/ArgumentSetWithIncompatibleValueException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class ArgumentSetWithIncompatibleValueException : SubstituteException
     {
         const string WhatProbablyWentWrong = "Could not set value of type {2} to argument {0} ({1}) because the types are incompatible.";

--- a/Source/NSubstitute/Exceptions/CallSequenceNotFoundException.cs
+++ b/Source/NSubstitute/Exceptions/CallSequenceNotFoundException.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+using System;
+using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {

--- a/Source/NSubstitute/Exceptions/CallSequenceNotFoundException.cs
+++ b/Source/NSubstitute/Exceptions/CallSequenceNotFoundException.cs
@@ -2,6 +2,7 @@
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class CallSequenceNotFoundException : SubstituteException
     {
         public CallSequenceNotFoundException(string message) : base(message) { }

--- a/Source/NSubstitute/Exceptions/CanNotPartiallySubForInterfaceOrDelegateException.cs
+++ b/Source/NSubstitute/Exceptions/CanNotPartiallySubForInterfaceOrDelegateException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class CanNotPartiallySubForInterfaceOrDelegateException : SubstituteException
     {
         public CanNotPartiallySubForInterfaceOrDelegateException(Type type) : base(DescribeProblem(type)) { }

--- a/Source/NSubstitute/Exceptions/CannotCreateEventArgsException.cs
+++ b/Source/NSubstitute/Exceptions/CannotCreateEventArgsException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class CannotCreateEventArgsException : SubstituteException
     {
         public CannotCreateEventArgsException() { }

--- a/Source/NSubstitute/Exceptions/CannotReturnNullforValueType.cs
+++ b/Source/NSubstitute/Exceptions/CannotReturnNullforValueType.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class CannotReturnNullForValueType : SubstituteException
     {
         const string Description = "Cannot return null for {0} because it is a value type. If you want to return the default value for this type use \"default({0})\".";

--- a/Source/NSubstitute/Exceptions/CouldNotRaiseEventException.cs
+++ b/Source/NSubstitute/Exceptions/CouldNotRaiseEventException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions

--- a/Source/NSubstitute/Exceptions/CouldNotRaiseEventException.cs
+++ b/Source/NSubstitute/Exceptions/CouldNotRaiseEventException.cs
@@ -2,6 +2,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class CouldNotRaiseEventException : SubstituteException
     {
         protected const string WhatProbablyWentWrong =

--- a/Source/NSubstitute/Exceptions/CouldNotSetReturnException.cs
+++ b/Source/NSubstitute/Exceptions/CouldNotSetReturnException.cs
@@ -27,12 +27,14 @@ namespace NSubstitute.Exceptions
         protected CouldNotSetReturnException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
+    [Serializable]
     public class CouldNotSetReturnDueToNoLastCallException : CouldNotSetReturnException
     {
         public CouldNotSetReturnDueToNoLastCallException() : base("Could not find a call to return from.") { }
         protected CouldNotSetReturnDueToNoLastCallException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 
+    [Serializable]
     public class CouldNotSetReturnDueToTypeMismatchException : CouldNotSetReturnException
     {
         public CouldNotSetReturnDueToTypeMismatchException(Type returnType, MethodInfo member) : base(DescribeProblem(returnType, member)) { }

--- a/Source/NSubstitute/Exceptions/MissingSequenceNumberException.cs
+++ b/Source/NSubstitute/Exceptions/MissingSequenceNumberException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions

--- a/Source/NSubstitute/Exceptions/MissingSequenceNumberException.cs
+++ b/Source/NSubstitute/Exceptions/MissingSequenceNumberException.cs
@@ -2,6 +2,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class MissingSequenceNumberException : SubstituteException
     {
         public MissingSequenceNumberException() { }

--- a/Source/NSubstitute/Exceptions/NotASubstituteException.cs
+++ b/Source/NSubstitute/Exceptions/NotASubstituteException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions

--- a/Source/NSubstitute/Exceptions/NotASubstituteException.cs
+++ b/Source/NSubstitute/Exceptions/NotASubstituteException.cs
@@ -2,6 +2,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class NotASubstituteException : SubstituteException
     {
         const string Explanation = "NSubstitute extension methods like .Received() can only be called on objects created using Substitute.For<T>() and related methods."; 

--- a/Source/NSubstitute/Exceptions/NotRunningAQueryException.cs
+++ b/Source/NSubstitute/Exceptions/NotRunningAQueryException.cs
@@ -2,6 +2,7 @@
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class NotRunningAQueryException : SubstituteException
     {
         public NotRunningAQueryException() { }

--- a/Source/NSubstitute/Exceptions/NotRunningAQueryException.cs
+++ b/Source/NSubstitute/Exceptions/NotRunningAQueryException.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+using System;
+using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {

--- a/Source/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
+++ b/Source/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions

--- a/Source/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
+++ b/Source/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
@@ -2,6 +2,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class NullSubstituteReferenceException : NotASubstituteException 
     {
         public NullSubstituteReferenceException() { }

--- a/Source/NSubstitute/Exceptions/ReceivedCallsException.cs
+++ b/Source/NSubstitute/Exceptions/ReceivedCallsException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class ReceivedCallsException : SubstituteException
     {
         public ReceivedCallsException() { }

--- a/Source/NSubstitute/Exceptions/SubstituteException.cs
+++ b/Source/NSubstitute/Exceptions/SubstituteException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class SubstituteException : Exception
     {
         public SubstituteException() : this("") { }

--- a/Source/NSubstitute/Exceptions/UnexpectedArgumentMatcherException.cs
+++ b/Source/NSubstitute/Exceptions/UnexpectedArgumentMatcherException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace NSubstitute.Exceptions
 {
+    [Serializable]
     public class UnexpectedArgumentMatcherException : SubstituteException
     {
         public static string WhatProbablyWentWrong =


### PR DESCRIPTION
Enables other frameworks to report exceptions across application domains using the default binary serializer.

Sorry if I am not following the rules properly for this, this is my first time attempting to contribute on GitHub.  Just let me know and I will attempt to correct it.

David Mann