### PR TITLE
Document that the position for ArgAt is zero-based

### DIFF
--- a/Source/Docs/help/_posts/2010-02-03-return-from-function.markdown
+++ b/Source/Docs/help/_posts/2010-02-03-return-from-function.markdown
@@ -27,7 +27,10 @@ Assert.That(calculator.Add(-73, 9348), Is.EqualTo(9275));
 In this example [argument matchers](/help/argument-matchers) are used to match all calls to `Add()`, and a lambda function is used to return the sum of the first and second arguments passed to the call.
 
 ### Call information
-The function we provide to `Returns()` and `ReturnsForAnyArgs()` is of type `Func<CallInfo,T>`, where `T` is the type the call is returning, and `CallInfo` is a type which provides access to the arguments used for the call. In the previous example we accessed these arguments using an indexer (`x[1]` for the second argument). `CallInfo` also has a convenience method to pick arguments in a strongly typed way: 
+The function we provide to `Returns()` and `ReturnsForAnyArgs()` is of type `Func<CallInfo,T>`, where `T` is the type the call is returning, and `CallInfo` is a type which provides access to the arguments used for the call. In the previous example we accessed these arguments using an indexer (`x[1]` for the second argument). `CallInfo` also has a couple of convenience methods to pick arguments in a strongly typed way:
+
+* `T Arg<T>()`: Gets the argument of type `T` passed to this call.
+* `T ArgAt<T>(int position)`: Gets the argument passed to this call at the specified zero-based position, converted to type `T`.
 
 {% examplecode csharp %}
 public interface IFoo {

--- a/Source/NSubstitute/Core/CallInfo.cs
+++ b/Source/NSubstitute/Core/CallInfo.cs
@@ -100,12 +100,12 @@ namespace NSubstitute.Core
         }
 
         /// <summary>
-        /// Gets the argument passed to this call at the specified position converted to type `T`.
+        /// Gets the argument passed to this call at the specified zero-based position, converted to type `T`.
         /// This will throw if there are no arguments, if the argument is out of range or if it
         /// cannot be converted to the specified type.
         /// </summary>
         /// <typeparam name="T">The type of the argument to retrieve</typeparam>
-        /// <param name="position"></param>
+        /// <param name="position">The zero-based position of the argument to retrieve</param>
         /// <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
         public T ArgAt<T>(int position)
         {


### PR DESCRIPTION
This PR changes the documentation for the `ArgAt<T>()` method to specify that the `position` of the argument is zero-based. I would love to add information about this to the [documentation about call information](https://nsubstitute.github.io/help/return-from-function/#call_information), but I don't know where the documentation is hosted. Where can I find it?