### PR TITLE
Add extensibility point for custom auto providers

### DIFF
--- a/Source/NSubstitute.Acceptance.Specs.NET/NSubstitute.Acceptance.Specs.NET.csproj
+++ b/Source/NSubstitute.Acceptance.Specs.NET/NSubstitute.Acceptance.Specs.NET.csproj
@@ -112,6 +112,9 @@
     <Compile Include="..\NSubstitute.Acceptance.Specs\ClearSubstitute.cs">
       <Link>ClearSubstitute.cs</Link>
     </Compile>
+    <Compile Include="..\NSubstitute.Acceptance.Specs\CustomHandlersSpecs.cs">
+      <Link>CustomHandlersSpecs.cs</Link>
+    </Compile>
     <Compile Include="..\NSubstitute.Acceptance.Specs\DynamicCalls.cs">
       <Link>DynamicCalls.cs</Link>
     </Compile>

--- a/Source/NSubstitute.Acceptance.Specs/CustomHandlersSpecs.cs
+++ b/Source/NSubstitute.Acceptance.Specs/CustomHandlersSpecs.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute.Core;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    [TestFixture]
+    public class CustomHandlersSpecs
+    {
+        [Test]
+        public void Value_from_custom_handler_is_returned()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return("42")));
+
+            //act
+            var result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Value_from_custom_handler_is_returned_for_setup_after_invocation()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            //invoke it before registering handler
+            source.GetValue();
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return("42")));
+
+            //act
+            var result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Custom_handler_is_called_for_each_time()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            var values = new Queue<string>(new[] { "42", "10" });
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return(values.Dequeue())));
+
+            //act
+            var result = source.GetValue();
+            result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.EqualTo("10"));
+        }
+
+        [Test]
+        public void Configured_call_has_more_priority_than_custom_handler()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return("xxx")));
+
+            source.GetValue().Returns("42");
+
+            //act
+            var result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Updated_ref_parameter_doesnt_affect_call_specification()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            //Configure our handler to update "ref" argument value
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    call =>
+                    {
+                        if (call.GetMethodInfo().Name != nameof(IValueSource.GetValueWithRef))
+                            return RouteAction.Continue();
+
+                        var args = call.GetArguments();
+                        args[0] = "refArg";
+
+                        return RouteAction.Return("xxx");
+                    }));
+
+            string refValue = "ref";
+            source.GetValueWithRef(ref refValue).Returns("42");
+
+            //act
+            refValue = "ref";
+            var result = source.GetValueWithRef(ref refValue);
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Set_out_parameter_doesnt_affect_call_specification()
+        {
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            //Configure our handler to update "out" argument value
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    call =>
+                    {
+                        if (call.GetMethodInfo().Name != nameof(IValueSource.GetValueWithOut))
+                            return RouteAction.Continue();
+
+                        var args = call.GetArguments();
+                        args[0] = "outArg";
+
+                        return RouteAction.Return("xxx");
+                    }));
+
+            string outArg;
+            source.GetValueWithOut(out outArg).Returns("42");
+
+            //act
+            string otherOutArg;
+            var result = source.GetValueWithOut(out otherOutArg);
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Is_not_called_for_specifying_call()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            bool wasInvoked = false;
+            router.RegisterCustomCallHandlerFactory(state =>
+                    new ActionHandler(_ =>
+                    {
+                        wasInvoked = true;
+                        return RouteAction.Continue();
+                    }));
+
+            //act
+            source.MethodWithArgs(Arg.Any<string>(), Arg.Is("42")).Returns("");
+
+            //assert
+            Assert.That(wasInvoked, Is.False);
+        }
+
+        [Test]
+        public void Auto_value_is_returned_if_skipped()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                    new ActionHandler(_ => RouteAction.Continue()));
+
+            //act
+            var result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.Not.Null);
+        }
+
+        [Test]
+        public void First_added_handler_has_precedence()
+        {
+            //arrange
+            var source = Substitute.For<IValueSource>();
+            var router = SubstitutionContext.Current.GetCallRouterFor(source);
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return("42")));
+
+            router.RegisterCustomCallHandlerFactory(state =>
+                new ActionHandler(
+                    _ => RouteAction.Return("10")));
+
+            //act
+            var result = source.GetValue();
+
+            //assert
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+
+        public interface IValueSource
+        {
+            string GetValue();
+            string GetValueWithRef(ref string arg1);
+            string GetValueWithOut(out string arg1);
+            string MethodWithArgs(string arg1, string arg2);
+        }
+
+        private class ActionHandler : ICallHandler
+        {
+            private readonly Func<ICall, RouteAction> _handler;
+
+            public ActionHandler(Func<ICall, RouteAction> handler)
+            {
+                _handler = handler;
+            }
+
+            public RouteAction Handle(ICall call) => _handler.Invoke(call);
+        }
+    }
+}

--- a/Source/NSubstitute.NET/NSubstitute.NET.csproj
+++ b/Source/NSubstitute.NET/NSubstitute.NET.csproj
@@ -294,6 +294,9 @@
     <Compile Include="..\NSubstitute\Core\ConfiguredCall.cs">
       <Link>Core\ConfiguredCall.cs</Link>
     </Compile>
+    <Compile Include="..\NSubstitute\Core\CustomHandlers.cs">
+      <Link>Core\CustomHandlers.cs</Link>
+    </Compile>
     <Compile Include="..\NSubstitute\Core\DefaultForType.cs">
       <Link>Core\DefaultForType.cs</Link>
     </Compile>
@@ -359,6 +362,9 @@
     </Compile>
     <Compile Include="..\NSubstitute\Core\IConfigureCall.cs">
       <Link>Core\IConfigureCall.cs</Link>
+    </Compile>
+    <Compile Include="..\NSubstitute\Core\ICustomHandlers.cs">
+      <Link>Core\ICustomHandlers.cs</Link>
     </Compile>
     <Compile Include="..\NSubstitute\Core\IDefaultForType.cs">
       <Link>Core\IDefaultForType.cs</Link>
@@ -650,6 +656,9 @@
     </Compile>
     <Compile Include="..\NSubstitute\Routing\Handlers\ReturnFromBaseIfRequired.cs">
       <Link>Routing\Handlers\ReturnFromBaseIfRequired.cs</Link>
+    </Compile>
+    <Compile Include="..\NSubstitute\Routing\Handlers\ReturnFromCustomHandlers.cs">
+      <Link>Routing\Handlers\ReturnFromCustomHandlers.cs</Link>
     </Compile>
     <Compile Include="..\NSubstitute\Routing\Handlers\ReturnResultForTypeHandler.cs">
       <Link>Routing\Handlers\ReturnResultForTypeHandler.cs</Link>

--- a/Source/NSubstitute.Specs/CallSpecificationFactorySpecs.cs
+++ b/Source/NSubstitute.Specs/CallSpecificationFactorySpecs.cs
@@ -86,6 +86,7 @@ namespace NSubstitute.Specs
                 var call = mock<ICall>();
                 call.stub(x => x.GetMethodInfo()).Return(methodInfo);
                 call.stub(x => x.GetArguments()).Return(arguments);
+                call.stub(x => x.GetOriginalArguments()).Return(arguments);
                 call.stub(x => x.GetArgumentSpecifications()).Return(mock<IList<IArgumentSpecification>>());
                 return call;
             }

--- a/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
+++ b/Source/NSubstitute.Specs/Infrastructure/TestCallRouter.cs
@@ -11,6 +11,11 @@ namespace NSubstitute.Specs.Infrastructure
         {
             return new ConfiguredCall(x => { });
         }
+
+        public void RegisterCustomCallHandlerFactory(CallHandlerFactory factory)
+        {
+        }
+
         public void Clear(ClearOptions clear) { }
 
         public IEnumerable<ICall> ReceivedCalls() { return new ICall[0]; }

--- a/Source/NSubstitute/Core/Call.cs
+++ b/Source/NSubstitute/Core/Call.cs
@@ -11,6 +11,7 @@ namespace NSubstitute.Core
     {
         private readonly MethodInfo _methodInfo;
         private readonly object[] _arguments;
+        private readonly object[] _originalArguments;
         private readonly object _target;
         private readonly IParameterInfo[] _parameterInfos;
         private readonly IList<IArgumentSpecification> _argumentSpecifications;
@@ -21,6 +22,7 @@ namespace NSubstitute.Core
         {
             _methodInfo = methodInfo;
             _arguments = arguments;
+            _originalArguments = arguments.ToArray();
             _target = target;
             _parameterInfos = GetParameterInfosFrom(_methodInfo);
             _argumentSpecifications = argumentSpecsForCall;
@@ -31,6 +33,7 @@ namespace NSubstitute.Core
         {
             _methodInfo = methodInfo;
             _arguments = arguments;
+            _originalArguments = arguments.ToArray();
             _target = target;
             _parameterInfos = parameterInfos ?? GetParameterInfosFrom(_methodInfo);
             _argumentSpecifications = (_parameterInfos.Length == 0) ? EmptyList() : SubstitutionContext.Current.DequeueAllArgumentSpecifications();
@@ -90,6 +93,11 @@ namespace NSubstitute.Core
         public object[] GetArguments()
         {
             return _arguments;
+        }
+
+        public object[] GetOriginalArguments()
+        {
+            return _originalArguments;
         }
 
         public object Target()

--- a/Source/NSubstitute/Core/CallRouter.cs
+++ b/Source/NSubstitute/Core/CallRouter.cs
@@ -95,5 +95,12 @@ namespace NSubstitute.Core
         {
             _substituteState.ResultsForType.SetResult(type, returnValue);
         }
+
+        public void RegisterCustomCallHandlerFactory(CallHandlerFactory factory)
+        {
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+            _substituteState.CustomHandlers.AddCustomHandlerFactory(factory);
+        }
     }
 }

--- a/Source/NSubstitute/Core/CallSpecification.cs
+++ b/Source/NSubstitute/Core/CallSpecification.cs
@@ -73,9 +73,9 @@ namespace NSubstitute.Core
                    && a.Name.Equals(b.Name, StringComparison.Ordinal);
 	    }
 
-	    public IEnumerable<ArgumentMatchInfo> NonMatchingArguments(ICall call)
+        public IEnumerable<ArgumentMatchInfo> NonMatchingArguments(ICall call)
         {
-            var arguments = call.GetArguments();
+            var arguments = call.GetOriginalArguments();
             return arguments
                     .Select((arg, index) => new ArgumentMatchInfo(index, arg, _argumentSpecifications[index]))
                     .Where(x => !x.IsMatch);
@@ -89,7 +89,7 @@ namespace NSubstitute.Core
 
         public string Format(ICall call)
         {
-            return CallFormatter.Format(call.GetMethodInfo(), FormatArguments(call.GetArguments()));
+            return CallFormatter.Format(call.GetMethodInfo(), FormatArguments(call.GetOriginalArguments()));
         }
 
         private IEnumerable<string> FormatArguments(IEnumerable<object> arguments)
@@ -122,7 +122,7 @@ namespace NSubstitute.Core
 
         private bool HasDifferentNumberOfArguments(ICall call)
         {
-            return _argumentSpecifications.Length != call.GetArguments().Length;
+            return _argumentSpecifications.Length != call.GetOriginalArguments().Length;
         }
     }
 }

--- a/Source/NSubstitute/Core/CallSpecificationFactory.cs
+++ b/Source/NSubstitute/Core/CallSpecificationFactory.cs
@@ -15,7 +15,7 @@ namespace NSubstitute.Core
         {
             var methodInfo = call.GetMethodInfo();
             var argumentSpecs = call.GetArgumentSpecifications();
-            var arguments = call.GetArguments();
+            var arguments = call.GetOriginalArguments();
             var parameterInfos = call.GetParameterInfos();
             var argumentSpecificationsForCall = _argumentSpecificationsFactory.Create(argumentSpecs, arguments, parameterInfos, matchArgs);
             return new CallSpecification(methodInfo, argumentSpecificationsForCall);

--- a/Source/NSubstitute/Core/CustomHandlers.cs
+++ b/Source/NSubstitute/Core/CustomHandlers.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace NSubstitute.Core
+{
+    public class CustomHandlers : ICustomHandlers
+    {
+        private readonly List<ICallHandler> _handlers = new List<ICallHandler>();
+        private readonly ISubstituteState _substituteState;
+
+        public IEnumerable<ICallHandler> Handlers => _handlers;
+
+        public CustomHandlers(ISubstituteState substituteState)
+        {
+            _substituteState = substituteState;
+        }
+
+        public void AddCustomHandlerFactory(CallHandlerFactory factory)
+        {
+            _handlers.Add(factory.Invoke(_substituteState));
+        }
+    }
+}

--- a/Source/NSubstitute/Core/ICall.cs
+++ b/Source/NSubstitute/Core/ICall.cs
@@ -10,6 +10,7 @@ namespace NSubstitute.Core
         Type GetReturnType();
         MethodInfo GetMethodInfo();
         object[] GetArguments();
+        object[] GetOriginalArguments();
         object Target();
         IParameterInfo[] GetParameterInfos();
         IList<IArgumentSpecification> GetArgumentSpecifications();

--- a/Source/NSubstitute/Core/ICallRouter.cs
+++ b/Source/NSubstitute/Core/ICallRouter.cs
@@ -11,6 +11,7 @@ namespace NSubstitute.Core
         IEnumerable<ICall> ReceivedCalls();
         void SetRoute(Func<ISubstituteState, IRoute> getRoute);
         void SetReturnForType(Type type, IReturn returnValue);
+        void RegisterCustomCallHandlerFactory(CallHandlerFactory factory);
         void Clear(ClearOptions clear);
     }
 }

--- a/Source/NSubstitute/Core/ICustomHandlers.cs
+++ b/Source/NSubstitute/Core/ICustomHandlers.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace NSubstitute.Core
+{
+    /// <summary>
+    ///     Factory method which creates <see cref="ICallHandler" /> from the <see cref="ISubstituteState" />.
+    /// </summary>
+    public delegate ICallHandler CallHandlerFactory(ISubstituteState substituteState);
+
+    public interface ICustomHandlers
+    {
+        IEnumerable<ICallHandler> Handlers { get; }
+        void AddCustomHandlerFactory(CallHandlerFactory factory);
+    }
+}

--- a/Source/NSubstitute/Core/ISubstituteState.cs
+++ b/Source/NSubstitute/Core/ISubstituteState.cs
@@ -16,8 +16,10 @@ namespace NSubstitute.Core
         IConfigureCall ConfigureCall { get; }
         IEventHandlerRegistry EventHandlerRegistry { get; }
         IAutoValueProvider[] AutoValueProviders { get; }
+        ICallResults AutoValuesCallResults { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         IResultsForType ResultsForType { get; }
+        ICustomHandlers CustomHandlers { get; }
         void ClearUnusedCallSpecs();
     }
 }

--- a/Source/NSubstitute/Core/SubstituteState.cs
+++ b/Source/NSubstitute/Core/SubstituteState.cs
@@ -17,7 +17,9 @@ namespace NSubstitute.Core
         public IConfigureCall ConfigureCall { get; private set; }
         public IEventHandlerRegistry EventHandlerRegistry { get; private set; }
         public IAutoValueProvider[] AutoValueProviders { get; private set; }
+        public ICallResults AutoValuesCallResults { get; }
         public IResultsForType ResultsForType { get; private set; }
+        public ICustomHandlers CustomHandlers { get; }
 
         public SubstituteState(ISubstitutionContext substitutionContext, SubstituteConfig option)
         {
@@ -31,13 +33,13 @@ namespace NSubstitute.Core
             ReceivedCalls = callStack;
             PendingSpecification = new PendingSpecification();
             CallResults = new CallResults(callInfoFactory);
+            AutoValuesCallResults = new CallResults(callInfoFactory);
             CallSpecificationFactory = CallSpecificationFactoryFactoryYesThatsRight.CreateCallSpecFactory();
             CallActions = new CallActions(callInfoFactory);
             CallBaseExclusions = new CallBaseExclusions();
             ResultsForType = new ResultsForType(callInfoFactory);
-
+            CustomHandlers = new CustomHandlers(this);
             var getCallSpec = new GetCallSpec(callStack, PendingSpecification, CallSpecificationFactory, CallActions);
-
             ConfigureCall = new ConfigureCall(CallResults, CallActions, getCallSpec);
             EventHandlerRegistry = new EventHandlerRegistry();
             AutoValueProviders = new IAutoValueProvider[] { 

--- a/Source/NSubstitute/Routing/Handlers/ReturnFromCustomHandlers.cs
+++ b/Source/NSubstitute/Routing/Handlers/ReturnFromCustomHandlers.cs
@@ -1,0 +1,27 @@
+﻿using NSubstitute.Core;
+
+namespace NSubstitute.Routing.Handlers
+{
+    public class ReturnFromCustomHandlers : ICallHandler
+    {
+        private readonly ICustomHandlers _customHandlers;
+
+        public ReturnFromCustomHandlers(ICustomHandlers customHandlers)
+        {
+            _customHandlers = customHandlers;
+        }
+        public RouteAction Handle(ICall call)
+        {
+            foreach (var handler in _customHandlers.Handlers)
+            {
+                var result = handler.Handle(call);
+                if (result.HasReturnValue)
+                {
+                    return result;
+                }
+            }
+
+            return RouteAction.Continue();
+        }
+    }
+}

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -12,7 +12,7 @@ namespace NSubstitute.Routing
                 new ClearUnusedCallSpecHandler(state)
                 , new AddCallToQueryResultHandler(state.SubstitutionContext, state.CallSpecificationFactory)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -22,7 +22,7 @@ namespace NSubstitute.Routing
                 new ClearLastCallRouterHandler(state.SubstitutionContext)
                 , new ClearUnusedCallSpecHandler(state)
                 , new CheckReceivedCallsHandler(state.ReceivedCalls, state.CallSpecificationFactory, new ReceivedCallsExceptionThrower(), matchArgs, requiredQuantity)
-                , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
@@ -59,7 +59,7 @@ namespace NSubstitute.Routing
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
                 , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
                 , new ReturnConfiguredResultHandler(state.CallResults)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });
@@ -75,7 +75,8 @@ namespace NSubstitute.Routing
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
-                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall)
+                , new ReturnFromCustomHandlers(state.CustomHandlers)
+                , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
             });


### PR DESCRIPTION
This PR creates extensibility point for external parties to specify custom default values. This is a merge of #156 and #234.

__Changes overview:__  
1. Added custom handlers call action to `RecordReplay` route. 
I haven't created any extension method for this feature. That is because I assume this feature to be used rarely and extension method will pollute the completion menu. Moreover, given that very low-level API is provided, it doesn't seem to be a feature for "broad masses" :) Let me know if you have different opinion.

    For now, API is following: `SubstitutionContext.Current.GetCallRouterFor(source).RegisterCustomCallHandler(factory)`.

2. Introduced `OriginalArguments` to the `ICall` interface and [use them for specifications](https://github.com/Zvirja/NSubstitute/blob/ea566ae65422ef768f02a7b2d5f6215d6b31a39e/Source/NSubstitute/Core/CallSpecificationFactory.cs#L18). This way if call handler (or user in `When/Do` statement) modify argument values (e.g. for `ref` parameters), that doesn't affect rules. Check the following tests: [test1](https://github.com/nsubstitute/NSubstitute/pull/259/files#diff-b7c0c74c6a3e3aec23408093be9eff74R91), [test2](https://github.com/nsubstitute/NSubstitute/pull/259/files#diff-b7c0c74c6a3e3aec23408093be9eff74R123).

3. AutoValue feature uses its own cache for known results, rather than register its result globally. Current behavior leads to "increased priority" for auto-values, if setup is done after the first invocation. See [this test](https://github.com/nsubstitute/NSubstitute/pull/259/files#diff-b7c0c74c6a3e3aec23408093be9eff74R29) for more details. Also, [see this discussion](https://github.com/nsubstitute/NSubstitute/pull/234#discussion-diff-66973758).