### PR TITLE
Extend NuSpec with information about all the supported targets

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -153,7 +153,13 @@ Target "NuGet" <| fun _ ->
                              "Microsoft.CSharp", "[4.0.1, )"
                              "NETStandard.Library", "[1.6.0, )"
                              "System.Linq.Queryable", "[4.0.1, )"
-                             "System.Reflection.TypeExtensions", "[4.1.0, )" ]}]})
+                             "System.Reflection.TypeExtensions", "[4.1.0, )" ]}
+                      { FrameworkVersion = "net35"
+                        Dependencies = [] }
+                      { FrameworkVersion = "net40"
+                        Dependencies = [] }
+                      { FrameworkVersion = "net45"
+                        Dependencies = [] }]})
                         "Build/NSubstitute.nuspec"
 
 Target "Zip" <| fun _ -> 


### PR DESCRIPTION
Fix for the issue #295.

This change updates `nuspec` with information about all the supported targets.
As result if you install this library to the .NET 4.6.2 project, NuGet will not install all the dependencies and will just reference the `net45/NSubstitute.dll` file.

BTW, I was unable to find how to make the full `nupkg` file locally. Could you advice parameters for the `build.bat`, so that it will produce `nupkg` identical to the published one?