### PR TITLE
Fixes warning System.ComponentModel.TypeConverter 4.0.1 was not found

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -11,7 +11,6 @@
     <PackageIconUrl>http://nsubstitute.github.com/images/nsubstitute-100x100.png</PackageIconUrl>
     <PackageProjectUrl>http://nsubstitute.github.com/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/nsubstitute/NSubstitute/raw/master/LICENSE.txt</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion>1.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -32,6 +31,10 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="4.1.1-*" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
@@ -40,15 +43,12 @@
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-
-    <PackageReference Include="Castle.Core" Version="4.0.0-*" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Castle.Core" Version="4.0.0-*" />
   </ItemGroup>
 
 </Project>

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Castle.Core" Version="4.0.0-*" />
+    <PackageReference Include="Castle.Core" Version="4.1.1-*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
As described in #310 this PR fixes the mentioned warning. 