### PR TITLE
Sign .NET Core output assembly

### DIFF
--- a/Source/NSubstitute/project.json
+++ b/Source/NSubstitute/project.json
@@ -14,8 +14,9 @@
   "frameworks": {
     "netstandard1.5": {
       "buildOptions": {
+        "keyFile": "../nsubstitute.snk",
         "xmlDoc": true,
-	"nowarn": [ "CS1591" ]
+        "nowarn": [ "CS1591" ]
       },
       "dependencies": {
         "Castle.Core": "4.0.0-*",


### PR DESCRIPTION
* Fixes CS8002 warning "C# Referenced assembly does not have a strong name." when referencing .NET Standard library.