### PR TITLE
Extending auto value

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
+++ b/Source/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NSubstitute.Core;
+using NSubstitute.Routing.Handlers;
 using NUnit.Framework;
 
 namespace NSubstitute.Acceptance.Specs
@@ -202,6 +204,22 @@ namespace NSubstitute.Acceptance.Specs
             AssertObjectIsASubstitute(sample2);
 
             Assert.That(sample1, Is.SameAs(sample2));
+        }
+
+        [Test]
+        public void Multiple_calls_to_observable_method_and_set_to_return_and_forget()
+        {
+            var sub = Substitute.For<IFooWithObservable>();
+            var callRouter = SubstitutionContext.Current.GetCallRouterFor(sub);
+            callRouter.AutoValueBehaviour = AutoValueBehaviour.ReturnAndForgetValue;
+            ISample sample1 = null;
+            ISample sample2 = null;
+            sub.GetSamples().Subscribe(new AnonymousObserver<ISample>(x => sample1 = x));
+            sub.GetSamples().Subscribe(new AnonymousObserver<ISample>(x => sample2 = x));
+            AssertObjectIsASubstitute(sample1);
+            AssertObjectIsASubstitute(sample2);
+
+            Assert.That(sample1, Is.Not.EqualTo(sample2));
         }
 
         public interface IFooWithObservable 

--- a/Source/NSubstitute.Specs/CallResultsSpecs.cs
+++ b/Source/NSubstitute.Specs/CallResultsSpecs.cs
@@ -122,19 +122,39 @@ namespace NSubstitute.Specs
 
         public class When_getting_a_void_type_result : Concern
         {
+            readonly object _expectedResult = new object();
             ICall _call;
+            ICallSpecification _callSpecification;
+            IReturn _resultToReturn;
 
             [Test]
-            public void Should_not_have_result_for_call()
+            public void Should_have_result_for_call()
             {
-                Assert.That(sut.HasResultFor(_call), Is.False);
+                Assert.That(sut.HasResultFor(_call));
+            }
+
+            [Test]
+            public void Should_get_the_result_that_was_set()
+            {
+                Assert.That(sut.GetResult(_call), Is.SameAs(_expectedResult));
+            }
+
+            public override void Because()
+            {
+                sut.SetResult(_callSpecification, _resultToReturn);
             }
 
             public override void Context()
             {
                 base.Context();
                 _call = mock<ICall>();
-                _call.stub(x => x.GetReturnType()).Return(typeof (void));
+                _call.stub(x => x.GetReturnType()).Return(typeof(void));
+                _callSpecification = mock<ICallSpecification>();
+                _callSpecification.stub(x => x.IsSatisfiedBy(_call)).Return(true);
+
+                var callInfo = StubCallInfoForCall(_call);
+                _resultToReturn = mock<IReturn>();
+                _resultToReturn.stub(x => x.ReturnFor(callInfo)).Return(_expectedResult);
             }
         }
     }

--- a/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
+++ b/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NSubstitute.Core;
 using NSubstitute.Routing;
 using NSubstitute.Routing.AutoValues;
+using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Specs.Infrastructure
 {
@@ -43,5 +44,7 @@ namespace NSubstitute.Specs.Infrastructure
         {
             get { return new List<IAutoValueProvider>(); }
         }
+
+        public AutoValueBehaviour AutoValueBehaviour { get; set; }
     }
 }

--- a/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
+++ b/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NSubstitute.Core;
 using NSubstitute.Routing;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Specs.Infrastructure
 {
@@ -36,6 +37,11 @@ namespace NSubstitute.Specs.Infrastructure
         {
             TypeUseForSetReturnForType = type;
             ReturnValueUsedForSetReturnForType = returnValue;
+        }
+
+        public IList<IAutoValueProvider> AutoValueProviders
+        {
+            get { return new List<IAutoValueProvider>(); }
         }
     }
 }

--- a/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
+++ b/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Routing\AutoValues\AutoQueryableProviderSpecs.cs" />
     <Compile Include="Routing\AutoValues\AutoStringProviderSpecs.cs" />
     <Compile Include="Routing\AutoValues\AutoSubstituteProviderSpecs.cs" />
+    <Compile Include="Routing\AutoValues\AutoObservableProviderSpecs.cs" />
     <Compile Include="Routing\AutoValues\AutoTaskProviderSpecs.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
+++ b/Source/NSubstitute.Specs/NSubstitute.Specs.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Routing\AutoValues\AutoTaskProviderSpecs.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Routing\AutoValues\CompositeProviderSpecs.cs" />
     <Compile Include="Routing\Handlers\AddCallToQueryResultHandlerSpecs.cs" />
     <Compile Include="Routing\Handlers\CheckReceivedCallHandlerSpecs.cs" />
     <Compile Include="Routing\Handlers\ClearLastCallRouterHandlerSpecs.cs" />

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoArrayProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoArrayProviderSpecs.cs
@@ -9,38 +9,17 @@ namespace NSubstitute.Specs.Routing.AutoValues
     public class AutoArrayProviderSpecs : ConcernFor<AutoArrayProvider>
     {
         [Test]
-        public void Can_provide_value_for_arrays()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof(int[])));
-        }
-
-        [Test]
-        public void Can_not_provide_value_for_non_arrays()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(string)));
-            Assert.False(sut.CanProvideValueFor(typeof(int)));
-        }
-
-        [Test]
-        public void Provides_empty_array_value()
-        {
-            var array = sut.GetValue(typeof(int[]));
-            Assert.That(array, Is.Not.Null);
-            Assert.That(array, Is.Empty);
-        }
-
-        [Test]
         public void Provides_empty_array_value_for_arrays()
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string[])), Is.EqualTo(Maybe.Just(new string[0])));
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int[])), Is.EqualTo(Maybe.Just(new int[0])));
+            Assert.That(sut.GetValue(typeof(string[])), Is.EqualTo(Maybe.Just(new string[0])));
+            Assert.That(sut.GetValue(typeof(int[])), Is.EqualTo(Maybe.Just(new int[0])));
         }
 
         [Test]
         public void Provides_no_value_for_non_arrays()
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string)), Is.EqualTo(Maybe.Nothing<object>()));
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(typeof(string)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         public override AutoArrayProvider CreateSubjectUnderTest()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoArrayProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoArrayProviderSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using NSubstitute.Core;
 using NSubstitute.Routing.AutoValues;
 using NSubstitute.Specs.Infrastructure;
 using NUnit.Framework;
@@ -26,6 +27,20 @@ namespace NSubstitute.Specs.Routing.AutoValues
             var array = sut.GetValue(typeof(int[]));
             Assert.That(array, Is.Not.Null);
             Assert.That(array, Is.Empty);
+        }
+
+        [Test]
+        public void Provides_empty_array_value_for_arrays()
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string[])), Is.EqualTo(Maybe.Just(new string[0])));
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int[])), Is.EqualTo(Maybe.Just(new int[0])));
+        }
+
+        [Test]
+        public void Provides_no_value_for_non_arrays()
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         public override AutoArrayProvider CreateSubjectUnderTest()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
@@ -11,8 +11,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
     public class AutoObservableProviderSpecs : ConcernFor<AutoObservableProvider>
     {
         private IAutoValueProvider _testValuesProvider;
-        private IMaybeAutoValueProvider _testMaybeValuesProvider;
-        
+
         [Test]
         public void Substitute_should_automock_observable()
         {
@@ -34,7 +33,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
         [TestCase(typeof(List<int>))]
         public void Provides_no_value_for_non_observables(Type type)
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         [Test]
@@ -49,7 +48,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
         public void Provides_value_for_observables<T>()
         {
             var observer = mock<IObserver<T>>();
-            var value = ((IMaybeAutoValueProvider)sut).GetValue(typeof(IObservable<T>)).ValueOrDefault();
+            var value = sut.GetValue(typeof(IObservable<T>)).ValueOrDefault();
             Assert.IsInstanceOf<IObservable<T>>(value);
             ((IObservable<T>) value).Subscribe(observer);
             observer.received(x => x.OnNext(default(T)));
@@ -61,10 +60,10 @@ namespace NSubstitute.Specs.Routing.AutoValues
         {
             const string autoValue = "test";
             var observer = mock<IObserver<string>>();
-            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
+            _testValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
 
             var type = typeof(IObservable<string>);
-            var value = (IObservable<string>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault();
+            var value = (IObservable<string>)sut.GetValue(type).ValueOrDefault();
             value.Subscribe(observer);
             observer.received(x => x.OnNext(It.Is(autoValue)));
             observer.received(x => x.OnCompleted());
@@ -75,10 +74,10 @@ namespace NSubstitute.Specs.Routing.AutoValues
         {
             const int autoValue = 10;
             var observer = mock<IObserver<int>>();
-            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
+            _testValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
 
             var type = typeof(IObservable<int>);
-            var value = (IObservable<int>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault();
+            var value = (IObservable<int>)sut.GetValue(type).ValueOrDefault();
             value.Subscribe(observer);
             observer.received(x => x.OnNext(It.Is(autoValue)));
             observer.received(x => x.OnCompleted());
@@ -87,12 +86,11 @@ namespace NSubstitute.Specs.Routing.AutoValues
         public override void Context()
         {
             _testValuesProvider = mock<IAutoValueProvider>();
-            _testMaybeValuesProvider = mock<IMaybeAutoValueProvider>();
         }
 
         public override AutoObservableProvider CreateSubjectUnderTest()
         {
-            return new AutoObservableProvider(() => new[] { _testValuesProvider }, () => new[] { _testMaybeValuesProvider });
+            return new AutoObservableProvider(() => new[] { _testValuesProvider });
         }
 
         public interface IFoo2

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
@@ -1,0 +1,104 @@
+﻿#if NET45
+using System;
+using NSubstitute.Routing.AutoValues;
+using NSubstitute.Specs.Infrastructure;
+using NUnit.Framework;
+using System.Collections.Generic;
+using NSubstitute.Core;
+
+namespace NSubstitute.Specs.Routing.AutoValues
+{
+    public class AutoObservableProviderSpecs : ConcernFor<AutoObservableProvider>
+    {
+        private IAutoValueProvider _testValuesProvider;
+        private IMaybeAutoValueProvider _testMaybeValuesProvider;
+        
+        [Test]
+        public void Substitute_should_automock_observable()
+        {
+            var foo2 = Substitute.For<IFoo2>();
+            var observer = mock<IObserver<object>>();
+
+            var observable = foo2.GetObject();
+
+            Assert.NotNull(observable);
+            observable.Subscribe(observer);
+            observer.received(x => x.OnNext(It.Is<object>(null)));
+            observer.received(x => x.OnCompleted());
+        }
+
+        [Test]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(int))]
+        [TestCase(typeof(int[]))]
+        [TestCase(typeof(List<int>))]
+        public void Provides_no_value_for_non_observables(Type type)
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        public void Provides_value_for_observables()
+        {
+            Provides_value_for_observables<string>();
+            Provides_value_for_observables<int>();
+            Provides_value_for_observables<int[]>();
+            Provides_value_for_observables<List<int>>();
+        }
+
+        public void Provides_value_for_observables<T>()
+        {
+            var observer = mock<IObserver<T>>();
+            var value = ((IMaybeAutoValueProvider)sut).GetValue(typeof(IObservable<T>)).ValueOrDefault();
+            Assert.IsInstanceOf<IObservable<T>>(value);
+            ((IObservable<T>) value).Subscribe(observer);
+            observer.received(x => x.OnNext(default(T)));
+            observer.received(x => x.OnCompleted());
+        }
+
+        [Test]
+        public void Provides_value_from_other_auto_value_providers()
+        {
+            const string autoValue = "test";
+            var observer = mock<IObserver<string>>();
+            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
+
+            var type = typeof(IObservable<string>);
+            var value = (IObservable<string>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault();
+            value.Subscribe(observer);
+            observer.received(x => x.OnNext(It.Is(autoValue)));
+            observer.received(x => x.OnCompleted());
+        }
+
+        [Test]
+        public void Provides_value_from_other_auto_value_providers_of_value_types()
+        {
+            const int autoValue = 10;
+            var observer = mock<IObserver<int>>();
+            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
+
+            var type = typeof(IObservable<int>);
+            var value = (IObservable<int>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault();
+            value.Subscribe(observer);
+            observer.received(x => x.OnNext(It.Is(autoValue)));
+            observer.received(x => x.OnCompleted());
+        }
+
+        public override void Context()
+        {
+            _testValuesProvider = mock<IAutoValueProvider>();
+            _testMaybeValuesProvider = mock<IMaybeAutoValueProvider>();
+        }
+
+        public override AutoObservableProvider CreateSubjectUnderTest()
+        {
+            return new AutoObservableProvider(() => new[] { _testValuesProvider }, () => new[] { _testMaybeValuesProvider });
+        }
+
+        public interface IFoo2
+        {
+            IObservable<object> GetObject();
+        }
+    }
+}
+#endif

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoObservableProviderSpecs.cs
@@ -90,7 +90,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
 
         public override AutoObservableProvider CreateSubjectUnderTest()
         {
-            return new AutoObservableProvider(() => new[] { _testValuesProvider });
+            return new AutoObservableProvider(() => _testValuesProvider);
         }
 
         public interface IFoo2

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoQueryableProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoQueryableProviderSpecs.cs
@@ -10,61 +10,6 @@ namespace NSubstitute.Specs.Routing.AutoValues
 {
     public class AutoQueryableProviderSpecs : ConcernFor<AutoQueryableProvider>
     {
-
-        [Test]
-        public void Can_provide_value_for_queryables()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof(IQueryable<int>)));
-            Assert.That(sut.CanProvideValueFor(typeof(IQueryable<List<int>>)));
-        }
-
-        [Test]
-        public void Can_not_provide_value_for_non_queryable_enumerables()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(IEnumerable<>)));
-            Assert.False(sut.CanProvideValueFor(typeof(IList<>)));
-        }
-
-        [Test]
-        public void Can_not_provide_value_for_value_types()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(int)));
-            Assert.False(sut.CanProvideValueFor(typeof(string)));
-        }
-
-        [Test]
-        public void Provides_empty_queryable_value_type()
-        {
-            var queryable = (IQueryable<int>)sut.GetValue(typeof(IQueryable<int>));
-            Assert.That(queryable, Is.Not.Null);
-            Assert.That(queryable, Is.Empty);
-            Assert.DoesNotThrow(() => queryable.Any());
-        }
-
-        [Test]
-        public void Should_create_substitute_for_queryable_of_string()
-        {
-            var type = typeof(IQueryable<string>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(sut.GetValue(type), Is.InstanceOf(typeof(IQueryable<string>)));
-        }
-
-        [Test]
-        public void Should_create_substitute_for_queryable_of_value_type()
-        {
-            var type = typeof(IQueryable<int>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(sut.GetValue(type), Is.InstanceOf(typeof(IQueryable<int>)));
-        }
-
-        [Test]
-        public void Should_create_substitute_for_queryable_of_complex_type()
-        {
-            var type = typeof(IQueryable<List<string>>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(sut.GetValue(type), Is.InstanceOf(typeof(IQueryable<List<string>>)));
-        }
-
         [Test]
         public void Substitute_should_automock_queryable()
         {
@@ -80,8 +25,8 @@ namespace NSubstitute.Specs.Routing.AutoValues
         [Test]
         public void Provides_no_value_for_non_queryable()
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(IEnumerable<>)), Is.EqualTo(Maybe.Nothing<object>()));
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(IList<>)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(typeof(IEnumerable<>)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(typeof(IList<>)), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         [Test]
@@ -94,7 +39,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
 
         private void Provides_value_for_queryables<T>()
         {
-            var queryable = ((IMaybeAutoValueProvider)sut).GetValue(typeof(IQueryable<T>)).ValueOrDefault();
+            var queryable = sut.GetValue(typeof(IQueryable<T>)).ValueOrDefault();
             Assert.IsInstanceOf<IQueryable<T>>(queryable);
             CollectionAssert.AreEquivalent(new T[0], (IQueryable<T>)queryable);
         }

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoQueryableProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoQueryableProviderSpecs.cs
@@ -1,8 +1,10 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System;
+using NSubstitute.Routing.AutoValues;
 using NSubstitute.Specs.Infrastructure;
 using NUnit.Framework;
 using System.Linq;
 using System.Collections.Generic;
+using NSubstitute.Core;
 
 namespace NSubstitute.Specs.Routing.AutoValues
 {
@@ -73,6 +75,28 @@ namespace NSubstitute.Specs.Routing.AutoValues
             Assert.That(queryable, Is.Not.Null);
             Assert.That(queryable, Is.Empty);
             Assert.DoesNotThrow(() => queryable.Any());
+        }
+
+        [Test]
+        public void Provides_no_value_for_non_queryable()
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(IEnumerable<>)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(IList<>)), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        public void Provides_value_for_queryables()
+        {
+            Provides_value_for_queryables<int>();
+            Provides_value_for_queryables<string>();
+            Provides_value_for_queryables<List<int>>();
+        }
+
+        private void Provides_value_for_queryables<T>()
+        {
+            var queryable = ((IMaybeAutoValueProvider)sut).GetValue(typeof(IQueryable<T>)).ValueOrDefault();
+            Assert.IsInstanceOf<IQueryable<T>>(queryable);
+            CollectionAssert.AreEquivalent(new T[0], (IQueryable<T>)queryable);
         }
 
         public override AutoQueryableProvider CreateSubjectUnderTest()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoStringProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoStringProviderSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using NSubstitute.Core;
 using NSubstitute.Routing.AutoValues;
 using NSubstitute.Specs.Infrastructure;
 using NUnit.Framework;
@@ -23,6 +24,18 @@ namespace NSubstitute.Specs.Routing.AutoValues
         public void Can_not_provide_a_value_for_an_int_because_that_would_be_silly()
         {
             Assert.That(sut.CanProvideValueFor(typeof(int)), Is.False);
+        }
+
+        [Test]
+        public void Provides_no_value_for_non_string()
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        public void Provides_value_for_string()
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string)), Is.EqualTo(Maybe.Just<object>("")));
         }
 
         public override AutoStringProvider CreateSubjectUnderTest()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoStringProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoStringProviderSpecs.cs
@@ -9,33 +9,15 @@ namespace NSubstitute.Specs.Routing.AutoValues
     public class AutoStringProviderSpecs : ConcernFor<AutoStringProvider>
     {
         [Test]
-        public void Can_provide_value_for_string()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof(string)));
-        }
-
-        [Test]
-        public void Should_return_empty_string_value()
-        {
-            Assert.That(sut.GetValue(typeof(string)), Is.SameAs(string.Empty));
-        }
-
-        [Test]
-        public void Can_not_provide_a_value_for_an_int_because_that_would_be_silly()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof(int)), Is.False);
-        }
-
-        [Test]
         public void Provides_no_value_for_non_string()
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(typeof(int)), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         [Test]
         public void Provides_value_for_string()
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(typeof(string)), Is.EqualTo(Maybe.Just<object>("")));
+            Assert.That(sut.GetValue(typeof(string)), Is.EqualTo(Maybe.Just<object>("")));
         }
 
         public override AutoStringProvider CreateSubjectUnderTest()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoSubstituteProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoSubstituteProviderSpecs.cs
@@ -12,71 +12,6 @@ namespace NSubstitute.Specs.Routing.AutoValues
         private ISubstituteFactory _substituteFactory;
 
         [Test]
-        public void Can_provide_value_for_interface()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof (IFoo)));
-        }
-
-        [Test]
-        public void Can_provide_value_for_delegates()
-        {
-            Assert.That(sut.CanProvideValueFor(typeof (Func<int>)));
-        }
-
-        [Test]
-        [TestCase(typeof(TestClasses.PureVirtualAbstractClassWithDefaultCtor), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithParameterlessConstructor), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithVirtualInterfaceImpl), true)]
-        [TestCase(typeof(TestClasses.PureDescendentOfPureVirtualClass), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicField), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticMethod), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticField), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticProperty), true)]
-        [TestCase(typeof(TestClasses.PureVirtualClassWithoutParameterlessConstructor), false)]
-        [TestCase(typeof(TestClasses.ClassWithANonVirtualPublicMember), false)]
-        [TestCase(typeof(TestClasses.ClassWithNonVirtualInterfaceImpl), false)]
-        [TestCase(typeof(TestClasses.ImpureDescendentOfPureVirtualClass), false)]
-        [TestCase(typeof(TestClasses.VirtualClassWithInternalConstructor), false)]
-        [TestCase(typeof(TestClasses.SealedClassWithoutMethods), false)]
-        public void Can_provide_value_for_class_type(Type type, bool shouldProvideValue)
-        {
-            Assert.That(sut.CanProvideValueFor(type), Is.EqualTo(shouldProvideValue));
-        }
-
-        [Test]
-        public void Should_not_provide_value_for_object_type_as_by_default_object_methods_are_not_proxied()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(object)));
-        }
-
-        [Test]
-        public void Should_not_provide_value_for_string()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(string)));
-        }
-
-        [Test]
-        public void Should_not_provide_value_for_array()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(int[])));
-        }
-
-        [Test]
-        public void Should_not_provide_value_for_value_type()
-        {
-            Assert.False(sut.CanProvideValueFor(typeof(int)));
-        }
-
-        [Test]
-        public void Should_create_substitute_for_type()
-        {
-            var autoValue = new object();
-            _substituteFactory.stub(x => x.Create(new[] {typeof (IFoo)}, new object[0])).Return(autoValue);
-
-            Assert.That(sut.GetValue(typeof (IFoo)), Is.SameAs(autoValue));
-        }
-
-        [Test]
         [TestCase(typeof(TestClasses.PureVirtualClassWithoutParameterlessConstructor))]
         [TestCase(typeof(TestClasses.ClassWithANonVirtualPublicMember))]
         [TestCase(typeof(TestClasses.ClassWithNonVirtualInterfaceImpl))]
@@ -92,7 +27,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
             var autoValue = new object();
             _substituteFactory.stub(x => x.Create(new[] { type }, new object[0])).Return(autoValue);
 
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         [Test]
@@ -111,7 +46,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
             var autoValue = new object();
             _substituteFactory.stub(x => x.Create(new[] { type }, new object[0])).Return(autoValue);
 
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Just(autoValue)));
+            Assert.That(sut.GetValue(type), Is.EqualTo(Maybe.Just(autoValue)));
         }
 
         public override void Context()

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoSubstituteProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoSubstituteProviderSpecs.cs
@@ -76,6 +76,44 @@ namespace NSubstitute.Specs.Routing.AutoValues
             Assert.That(sut.GetValue(typeof (IFoo)), Is.SameAs(autoValue));
         }
 
+        [Test]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithoutParameterlessConstructor))]
+        [TestCase(typeof(TestClasses.ClassWithANonVirtualPublicMember))]
+        [TestCase(typeof(TestClasses.ClassWithNonVirtualInterfaceImpl))]
+        [TestCase(typeof(TestClasses.ImpureDescendentOfPureVirtualClass))]
+        [TestCase(typeof(TestClasses.VirtualClassWithInternalConstructor))]
+        [TestCase(typeof(TestClasses.SealedClassWithoutMethods))]
+        [TestCase(typeof(object))]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(int[]))]
+        [TestCase(typeof(int))]
+        public void Provides_no_value_for_non_substitutables(Type type)
+        {
+            var autoValue = new object();
+            _substituteFactory.stub(x => x.Create(new[] { type }, new object[0])).Return(autoValue);
+
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        [TestCase(typeof(TestClasses.PureVirtualAbstractClassWithDefaultCtor))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithParameterlessConstructor))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithVirtualInterfaceImpl))]
+        [TestCase(typeof(TestClasses.PureDescendentOfPureVirtualClass))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicField))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticMethod))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticField))]
+        [TestCase(typeof(TestClasses.PureVirtualClassWithAPublicStaticProperty))]
+        [TestCase(typeof(IFoo))]
+        [TestCase(typeof(Func<int>))]
+        public void Provides_value_for_substitutables(Type type)
+        {
+            var autoValue = new object();
+            _substituteFactory.stub(x => x.Create(new[] { type }, new object[0])).Return(autoValue);
+
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Just(autoValue)));
+        }
+
         public override void Context()
         {
             _substituteFactory = mock<ISubstituteFactory>();

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
@@ -1,15 +1,18 @@
 ﻿#if (NET4 || NET45)
+using System;
 using System.Threading.Tasks;
 using NSubstitute.Routing.AutoValues;
 using NSubstitute.Specs.Infrastructure;
 using NUnit.Framework;
 using System.Collections.Generic;
+using NSubstitute.Core;
 
 namespace NSubstitute.Specs.Routing.AutoValues
 {
     public class AutoTaskProviderSpecs : ConcernFor<AutoTaskProvider>
     {
         private IAutoValueProvider _testValuesProvider;
+        private IMaybeAutoValueProvider _testMaybeValuesProvider;
 
         [Test]
         public void Should_create_substitute_with_another_auto_value_provider_if_available()
@@ -66,14 +69,61 @@ namespace NSubstitute.Specs.Routing.AutoValues
             Assert.Null(task.Result);
         }
 
+        [Test]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(int))]
+        [TestCase(typeof(int[]))]
+        [TestCase(typeof(List<int>))]
+        public void Provides_no_value_for_non_tasks(Type type)
+        {
+            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        public void Provides_value_for_tasks()
+        {
+            Provides_value_for_tasks<string>();
+            Provides_value_for_tasks<int>();
+            Provides_value_for_tasks<int[]>();
+            Provides_value_for_tasks<List<int>>();
+        }
+
+        public void Provides_value_for_tasks<T>()
+        {
+            var value = ((IMaybeAutoValueProvider)sut).GetValue(typeof(Task<T>)).ValueOrDefault();
+            Assert.IsInstanceOf<Task<T>>(value);
+            Assert.That(((Task<T>) value).Result, Is.EqualTo(default(T)));
+        }
+
+        [Test]
+        public void Provides_value_from_other_auto_value_providers()
+        {
+            const string autoValue = "test";
+            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
+
+            var type = typeof(Task<string>);
+            Assert.That(((Task<string>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
+        }
+
+        [Test]
+        public void Provides_value_from_other_auto_value_providers_of_value_types()
+        {
+            const int autoValue = 10;
+            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
+
+            var type = typeof(Task<int>);
+            Assert.That(((Task<int>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
+        }
+
         public override void Context()
         {
             _testValuesProvider = mock<IAutoValueProvider>();
+            _testMaybeValuesProvider = mock<IMaybeAutoValueProvider>();
         }
 
         public override AutoTaskProvider CreateSubjectUnderTest()
         {
-            return new AutoTaskProvider(() => new[] { _testValuesProvider });
+            return new AutoTaskProvider(() => new[] { _testValuesProvider }, () => new[] { _testMaybeValuesProvider });
         }
 
         public interface IFoo2

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
@@ -77,7 +77,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
 
         public override AutoTaskProvider CreateSubjectUnderTest()
         {
-            return new AutoTaskProvider(() => new[] { _testValuesProvider });
+            return new AutoTaskProvider(() => _testValuesProvider);
         }
 
         public interface IFoo2

--- a/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/AutoTaskProviderSpecs.cs
@@ -12,51 +12,6 @@ namespace NSubstitute.Specs.Routing.AutoValues
     public class AutoTaskProviderSpecs : ConcernFor<AutoTaskProvider>
     {
         private IAutoValueProvider _testValuesProvider;
-        private IMaybeAutoValueProvider _testMaybeValuesProvider;
-
-        [Test]
-        public void Should_create_substitute_with_another_auto_value_provider_if_available()
-        {
-            const string autoValue = "test";
-            _testValuesProvider.stub(x => x.CanProvideValueFor(typeof(string))).Return(true);
-            _testValuesProvider.stub(x => x.GetValue(typeof(string))).Return(autoValue);
-
-            var type = typeof (Task<string>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(((Task<string>)sut.GetValue(type)).Result, Is.SameAs(autoValue));
-        }
-
-        [Test]
-        public void Should_create_substitute_for_task_of_string()
-        {
-            var type = typeof (Task<string>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(((Task<string>)sut.GetValue(type)).Result, Is.Null);
-        }
-
-        [Test]
-        public void Should_create_substitute_for_task_of_value_type()
-        {
-            var type = typeof (Task<int>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(((Task<int>)sut.GetValue(type)).Result, Is.EqualTo(default(int)));
-        }
-
-        [Test]
-        public void Should_create_substitute_for_task_of_complex_type()
-        {
-            var type = typeof (Task<List<string>>);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.That(((Task<List<string>>)sut.GetValue(type)).Result, Is.Null);
-        }
-
-        [Test]
-        public void Should_create_substitute_for_task()
-        {
-            var type = typeof (Task);
-            Assert.True(sut.CanProvideValueFor(type));
-            Assert.True(((Task)sut.GetValue(type)).IsCompleted);
-        }
 
         [Test]
         public void Substitute_should_automock_task()
@@ -76,7 +31,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
         [TestCase(typeof(List<int>))]
         public void Provides_no_value_for_non_tasks(Type type)
         {
-            Assert.That(((IMaybeAutoValueProvider)sut).GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
+            Assert.That(sut.GetValue(type), Is.EqualTo(Maybe.Nothing<object>()));
         }
 
         [Test]
@@ -90,7 +45,7 @@ namespace NSubstitute.Specs.Routing.AutoValues
 
         public void Provides_value_for_tasks<T>()
         {
-            var value = ((IMaybeAutoValueProvider)sut).GetValue(typeof(Task<T>)).ValueOrDefault();
+            var value = sut.GetValue(typeof(Task<T>)).ValueOrDefault();
             Assert.IsInstanceOf<Task<T>>(value);
             Assert.That(((Task<T>) value).Result, Is.EqualTo(default(T)));
         }
@@ -99,31 +54,30 @@ namespace NSubstitute.Specs.Routing.AutoValues
         public void Provides_value_from_other_auto_value_providers()
         {
             const string autoValue = "test";
-            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
+            _testValuesProvider.stub(x => x.GetValue(typeof(string))).Return(Maybe.Just<object>(autoValue));
 
             var type = typeof(Task<string>);
-            Assert.That(((Task<string>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
+            Assert.That(((Task<string>)sut.GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
         }
 
         [Test]
         public void Provides_value_from_other_auto_value_providers_of_value_types()
         {
             const int autoValue = 10;
-            _testMaybeValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
+            _testValuesProvider.stub(x => x.GetValue(typeof(int))).Return(Maybe.Just<object>(autoValue));
 
             var type = typeof(Task<int>);
-            Assert.That(((Task<int>)((IMaybeAutoValueProvider)sut).GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
+            Assert.That(((Task<int>)sut.GetValue(type).ValueOrDefault()).Result, Is.EqualTo(autoValue));
         }
 
         public override void Context()
         {
             _testValuesProvider = mock<IAutoValueProvider>();
-            _testMaybeValuesProvider = mock<IMaybeAutoValueProvider>();
         }
 
         public override AutoTaskProvider CreateSubjectUnderTest()
         {
-            return new AutoTaskProvider(() => new[] { _testValuesProvider }, () => new[] { _testMaybeValuesProvider });
+            return new AutoTaskProvider(() => new[] { _testValuesProvider });
         }
 
         public interface IFoo2

--- a/Source/NSubstitute.Specs/Routing/AutoValues/CompositeProviderSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/AutoValues/CompositeProviderSpecs.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using NSubstitute.Core;
+using NSubstitute.Routing.AutoValues;
+using NSubstitute.Specs.Infrastructure;
+using NUnit.Framework;
+
+namespace NSubstitute.Specs.Routing.AutoValues
+{
+    public class CompositeProviderSpecs : ConcernFor<CompositeProvider>
+    {
+        private IAutoValueProvider _provider1;
+        private IAutoValueProvider _provider2;
+        private IAutoValueProvider _provider3;
+        private List<IAutoValueProvider> _providers = new List<IAutoValueProvider>();
+
+        [Test]
+        public void Provides_no_value_when_no_provider_provides()
+        {
+            Assert.That(sut.GetValue(typeof(object)), Is.EqualTo(Maybe.Nothing<object>()));
+        }
+
+        [Test]
+        public void Provides_value_that_first_provider_provides()
+        {
+            var type = typeof(object);
+            var value2 = new object();
+            var value3 = new object();
+            _provider1.stub(x => x.GetValue(type)).Return(Maybe.Nothing<object>());
+            _provider2.stub(x => x.GetValue(type)).Return(Maybe.Just(value2));
+            _provider3.stub(x => x.GetValue(type)).Return(Maybe.Just(value3));
+
+            Assert.That(sut.GetValue(typeof(object)), Is.EqualTo(Maybe.Just(value2)));
+        }
+
+        [Test]
+        public void Provides_value_that_new_provider_provides()
+        {
+            var newProvider = mock<IAutoValueProvider>();
+            _providers.Insert(0, newProvider);
+            var type = typeof(object);
+            var newValue = new object();
+            var value2 = new object();
+            var value3 = new object();
+            newProvider.stub(x => x.GetValue(type)).Return(Maybe.Just(newValue));
+            _provider1.stub(x => x.GetValue(type)).Return(Maybe.Nothing<object>());
+            _provider2.stub(x => x.GetValue(type)).Return(Maybe.Just(value2));
+            _provider3.stub(x => x.GetValue(type)).Return(Maybe.Just(value3));
+
+            Assert.That(sut.GetValue(typeof(object)), Is.EqualTo(Maybe.Just(newValue)));
+        }
+
+        public override void Context()
+        {
+            base.Context();
+            _provider1 = mock<IAutoValueProvider>();
+            _provider2 = mock<IAutoValueProvider>();
+            _provider3 = mock<IAutoValueProvider>();
+            _providers.AddRange(new [] { _provider1, _provider2, _provider3 });
+        }
+
+        public override CompositeProvider CreateSubjectUnderTest()
+        {
+            return new CompositeProvider(_providers);
+        }
+    }
+}

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -36,7 +36,7 @@ namespace NSubstitute.Specs.Routing.Handlers
 
             public ReturnAutoValue CreateReturnAutoValue(AutoValueBehaviour autoValueBehaviour)
             {
-                return new ReturnAutoValue(autoValueBehaviour, new CompositeProvider(new [] { _firstAutoValueProvider, _secondAutoValueProvider }), ConfigureCall);
+                return new ReturnAutoValue(() => autoValueBehaviour, new CompositeProvider(new [] { _firstAutoValueProvider, _secondAutoValueProvider }), ConfigureCall);
             }
         }
 

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -269,5 +269,102 @@ namespace NSubstitute.Specs.Routing.Handlers
                 return CreateReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls);
             }
         }
+
+        public class When_method_is_void_but_has_an_auto_value_for_a_modified_out_param : Concern
+        {
+            readonly object _autoValue = 32;
+            private readonly object _newValue = 60;
+            private readonly object _oldValue = 155;
+            private object[] _arguments = new object[1];
+            private object[] _originalArguments = new object[1];
+
+            [Test]
+            public void Should_not_return_auto_value_for_parameter()
+            {
+                Assert.That(_arguments[0], Is.EqualTo(_newValue));
+            }
+
+            [Test]
+            public void Should_not_set_auto_value_to_return_for_subsequent_calls()
+            {
+                ConfigureCall.did_not_receive_with_any_args(x => x.SetResultForCall(It.IsAny<ICall>(), It.IsAny<IReturn>(), It.IsAny<MatchArgs>()));
+            }
+
+            public override void Context()
+            {
+                _type = typeof(void);
+                base.Context();
+                var parameterInfo = mock<IParameterInfo>();
+                var byRefType = typeof(int).MakeByRefType();
+                parameterInfo.stub(x => x.ParameterType).Return(byRefType);
+                _call.stub(x => x.GetParameterInfos()).Return(new[] { parameterInfo });
+                _call.stub(x => x.GetArguments()).Return(_arguments);
+                _call.stub(x => x.GetOriginalArguments()).Return(_originalArguments);
+                _originalArguments[0] = _oldValue;
+                _arguments[0] = _newValue;
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Nothing<object>());
+                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(Maybe.Just(_autoValue));
+            }
+
+            public override ReturnAutoValue CreateSubjectUnderTest()
+            {
+                return CreateReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls);
+            }
+        }
+
+        public class When_method_is_void_but_has_an_auto_value_for_one_modified_and_one_unmodified_out_param : Concern
+        {
+            readonly object _autoValue = 32;
+            private readonly object _newValue = 60;
+            private readonly object _oldValue = 155;
+            private object[] _arguments = new object[2];
+            private object[] _originalArguments = new object[2];
+
+            [Test]
+            public void Should_not_return_auto_value_for_modified_parameter()
+            {
+                Assert.That(_arguments[0], Is.EqualTo(_newValue));
+            }
+
+            [Test]
+            public void Should_not_return_auto_value_for_unmodified_parameter()
+            {
+                Assert.That(_arguments[1], Is.EqualTo(_autoValue));
+            }
+
+            [Test]
+            public void Should_set_auto_value_for_out_param_to_return_for_subsequent_calls()
+            {
+                object[] arguments = new object[2];
+                var callInfo =
+                    new CallInfo(new[] { new Argument(typeof(int).MakeByRefType(), () => arguments[0], x => arguments[0] = x), new Argument(typeof(int).MakeByRefType(), () => arguments[1], x => arguments[1] = x) });
+                ConfigureCall.received(x => x.SetResultForCall(It.Is(_call), It.Matches<IReturn>(arg => arg.ReturnFor(callInfo) == null), It.Is(MatchArgs.AsSpecifiedInCall)));
+                Assert.That(arguments[0], Is.Null);
+                Assert.That(arguments[1], Is.EqualTo(_autoValue));
+            }
+
+            public override void Context()
+            {
+                _type = typeof(void);
+                base.Context();
+                var parameterInfo = mock<IParameterInfo>();
+                var byRefType = typeof(int).MakeByRefType();
+                parameterInfo.stub(x => x.ParameterType).Return(byRefType);
+                _call.stub(x => x.GetParameterInfos()).Return(new[] { parameterInfo, parameterInfo });
+                _call.stub(x => x.GetArguments()).Return(_arguments);
+                _call.stub(x => x.GetOriginalArguments()).Return(_originalArguments);
+                _originalArguments[0] = _oldValue;
+                _originalArguments[1] = _newValue;
+                _arguments[0] = _newValue;
+                _arguments[1] = _newValue;
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Nothing<object>());
+                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(Maybe.Just(_autoValue));
+            }
+
+            public override ReturnAutoValue CreateSubjectUnderTest()
+            {
+                return CreateReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls);
+            }
+        }
     }
 }

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -59,6 +59,8 @@ namespace NSubstitute.Specs.Routing.Handlers
             public override void Context()
             {
                 base.Context();
+                _call.stub(x => x.GetArguments()).Return(new object[0]);
+                _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
                 _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
                 _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
             }
@@ -75,6 +77,13 @@ namespace NSubstitute.Specs.Routing.Handlers
             public void Should_continue_route()
             {
                 Assert.That(_result, Is.EqualTo(RouteAction.Continue()));
+            }
+
+            public override void Context()
+            {
+                base.Context();
+                _call.stub(x => x.GetArguments()).Return(new object[0]);
+                _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()
@@ -102,6 +111,8 @@ namespace NSubstitute.Specs.Routing.Handlers
             public override void Context()
             {
                 base.Context();
+                _call.stub(x => x.GetArguments()).Return(new object[0]);
+                _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
                 _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
                 _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
             }
@@ -114,7 +125,7 @@ namespace NSubstitute.Specs.Routing.Handlers
 
         public class When_has_an_auto_value_for_an_out_param_of_the_handled_call : Concern
         {
-            readonly object _autoValue = new object();
+            readonly object _autoValue = 32;
             private object[] _arguments = new object[1];
 
             [Test]
@@ -122,7 +133,17 @@ namespace NSubstitute.Specs.Routing.Handlers
             {
                 Assert.That(_arguments[0], Is.SameAs(_autoValue));
             }
-            
+
+            [Test]
+            public void Should_set_auto_value_for_out_param_to_return_for_subsequent_calls()
+            {
+                object[] arguments = new object[1];
+                var callInfo =
+                    new CallInfo(new[] {new Argument(typeof(int).MakeByRefType(), () => arguments[0], x => arguments[0] = x)});
+                ConfigureCall.received(x => x.SetResultForCall(It.Is(_call), It.Matches<IReturn>(arg => arg.ReturnFor(callInfo) == _autoValue), It.Is(MatchArgs.AsSpecifiedInCall)));
+                Assert.That(arguments[0], Is.SameAs(_autoValue));
+            }
+
             public override void Context()
             {
                 base.Context();
@@ -131,6 +152,8 @@ namespace NSubstitute.Specs.Routing.Handlers
                 parameterInfo.stub(x => x.ParameterType).Return(byRefType);
                 _call.stub(x => x.GetParameterInfos()).Return(new[] {parameterInfo});
                 _call.stub(x => x.GetArguments()).Return(_arguments);
+                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
                 _secondAutoValueProvider.stub(x => x.CanProvideValueFor(byRefType)).Return(true);
                 _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(_autoValue);
             }

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -204,5 +204,28 @@ namespace NSubstitute.Specs.Routing.Handlers
                 return CreateReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls);
             }
         }
+
+        public class When_method_is_void_but_has_no_out_param : Concern
+        {
+            [Test]
+            public void Should_not_set_to_return_for_subsequent_calls()
+            {
+                ConfigureCall.did_not_receive_with_any_args(x => x.SetResultForCall(It.IsAny<ICall>(), It.IsAny<IReturn>(), It.IsAny<MatchArgs>()));
+            }
+
+            public override void Context()
+            {
+                _type = typeof(void);
+                base.Context();
+                _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
+                _call.stub(x => x.GetArguments()).Return(new object[0]);
+                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(false);
+            }
+
+            public override ReturnAutoValue CreateSubjectUnderTest()
+            {
+                return CreateReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls);
+            }
+        }
     }
 }

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -36,7 +36,7 @@ namespace NSubstitute.Specs.Routing.Handlers
 
             public ReturnAutoValue CreateReturnAutoValue(AutoValueBehaviour autoValueBehaviour)
             {
-                return new ReturnAutoValue(autoValueBehaviour, new[] {_firstAutoValueProvider, _secondAutoValueProvider}, ConfigureCall);
+                return new ReturnAutoValue(autoValueBehaviour, new CompositeProvider(new [] { _firstAutoValueProvider, _secondAutoValueProvider }), ConfigureCall);
             }
         }
 

--- a/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
+++ b/Source/NSubstitute.Specs/Routing/Handlers/ReturnAutoValueSpecs.cs
@@ -61,8 +61,7 @@ namespace NSubstitute.Specs.Routing.Handlers
                 base.Context();
                 _call.stub(x => x.GetArguments()).Return(new object[0]);
                 _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
-                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Just(_autoValue));
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()
@@ -113,8 +112,7 @@ namespace NSubstitute.Specs.Routing.Handlers
                 base.Context();
                 _call.stub(x => x.GetArguments()).Return(new object[0]);
                 _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
-                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Just(_autoValue));
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()
@@ -152,10 +150,8 @@ namespace NSubstitute.Specs.Routing.Handlers
                 parameterInfo.stub(x => x.ParameterType).Return(byRefType);
                 _call.stub(x => x.GetParameterInfos()).Return(new[] {parameterInfo});
                 _call.stub(x => x.GetArguments()).Return(_arguments);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(true);
-                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(_autoValue);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(byRefType)).Return(true);
-                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(_autoValue);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Just(_autoValue));
+                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(Maybe.Just(_autoValue));
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()
@@ -194,9 +190,8 @@ namespace NSubstitute.Specs.Routing.Handlers
                 parameterInfo.stub(x => x.ParameterType).Return(byRefType);
                 _call.stub(x => x.GetParameterInfos()).Return(new[] { parameterInfo });
                 _call.stub(x => x.GetArguments()).Return(_arguments);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(false);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(byRefType)).Return(true);
-                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(_autoValue);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Nothing<object>());
+                _secondAutoValueProvider.stub(x => x.GetValue(byRefType)).Return(Maybe.Just(_autoValue));
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()
@@ -219,7 +214,7 @@ namespace NSubstitute.Specs.Routing.Handlers
                 base.Context();
                 _call.stub(x => x.GetParameterInfos()).Return(new IParameterInfo[0]);
                 _call.stub(x => x.GetArguments()).Return(new object[0]);
-                _secondAutoValueProvider.stub(x => x.CanProvideValueFor(_type)).Return(false);
+                _secondAutoValueProvider.stub(x => x.GetValue(_type)).Return(Maybe.Nothing<object>());
             }
 
             public override ReturnAutoValue CreateSubjectUnderTest()

--- a/Source/NSubstitute/Core/Call.cs
+++ b/Source/NSubstitute/Core/Call.cs
@@ -11,6 +11,7 @@ namespace NSubstitute.Core
     {
         private readonly MethodInfo _methodInfo;
         private readonly object[] _arguments;
+        private readonly IEnumerable<object> _originalArguments;
         private readonly object _target;
         private readonly IParameterInfo[] _parameterInfos;
         private readonly IList<IArgumentSpecification> _argumentSpecifications;
@@ -21,6 +22,7 @@ namespace NSubstitute.Core
         {
             _methodInfo = methodInfo;
             _arguments = arguments;
+            _originalArguments = arguments.ToArray();
             _target = target;
             _parameterInfos = GetParameterInfosFrom(_methodInfo);
             _argumentSpecifications = argumentSpecsForCall;
@@ -31,6 +33,7 @@ namespace NSubstitute.Core
         {
             _methodInfo = methodInfo;
             _arguments = arguments;
+            _originalArguments = _arguments.ToArray();
             _target = target;
             _parameterInfos = parameterInfos ?? GetParameterInfosFrom(_methodInfo);
             _argumentSpecifications = (_parameterInfos.Length == 0) ? EmptyList() : SubstitutionContext.Current.DequeueAllArgumentSpecifications();
@@ -90,6 +93,11 @@ namespace NSubstitute.Core
         public object[] GetArguments()
         {
             return _arguments;
+        }
+
+        public IEnumerable<object> GetOriginalArguments()
+        {
+            return _originalArguments;
         }
 
         public object Target()

--- a/Source/NSubstitute/Core/CallResults.cs
+++ b/Source/NSubstitute/Core/CallResults.cs
@@ -20,7 +20,6 @@ namespace NSubstitute.Core
 
         public bool HasResultFor(ICall call)
         {
-            if (ReturnsVoidFrom(call)) return false;
             return _results.Any(x => x.IsResultFor(call));
         }
 
@@ -30,11 +29,6 @@ namespace NSubstitute.Core
                     .Reverse()
                     .First(x => x.IsResultFor(call))
                     .GetResult(_callInfoFactory.Create(call));
-        }
-
-        bool ReturnsVoidFrom(ICall call)
-        {
-            return call.GetReturnType() == typeof (void);
         }
 
         class ResultForCallSpec

--- a/Source/NSubstitute/Core/CallRouter.cs
+++ b/Source/NSubstitute/Core/CallRouter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NSubstitute.Core.Arguments;
 using NSubstitute.Routing;
 using NSubstitute.Routing.AutoValues;
+using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Core
 {
@@ -93,6 +94,12 @@ namespace NSubstitute.Core
         public IList<IAutoValueProvider> AutoValueProviders
         {
             get { return _substituteState.AutoValueProviders; }
+        }
+
+        public AutoValueBehaviour AutoValueBehaviour
+        {
+            get { return _substituteState.AutoValueBehaviour; }
+            set { _substituteState.AutoValueBehaviour = value; }
         }
     }
 }

--- a/Source/NSubstitute/Core/CallRouter.cs
+++ b/Source/NSubstitute/Core/CallRouter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NSubstitute.Core.Arguments;
 using NSubstitute.Routing;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -87,6 +88,11 @@ namespace NSubstitute.Core
         public void SetReturnForType(Type type, IReturn returnValue)
         {
             _substituteState.ResultsForType.SetResult(type, returnValue);
+        }
+
+        public IList<IAutoValueProvider> AutoValueProviders
+        {
+            get { return _substituteState.AutoValueProviders; }
         }
     }
 }

--- a/Source/NSubstitute/Core/ICall.cs
+++ b/Source/NSubstitute/Core/ICall.cs
@@ -10,6 +10,7 @@ namespace NSubstitute.Core
         Type GetReturnType();
         MethodInfo GetMethodInfo();
         object[] GetArguments();
+        IEnumerable<object> GetOriginalArguments();
         object Target();
         IParameterInfo[] GetParameterInfos();
         IList<IArgumentSpecification> GetArgumentSpecifications();

--- a/Source/NSubstitute/Core/ICallRouter.cs
+++ b/Source/NSubstitute/Core/ICallRouter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NSubstitute.Routing;
 using NSubstitute.Routing.AutoValues;
+using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Core
 {
@@ -14,5 +15,6 @@ namespace NSubstitute.Core
         void SetRoute(Func<ISubstituteState, IRoute> getRoute);
         void SetReturnForType(Type type, IReturn returnValue);
         IList<IAutoValueProvider> AutoValueProviders { get; }
+        AutoValueBehaviour AutoValueBehaviour { get; set; }
     }
 }

--- a/Source/NSubstitute/Core/ICallRouter.cs
+++ b/Source/NSubstitute/Core/ICallRouter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NSubstitute.Routing;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -12,5 +13,6 @@ namespace NSubstitute.Core
         IEnumerable<ICall> ReceivedCalls();
         void SetRoute(Func<ISubstituteState, IRoute> getRoute);
         void SetReturnForType(Type type, IReturn returnValue);
+        IList<IAutoValueProvider> AutoValueProviders { get; }
     }
 }

--- a/Source/NSubstitute/Core/ISubstituteState.cs
+++ b/Source/NSubstitute/Core/ISubstituteState.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System.Collections.Generic;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -15,7 +16,7 @@ namespace NSubstitute.Core
         SequenceNumberGenerator SequenceNumberGenerator { get; }
         IConfigureCall ConfigureCall { get; }
         IEventHandlerRegistry EventHandlerRegistry { get; }
-        IAutoValueProvider[] AutoValueProviders { get; }
+        IList<IAutoValueProvider> AutoValueProviders { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         IResultsForType ResultsForType { get; }
         void ClearUnusedCallSpecs();

--- a/Source/NSubstitute/Core/ISubstituteState.cs
+++ b/Source/NSubstitute/Core/ISubstituteState.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using NSubstitute.Routing.AutoValues;
+using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Core
 {
@@ -19,6 +20,7 @@ namespace NSubstitute.Core
         IList<IAutoValueProvider> AutoValueProviders { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         IResultsForType ResultsForType { get; }
+        AutoValueBehaviour AutoValueBehaviour { get; set; }
         void ClearUnusedCallSpecs();
     }
 }

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -51,7 +51,7 @@ namespace NSubstitute.Core
                 new AutoStringProvider(), 
                 new AutoArrayProvider(),
 #if (NET4 || NET45)
-                new AutoTaskProvider(() => AutoValueProviders.ToArray()),
+                new AutoTaskProvider(() => new CompositeProvider(AutoValueProviders.ToArray())),
 #endif
             };
         }

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NSubstitute.Routing.AutoValues;
+using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Core
 {
@@ -20,6 +21,7 @@ namespace NSubstitute.Core
         public IEventHandlerRegistry EventHandlerRegistry { get; private set; }
         public IList<IAutoValueProvider> AutoValueProviders { get; private set; }
         public IResultsForType ResultsForType { get; private set; }
+        public AutoValueBehaviour AutoValueBehaviour { get; set; }
 
         public SubstituteState(ISubstitutionContext substitutionContext, SubstituteConfig option)
         {

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -1,4 +1,6 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System.Collections.Generic;
+using System.Linq;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -16,7 +18,7 @@ namespace NSubstitute.Core
         public SequenceNumberGenerator SequenceNumberGenerator { get; private set; }
         public IConfigureCall ConfigureCall { get; private set; }
         public IEventHandlerRegistry EventHandlerRegistry { get; private set; }
-        public IAutoValueProvider[] AutoValueProviders { get; private set; }
+        public IList<IAutoValueProvider> AutoValueProviders { get; private set; }
         public IResultsForType ResultsForType { get; private set; }
 
         public SubstituteState(ISubstitutionContext substitutionContext, SubstituteConfig option)
@@ -40,16 +42,16 @@ namespace NSubstitute.Core
 
             ConfigureCall = new ConfigureCall(CallResults, CallActions, getCallSpec);
             EventHandlerRegistry = new EventHandlerRegistry();
-            AutoValueProviders = new IAutoValueProvider[] { 
+            AutoValueProviders = new List<IAutoValueProvider> { 
 #if NET45
-                new AutoObservableProvider(() => AutoValueProviders),
+                new AutoObservableProvider(() => AutoValueProviders.ToArray()),
 #endif
                 new AutoQueryableProvider(),
                 new AutoSubstituteProvider(substituteFactory), 
                 new AutoStringProvider(), 
                 new AutoArrayProvider(),
 #if (NET4 || NET45)
-                new AutoTaskProvider(() => AutoValueProviders),
+                new AutoTaskProvider(() => AutoValueProviders.ToArray()),
 #endif
             };
         }

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -44,7 +44,7 @@ namespace NSubstitute.Core
             EventHandlerRegistry = new EventHandlerRegistry();
             AutoValueProviders = new List<IAutoValueProvider> { 
 #if NET45
-                new AutoObservableProvider(() => AutoValueProviders.ToArray()),
+                new AutoObservableProvider(() => new CompositeProvider(AutoValueProviders.ToArray())),
 #endif
                 new AutoQueryableProvider(),
                 new AutoSubstituteProvider(substituteFactory), 

--- a/Source/NSubstitute/NSubstitute.csproj
+++ b/Source/NSubstitute/NSubstitute.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Routing\AutoValues\AutoStringProvider.cs" />
     <Compile Include="Routing\AutoValues\AutoSubstituteProvider.cs" />
     <Compile Include="Routing\AutoValues\AutoTaskProvider.cs" />
+    <Compile Include="Routing\AutoValues\CompositeProvider.cs" />
     <Compile Include="Routing\AutoValues\IAutoValueProvider.cs" />
     <Compile Include="Routing\Handlers\AddCallToQueryResultHandler.cs" />
     <Compile Include="Routing\Handlers\ClearLastCallRouterHandler.cs" />

--- a/Source/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
@@ -3,26 +3,26 @@ using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoArrayProvider : IAutoValueProvider, IMaybeAutoValueProvider
+    public class AutoArrayProvider : IAutoValueProvider
     {
-        public bool CanProvideValueFor(Type type)
+        private bool CanProvideValueFor(Type type)
         {
             return type.IsArray;
         }
 
-        public object GetValue(Type type)
+        private object GetActualValue(Type type)
         {
             var rank = type.GetArrayRank();
             var dimensionLengths = new int[rank];
             return Array.CreateInstance(type.GetElementType(), dimensionLengths);
         }
 
-        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        public Maybe<object> GetValue(Type type)
         {
             if (!CanProvideValueFor(type))
                 return Maybe.Nothing<object>();
 
-            return Maybe.Just(GetValue(type));
+            return Maybe.Just(GetActualValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
@@ -1,8 +1,9 @@
 using System;
+using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoArrayProvider : IAutoValueProvider
+    public class AutoArrayProvider : IAutoValueProvider, IMaybeAutoValueProvider
     {
         public bool CanProvideValueFor(Type type)
         {
@@ -14,6 +15,14 @@ namespace NSubstitute.Routing.AutoValues
             var rank = type.GetArrayRank();
             var dimensionLengths = new int[rank];
             return Array.CreateInstance(type.GetElementType(), dimensionLengths);
+        }
+
+        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        {
+            if (!CanProvideValueFor(type))
+                return Maybe.Nothing<object>();
+
+            return Maybe.Just(GetValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
@@ -1,15 +1,14 @@
 ﻿#if NET45
 using System;
-using System.Linq;
 using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
     public class AutoObservableProvider : IAutoValueProvider
     {
-        private readonly Func<IAutoValueProvider[]> _autoValueProviders;
+        private readonly Func<IAutoValueProvider> _autoValueProviders;
 
-        public AutoObservableProvider(Func<IAutoValueProvider[]> autoValueProviders)
+        public AutoObservableProvider(Func<IAutoValueProvider> autoValueProviders)
         {
             _autoValueProviders = autoValueProviders;
         }
@@ -30,12 +29,8 @@ namespace NSubstitute.Routing.AutoValues
 
         private object GetValueFromProvider(Type type)
         {
-            if (_autoValueProviders == null)
-                return null;
-
             return _autoValueProviders()
-                .Select(vp => vp.GetValue(type))
-                .FirstOrDefault(vp => vp.HasValue())
+                .GetValue(type)
                 .ValueOrDefault();
         }
 

--- a/Source/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoQueryableProvider : IAutoValueProvider
+    public class AutoQueryableProvider : IAutoValueProvider, IMaybeAutoValueProvider
     {
         public bool CanProvideValueFor(Type type)
         {
@@ -19,6 +20,14 @@ namespace NSubstitute.Routing.AutoValues
             Type innerType = type.GetGenericArguments()[0];
 
             return Array.CreateInstance(innerType, 0).AsQueryable();
+        }
+
+        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        {
+            if (!CanProvideValueFor(type))
+                return Maybe.Nothing<object>();
+
+            return Maybe.Just(GetValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
@@ -5,29 +5,26 @@ using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoQueryableProvider : IAutoValueProvider, IMaybeAutoValueProvider
+    public class AutoQueryableProvider : IAutoValueProvider
     {
-        public bool CanProvideValueFor(Type type)
+        private bool CanProvideValueFor(Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryable<>);
         }
 
-        public object GetValue(Type type)
+        private object GetActualValue(Type type)
         {
-            if (!CanProvideValueFor(type))
-                throw new InvalidOperationException();
-
             Type innerType = type.GetGenericArguments()[0];
 
             return Array.CreateInstance(innerType, 0).AsQueryable();
         }
 
-        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        public Maybe<object> GetValue(Type type)
         {
             if (!CanProvideValueFor(type))
                 return Maybe.Nothing<object>();
 
-            return Maybe.Just(GetValue(type));
+            return Maybe.Just(GetActualValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoStringProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoStringProvider.cs
@@ -1,8 +1,9 @@
 using System;
+using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoStringProvider : IAutoValueProvider
+    public class AutoStringProvider : IAutoValueProvider, IMaybeAutoValueProvider
     {
         public bool CanProvideValueFor(Type type)
         {
@@ -12,6 +13,14 @@ namespace NSubstitute.Routing.AutoValues
         public object GetValue(Type type)
         {
             return string.Empty;
+        }
+
+        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        {
+            if (!CanProvideValueFor(type))
+                return Maybe.Nothing<object>();
+
+            return Maybe.Just(GetValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoStringProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoStringProvider.cs
@@ -3,24 +3,24 @@ using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoStringProvider : IAutoValueProvider, IMaybeAutoValueProvider
+    public class AutoStringProvider : IAutoValueProvider
     {
-        public bool CanProvideValueFor(Type type)
+        private bool CanProvideValueFor(Type type)
         {
             return type == typeof(string); 
         }
 
-        public object GetValue(Type type)
+        private object GetActualValue(Type type)
         {
             return string.Empty;
         }
 
-        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        public Maybe<object> GetValue(Type type)
         {
             if (!CanProvideValueFor(type))
                 return Maybe.Nothing<object>();
 
-            return Maybe.Just(GetValue(type));
+            return Maybe.Just(GetActualValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
@@ -5,7 +5,7 @@ using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoSubstituteProvider : IAutoValueProvider
+    public class AutoSubstituteProvider : IAutoValueProvider, IMaybeAutoValueProvider
     {
         private readonly ISubstituteFactory _substituteFactory;
 
@@ -68,6 +68,14 @@ namespace NSubstitute.Routing.AutoValues
         private bool NotStaticMethod(MethodInfo methodInfo)
         {
             return !methodInfo.IsStatic;
+        }
+
+        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        {
+            if (!CanProvideValueFor(type))
+                return Maybe.Nothing<object>();
+
+            return Maybe.Just(GetValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
@@ -5,7 +5,7 @@ using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
-    public class AutoSubstituteProvider : IAutoValueProvider, IMaybeAutoValueProvider
+    public class AutoSubstituteProvider : IAutoValueProvider
     {
         private readonly ISubstituteFactory _substituteFactory;
 
@@ -14,14 +14,14 @@ namespace NSubstitute.Routing.AutoValues
             _substituteFactory = substituteFactory;
         }
 
-        public bool CanProvideValueFor(Type type)
+        private bool CanProvideValueFor(Type type)
         {
             return type.IsInterface
                 || type.IsSubclassOf(typeof(Delegate))
                 || IsPureVirtualClassWithParameterlessConstructor(type);
         }
 
-        public object GetValue(Type type)
+        private object GetActualValue(Type type)
         {
             return _substituteFactory.Create(new[] { type }, new object[0]);
         }
@@ -70,12 +70,12 @@ namespace NSubstitute.Routing.AutoValues
             return !methodInfo.IsStatic;
         }
 
-        Maybe<object> IMaybeAutoValueProvider.GetValue(Type type)
+        public Maybe<object> GetValue(Type type)
         {
             if (!CanProvideValueFor(type))
                 return Maybe.Nothing<object>();
 
-            return Maybe.Just(GetValue(type));
+            return Maybe.Just(GetActualValue(type));
         }
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
@@ -1,6 +1,5 @@
 #if (NET4 || NET45)
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute.Core;
 
@@ -8,9 +7,9 @@ namespace NSubstitute.Routing.AutoValues
 {
     public class AutoTaskProvider : IAutoValueProvider
     {
-        private readonly Func<IAutoValueProvider[]> _autoValueProviders;
+        private readonly Func<IAutoValueProvider> _autoValueProviders;
 
-        public AutoTaskProvider(Func<IAutoValueProvider[]> autoValueProviders)
+        public AutoTaskProvider(Func<IAutoValueProvider> autoValueProviders)
         {
             _autoValueProviders = autoValueProviders;
         }
@@ -44,12 +43,8 @@ namespace NSubstitute.Routing.AutoValues
 
         private object GetValueFromProvider(Type type)
         {
-            if (_autoValueProviders == null)
-                return null;
-
             return _autoValueProviders()
-                .Select(vp => vp.GetValue(type))
-                .FirstOrDefault(vp => vp.HasValue())
+                .GetValue(type)
                 .ValueOrDefault();
         }
 

--- a/Source/NSubstitute/Routing/AutoValues/CompositeProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/CompositeProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute.Core;
+
+namespace NSubstitute.Routing.AutoValues
+{
+    public class CompositeProvider : IAutoValueProvider
+    {
+        private readonly IEnumerable<IAutoValueProvider> _providers;
+
+        public CompositeProvider(IEnumerable<IAutoValueProvider> providers)
+        {
+            if (providers == null)
+                throw new ArgumentNullException("providers");
+
+            _providers = providers;
+        }
+
+        public Maybe<object> GetValue(Type type)
+        {
+            return _providers
+                .Aggregate(
+                    Maybe.Nothing<object>(),
+                    (x, p) => x.OrElse(p.GetValue(type)));
+        }
+    }
+}

--- a/Source/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using NSubstitute.Core;
 
 namespace NSubstitute.Routing.AutoValues
 {
@@ -6,5 +7,10 @@ namespace NSubstitute.Routing.AutoValues
     {
         bool CanProvideValueFor(Type type);
         object GetValue(Type type);
+    }
+
+    public interface IMaybeAutoValueProvider
+    {
+        Maybe<object> GetValue(Type type);
     }
 }

--- a/Source/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
+++ b/Source/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
@@ -5,12 +5,6 @@ namespace NSubstitute.Routing.AutoValues
 {
     public interface IAutoValueProvider
     {
-        bool CanProvideValueFor(Type type);
-        object GetValue(Type type);
-    }
-
-    public interface IMaybeAutoValueProvider
-    {
         Maybe<object> GetValue(Type type);
     }
 }

--- a/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -14,10 +14,10 @@ namespace NSubstitute.Routing.Handlers
     public class ReturnAutoValue : ICallHandler
     {
         private readonly IAutoValueProvider _autoValueProvider;
-        private readonly AutoValueBehaviour _autoValueBehaviour;
+        private readonly Func<AutoValueBehaviour> _autoValueBehaviour;
         private readonly IConfigureCall ConfigureCall;
 
-        public ReturnAutoValue(AutoValueBehaviour autoValueBehaviour, IAutoValueProvider autoValueProvider, IConfigureCall configureCall)
+        public ReturnAutoValue(Func<AutoValueBehaviour> autoValueBehaviour, IAutoValueProvider autoValueProvider, IConfigureCall configureCall)
         {
             _autoValueProvider = autoValueProvider;
             ConfigureCall = configureCall;
@@ -78,7 +78,7 @@ namespace NSubstitute.Routing.Handlers
             if (byRefValues.Length == 0)
                 return RouteAction.Continue();
 
-            if (_autoValueBehaviour == AutoValueBehaviour.UseValueForSubsequentCalls)
+            if (_autoValueBehaviour() == AutoValueBehaviour.UseValueForSubsequentCalls)
                 ConfigureCall.SetResultForCall(call,
                     GetReturnValue<object>(null, byRefValues),
                     MatchArgs.AsSpecifiedInCall);
@@ -95,7 +95,7 @@ namespace NSubstitute.Routing.Handlers
                 .Where(x => !WasModified(x, call))
                 .ToArray();
 
-            if (_autoValueBehaviour == AutoValueBehaviour.UseValueForSubsequentCalls)
+            if (_autoValueBehaviour() == AutoValueBehaviour.UseValueForSubsequentCalls)
             {
                 ConfigureCall.SetResultForCall(call, GetReturnValue(valueToReturn, byRefValues), MatchArgs.AsSpecifiedInCall);
             }

--- a/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -75,21 +75,16 @@ namespace NSubstitute.Routing.Handlers
             var callInfo = new CallInfoFactory().Create(call);
             var byRefValues = GetByRefValues(callInfo).ToArray();
 
+            if (byRefValues.Length == 0)
+                return RouteAction.Continue();
+
             if (_autoValueBehaviour == AutoValueBehaviour.UseValueForSubsequentCalls)
                 ConfigureCall.SetResultForCall(call,
-                    GetReturnValue(GetDefault(call.GetReturnType()), byRefValues),
+                    GetReturnValue<object>(null, byRefValues),
                     MatchArgs.AsSpecifiedInCall);
 
             SetByRefValues(callInfo, byRefValues);
             return RouteAction.Continue();
-        }
-
-        private object GetDefault(Type type)
-        {
-            if (type == typeof(void))
-                return null;
-
-            return type.IsValueType ? Activator.CreateInstance(type) : null;
         }
 
         private Func<IAutoValueProvider, RouteAction> ReturnValueUsingProvider(ICall call, Type type)

--- a/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -87,13 +87,23 @@ namespace NSubstitute.Routing.Handlers
         private RouteAction ReturnValue(ICall call, object valueToReturn)
         {
             var callInfo = new CallInfoFactory().Create(call);
-            var byRefValues = GetByRefValues(callInfo).ToArray();
+            var byRefValues =
+                GetByRefValues(callInfo)
+                .Where(x => !WasModified(x, call))
+                .ToArray();
+
             if (_autoValueBehaviour == AutoValueBehaviour.UseValueForSubsequentCalls)
             {
                 ConfigureCall.SetResultForCall(call, GetReturnValue(valueToReturn, byRefValues), MatchArgs.AsSpecifiedInCall);
             }
             SetByRefValues(callInfo, byRefValues);
             return RouteAction.Return(valueToReturn);
+        }
+
+        private bool WasModified(ByRefArgument byRefArgument, ICall call)
+        {
+            return call.GetArguments()[byRefArgument.Index] !=
+                   call.GetOriginalArguments().ElementAt(byRefArgument.Index);
         }
 
         private class ByRefArgument

--- a/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/Source/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -70,7 +70,10 @@ namespace NSubstitute.Routing.Handlers
         private RouteAction NoReturnValue(ICall call)
         {
             var callInfo = new CallInfoFactory().Create(call);
-            var byRefValues = GetByRefValues(callInfo).ToArray();
+            var byRefValues = 
+                GetByRefValues(callInfo)
+                .Where(x => !WasModified(x, call))
+                .ToArray();
 
             if (byRefValues.Length == 0)
                 return RouteAction.Continue();

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -14,7 +14,7 @@ namespace NSubstitute.Routing
                 new ClearUnusedCallSpecHandler(state)
                 , new AddCallToQueryResultHandler(state.SubstitutionContext, state.CallSpecificationFactory)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
+                , new ReturnAutoValue(() => state.AutoValueBehaviour, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -24,7 +24,7 @@ namespace NSubstitute.Routing
                 new ClearLastCallRouterHandler(state.SubstitutionContext)
                 , new ClearUnusedCallSpecHandler(state)
                 , new CheckReceivedCallsHandler(state.ReceivedCalls, state.CallSpecificationFactory, new ReceivedCallsExceptionThrower(), matchArgs, requiredQuantity)
-                , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
+                , new ReturnAutoValue(() => AutoValueBehaviour.ReturnAndForgetValue, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -61,7 +61,7 @@ namespace NSubstitute.Routing
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
                 , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
+                , new ReturnAutoValue(() => state.AutoValueBehaviour, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
@@ -77,7 +77,7 @@ namespace NSubstitute.Routing
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
+                , new ReturnAutoValue(() => state.AutoValueBehaviour, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using NSubstitute.Core;
+using NSubstitute.Routing.AutoValues;
 using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Routing
@@ -12,7 +14,7 @@ namespace NSubstitute.Routing
                 new ClearUnusedCallSpecHandler(state)
                 , new AddCallToQueryResultHandler(state.SubstitutionContext, state.CallSpecificationFactory)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -22,7 +24,7 @@ namespace NSubstitute.Routing
                 new ClearLastCallRouterHandler(state.SubstitutionContext)
                 , new ClearUnusedCallSpecHandler(state)
                 , new CheckReceivedCallsHandler(state.ReceivedCalls, state.CallSpecificationFactory, new ReceivedCallsExceptionThrower(), matchArgs, requiredQuantity)
-                , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -59,7 +61,7 @@ namespace NSubstitute.Routing
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
                 , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
@@ -75,7 +77,7 @@ namespace NSubstitute.Routing
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, new CompositeProvider(state.AutoValueProviders), state.ConfigureCall)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });


### PR DESCRIPTION
This PR is bigger than I thought it would be, let me know if you want me to split it up to be easier to review.

It creates an extensible auto value infrastructure to be able to inject `AutoFixture` as a value provider as discussed in https://github.com/AutoFixture/AutoFixture/issues/592

It changes the `IAutoValueProvider` interface from `CanProvideValueFor` and `GetValue` to a `GetValue` returning a `Maybe<object>`. This way, I can return a `Maybe.Nothing` when `AutoFixture` emits an `OmitSpecimen`. Using the two methods approach, it would have to call `AutoFixture` twice.
Besides, using `Maybe` is a better interface in my point of view.

It also exposes an `IList<IAutoValueProvider>` to inject new providers inside the `CallRouter`, besides exposing an `AutoValueBehaviour` to be able to change the default auto value behavior for the `CallRouter`.

In addition, it now generates values for `ref` and `out` arguments, not by default though.
It asks for an "ByRef" type in this case, instead of the usual type. (i.e. `Int32&` instead of `Int32`).
If any `IAutoValueProvider` provides it and it wasn't modified by a setup, it sets the argument's value.
