### PR TITLE
Castlecore 4.0.0 beta002

### DIFF
--- a/Source/NSubstitute/project.json
+++ b/Source/NSubstitute/project.json
@@ -14,7 +14,8 @@
   "frameworks": {
     "netstandard1.5": {
       "buildOptions": {
-        "xmlDoc": true
+        "xmlDoc": true,
+	"nowarn": [ "CS1591" ]
       },
       "dependencies": {
         "Castle.Core": "4.0.0-*",

--- a/build.fsx
+++ b/build.fsx
@@ -149,7 +149,7 @@ Target "NuGet" <| fun _ ->
                  DependenciesByFramework = 
                      [{ FrameworkVersion = "netstandard1.5"
                         Dependencies = 
-                            ["Castle.Core", "[4.0.0-beta001, )"
+                            ["Castle.Core", "[4.0.0-beta002, )"
                              "Microsoft.CSharp", "[4.0.1, )"
                              "NETStandard.Library", "[1.6.0, )"
                              "System.Linq.Queryable", "[4.0.1, )"


### PR DESCRIPTION
@alexandrnikitin: Is this all we need to get the dotnet core build working with the latest castle core beta?

Should we update the .NET framework builds to use 4.0.0 instead of 3.3.3 as well?