### PR TITLE
Support for returning ValueTask<T> results.

### DIFF
--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -39,6 +39,17 @@ namespace NSubstitute.ReturnsExtensions
         }
 
         /// <summary>
+        /// Set null as returned value for this call.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ConfiguredCall ReturnsNull<T>(this ValueTask<T> value) where T : class
+        {
+            return value.Returns(i => SubstituteExtensions.CompletedValueTask<T>(null));
+        }
+
+        /// <summary>
         /// Set null as returned value for this call made with any arguments.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -47,6 +58,17 @@ namespace NSubstitute.ReturnsExtensions
         public static ConfiguredCall ReturnsNullForAnyArgs<T>(this Task<T> value) where T : class
         {
             return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedTask<T>(null));
+        }
+
+        /// <summary>
+        /// Set null as returned value for this call made with any arguments.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ConfiguredCall ReturnsNullForAnyArgs<T>(this ValueTask<T> value) where T : class
+        {
+            return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedValueTask<T>(null));
         }
     }
 }

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Castle.Core" Version="4.2.0-*" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
+++ b/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
@@ -20,5 +20,11 @@
         System.Threading.Tasks.Task<string> SayAsync(string s);
         System.Threading.Tasks.Task<SomeClass> SomeActionAsync();
         System.Threading.Tasks.Task<SomeClass> SomeActionWithParamsAsync(int i, string s);
+
+        System.Threading.Tasks.ValueTask<int> CountValueTaskAsync();
+        System.Threading.Tasks.ValueTask<string> EchoValueTaskAsync(int i);
+        System.Threading.Tasks.ValueTask<string> SayValueTaskAsync(string s);
+        System.Threading.Tasks.ValueTask<SomeClass> SomeActionValueTaskAsync();
+        System.Threading.Tasks.ValueTask<SomeClass> SomeActionWithParamsValueTaskAsync(int i, string s);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
@@ -117,12 +117,40 @@ namespace NSubstitute.Acceptance.Specs
         }
 
         [Test]
+        public void Return_result_for_any_arguments_async_ValueTask()
+        {
+            _something.EchoValueTaskAsync(1).ReturnsForAnyArgs("always");
+
+            Assert.That(_something.EchoValueTaskAsync(1).Result, Is.EqualTo("always"));
+            Assert.That(_something.EchoValueTaskAsync(2).Result, Is.EqualTo("always"));
+            Assert.That(_something.EchoValueTaskAsync(724).Result, Is.EqualTo("always"));
+        }
+
+        [Test]
+        public void Return_multiple_results_for_any_arguments_async_ValueTask()
+        {
+            _something.EchoValueTaskAsync(1).ReturnsForAnyArgs("first", "second");
+
+            Assert.That(_something.EchoValueTaskAsync(2).Result, Is.EqualTo("first"));
+            Assert.That(_something.EchoValueTaskAsync(724).Result, Is.EqualTo("second"));
+        }
+
+        [Test]
         public void Return_multiple_results_from_funcs_for_any_arguments_async()
         {
             _something.EchoAsync(1).ReturnsForAnyArgs(_ => "first", _ => "second");
 
             Assert.That(_something.EchoAsync(2).Result, Is.EqualTo("first"));
             Assert.That(_something.EchoAsync(724).Result, Is.EqualTo("second"));
+        }
+
+        [Test]
+        public void Return_multiple_results_from_funcs_for_any_arguments_async_ValueTask()
+        {
+            _something.EchoValueTaskAsync(1).ReturnsForAnyArgs(_ => "first", _ => "second");
+
+            Assert.That(_something.EchoValueTaskAsync(2).Result, Is.EqualTo("first"));
+            Assert.That(_something.EchoValueTaskAsync(724).Result, Is.EqualTo("second"));
         }
 
         [Test]
@@ -200,11 +228,28 @@ namespace NSubstitute.Acceptance.Specs
         }
 
         [Test]
+        public void Returns_Null_for_string_parameter_async_ValueTask()
+        {
+            const string stringValue = "something";
+            _something.SayValueTaskAsync(stringValue).ReturnsNull();
+
+            Assert.That(_something.SayValueTaskAsync("something").Result, Is.Null);
+        }
+
+        [Test]
         public void Returns_Null_for_method_returning_class_async()
         {
             _something.SomeActionAsync().ReturnsNull();
 
             Assert.That(_something.SomeActionAsync().Result, Is.Null);
+        }
+
+        [Test]
+        public void Returns_Null_for_method_returning_class_async_ValueTask()
+        {
+            _something.SomeActionValueTaskAsync().ReturnsNull();
+
+            Assert.That(_something.SomeActionValueTaskAsync().Result, Is.Null);
         }
 
         [Test]
@@ -224,12 +269,37 @@ namespace NSubstitute.Acceptance.Specs
         }
 
         [Test]
+        public void Returns_Null_for_any_args_when_string_parameter_async_ValueTask()
+        {
+            _something.SayValueTaskAsync("text").ReturnsNullForAnyArgs();
+
+            Assert.That(_something.SayValueTaskAsync("something").Result, Is.Null);
+        }
+
+        [Test]
+        public void Returns_Null_for_any_args_when_class_returned_async_ValueTask()
+        {
+            _something.SomeActionWithParamsValueTaskAsync(2, "text").ReturnsNullForAnyArgs();
+
+            Assert.That(_something.SomeActionWithParamsValueTaskAsync(123, "something else").Result, Is.Null);
+        }
+
+        [Test]
         public void Return_a_wrapped_async_result()
         {
             _something.CountAsync().Returns(3);
 
             Assert.That(_something.CountAsync(), Is.TypeOf<Task<int>>());
             Assert.That(_something.CountAsync().Result, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Return_a_wrapped_ValueTask_async_result()
+        {
+            _something.CountValueTaskAsync().Returns(3);
+
+            Assert.That(_something.CountValueTaskAsync(), Is.TypeOf<ValueTask<int>>());
+            Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3));
         }
 
         [Test]
@@ -244,6 +314,20 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountAsync().Result, Is.EqualTo(2), "Second return");
             Assert.That(_something.CountAsync().Result, Is.EqualTo(3), "Third return");
             Assert.That(_something.CountAsync().Result, Is.EqualTo(3), "Fourth return");
+        }
+
+        [Test]
+        public void Return_multiple_ValueTask_async_results_from_funcs()
+        {
+            _something.CountValueTaskAsync().Returns(
+                _ => 1,
+                _ => 2,
+                _ => 3);
+
+            Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(1), "First return");
+            Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(2), "Second return");
+            Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3), "Third return");
+            Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3), "Fourth return");
         }
 
         [SetUp]


### PR DESCRIPTION
This PR adds support for returning `ValueTask<T>` in a easy way, very similar to what was already present in NSubstitute for regular `Task<T>` (exact same naming as for extension methods that work on `Task<T>`). 

In current project I use `ValueTask<T>` for scenarios where returned value in most cases would come from cache and would not involve IO bound operation. I wanted to have easy way for creating stubs for such abstractions similar to what NSubstitute offers today for tasks. First I just wanted to check source code to see whats possible but ended up implementing it. I didn't consult this feature upfront so I will totally understand if this PR won't be accepted because you don't want this feature/`ValueTask<T>` dependency.