### PR TITLE
Fixes #205 (Problem with parallel substituting for delegates)

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/MultipleThreads.cs
+++ b/Source/NSubstitute.Acceptance.Specs/MultipleThreads.cs
@@ -92,6 +92,25 @@ namespace NSubstitute.Acceptance.Specs
             }
         }
 
+        [Test]
+        [Ignore("Long running, non-deterministic test.")]
+        [Timeout(60 * 1000)]
+        public void Create_Delegate_Substitute_From_Many_Threads()
+        {
+            var tasks =
+                Enumerable.Range(0, 20).Select( _ => 
+                    new Task(() =>
+                        {
+                            for (var i = 0; i < 1000; ++i)
+                            {
+                                Substitute.For<Func<string>>();
+                            }
+                        })).ToArray();
+
+            Task.StartAll(tasks);
+            Task.AwaitAll(tasks);
+        }
+
         public interface IFoo
         {
             int Number();

--- a/Source/NSubstitute/Core/CallRouterResolver.cs
+++ b/Source/NSubstitute/Core/CallRouterResolver.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET4
+using System.Collections.Concurrent;
+#endif
 using System.Collections.Generic;
 using NSubstitute.Exceptions;
 
@@ -6,7 +9,11 @@ namespace NSubstitute.Core
 {
     public class CallRouterResolver : ICallRouterResolver
     {
+#if NET4
+        IDictionary<object, ICallRouter> _callRouterMappings = new ConcurrentDictionary<object, ICallRouter>();
+#else
         IDictionary<object, ICallRouter> _callRouterMappings = new Dictionary<object, ICallRouter>();
+#endif
 
         public ICallRouter ResolveFor(object substitute)
         {
@@ -25,7 +32,15 @@ namespace NSubstitute.Core
         {
             if (proxy is ICallRouter) return;
             if (proxy is ICallRouterProvider) return;
+
+#if NET4
             _callRouterMappings.Add(proxy, callRouter);
+#else
+            lock (_callRouterMappings)
+            {
+                _callRouterMappings.Add(proxy, callRouter);
+            }
+#endif
         }
     }
 }

--- a/Source/NSubstitute/Core/CallRouterResolver.cs
+++ b/Source/NSubstitute/Core/CallRouterResolver.cs
@@ -21,10 +21,20 @@ namespace NSubstitute.Core
             if (substitute is ICallRouter) return (ICallRouter)substitute;
             if (substitute is ICallRouterProvider) return ((ICallRouterProvider) substitute).CallRouter;
             ICallRouter callRouter;
+#if NET4
             if (_callRouterMappings.TryGetValue(substitute, out callRouter))
             {
                 return callRouter;
             }
+#else
+            lock (_callRouterMappings)
+            {
+                if (_callRouterMappings.TryGetValue(substitute, out callRouter))
+                {
+                    return callRouter;
+                }
+            }
+#endif
             throw new NotASubstituteException();
         }
 


### PR DESCRIPTION
Fixes #205 (Problem with parallel substituting for delegates)

I adjusted `CallRouterResolver` and added `ConcurrentDictionary` for .NET 4x family and `lock` for .NET 3.5.