### PR TITLE
Add back .NET 4.0 Build

### DIFF
--- a/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Core.Arguments
 {

--- a/src/NSubstitute/Core/DefaultForType.cs
+++ b/src/NSubstitute/Core/DefaultForType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Core/IReturn.cs
+++ b/src/NSubstitute/Core/IReturn.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Exceptions;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Core/SubstituteFactory.cs
+++ b/src/NSubstitute/Core/SubstituteFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Exceptions;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -38,6 +38,7 @@ namespace NSubstitute.ReturnsExtensions
             return value.Returns(i => SubstituteExtensions.CompletedTask<T>(null));
         }
 
+#if !NET40
         /// <summary>
         /// Set null as returned value for this call.
         /// </summary>
@@ -48,6 +49,7 @@ namespace NSubstitute.ReturnsExtensions
         {
             return value.Returns(i => SubstituteExtensions.CompletedValueTask<T>(null));
         }
+#endif
 
         /// <summary>
         /// Set null as returned value for this call made with any arguments.
@@ -60,6 +62,7 @@ namespace NSubstitute.ReturnsExtensions
             return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedTask<T>(null));
         }
 
+#if !NET40
         /// <summary>
         /// Set null as returned value for this call made with any arguments.
         /// </summary>
@@ -70,5 +73,6 @@ namespace NSubstitute.ReturnsExtensions
         {
             return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedValueTask<T>(null));
         }
+#endif
     }
 }

--- a/src/NSubstitute/Extensions/TypeExtensions.cs
+++ b/src/NSubstitute/Extensions/TypeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace NSubstitute.Extensions
+{
+    internal static class TypeExtensions
+    {
+#if NET40
+        /// <summary>
+        /// Extension method to replicate NET45 and NETSTANDARD reflection API in NET40
+        /// and avoid additional compilation symbols
+        /// </summary>
+        internal static Type GetTypeInfo(this Type type)
+        {
+            return type;
+        }
+#endif
+    }
+}

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -4,7 +4,7 @@
     <Description>NSubstitute is a friendly substitute for .NET mocking frameworks. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
     <Version>3.0.0</Version>
     <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin</Authors>
-    <TargetFrameworks>netstandard1.3;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net46;net45;net40</TargetFrameworks>
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>
@@ -35,19 +35,24 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)'=='net40' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Castle.Core" Version="4.2.0-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)'=='net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Castle.Core" Version="4.2.0-*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="Castle.Core" Version="4.2.0-*" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)'=='net46'">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Castle.DynamicProxy;
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Proxies.CastleDynamicProxy
 {

--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateCall.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateCall.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Core;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Proxies.DelegateProxy
 {

--- a/src/NSubstitute/Proxies/ProxyFactory.cs
+++ b/src/NSubstitute/Proxies/ProxyFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using NSubstitute.Core;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Proxies
 {

--- a/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Core;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Routing.AutoValues
 {

--- a/src/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Routing.AutoValues
 {

--- a/src/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoSubstituteProvider.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Core;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Routing.AutoValues
 {

--- a/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using NSubstitute.Extensions;
 
 namespace NSubstitute.Routing.AutoValues
 {

--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -69,6 +69,7 @@ namespace NSubstitute
             return Returns(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedFuncs.ToArray());
         }
 
+#if !NET40
         /// <summary>
         /// Set a return value for this call. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
@@ -101,6 +102,7 @@ namespace NSubstitute
 
             return Returns(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedFuncs.ToArray());
         }
+#endif
 
         /// <summary>
         /// Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in Tasks.
@@ -135,6 +137,7 @@ namespace NSubstitute
             return Returns(MatchArgs.Any, wrappedFunc, wrappedFuncs.ToArray());
         }
 
+#if !NET40
         /// <summary>
         /// Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
@@ -168,6 +171,7 @@ namespace NSubstitute
             return Returns(MatchArgs.Any, wrappedFunc, wrappedFuncs.ToArray());
         }
 
+#endif
         /// <summary>
         /// Set a return value for this call made with any arguments.
         /// </summary>
@@ -364,19 +368,23 @@ namespace NSubstitute
             return x => CompletedTask(returnThis(x));
         }
 
+#if !NET40
         private static Func<CallInfo, ValueTask<T>> WrapFuncInValueTask<T>(Func<CallInfo, T> returnThis)
         {
             return x => CompletedValueTask(returnThis(x));
         }
 
-        internal static Task<T> CompletedTask<T>(T result) 
-        {
-            return Task.FromResult(result);
-        }
-
         internal static ValueTask<T> CompletedValueTask<T>(T result)
         {
             return new ValueTask<T>(result);
+        }
+#endif
+
+        internal static Task<T> CompletedTask<T>(T result)
+        {
+            var taskSource = new TaskCompletionSource<T>();
+            taskSource.SetResult(result);
+            return taskSource.Task;
         }
 
         private static ICallRouter GetRouterForSubstitute<T>(T substitute)

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -90,6 +90,10 @@ namespace NSubstitute.Acceptance.Specs
             _something.Received().Funky(Arg.Any<float>(), 12, "Lots", null);
         }
 
+#if !NET40
+        //These tests should be possible to run on .NET 4.0 with Microsoft.Bcl.Async,
+        //but the package doesn't seem to play nicely with the new csproj format.
+        //Possibly caused by: https://github.com/Microsoft/msbuild/issues/1310
         [Test]
         public void Received_for_async_method_can_be_awaited()
         {
@@ -112,6 +116,7 @@ namespace NSubstitute.Acceptance.Specs
         {
             await _something.DidNotReceive().Async();
         }
+#endif
 
         [Test]
         public void Resolve_potentially_ambiguous_matches_by_checking_for_non_default_argument_values()

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -90,10 +90,6 @@ namespace NSubstitute.Acceptance.Specs
             _something.Received().Funky(Arg.Any<float>(), 12, "Lots", null);
         }
 
-#if !NET40
-        //These tests should be possible to run on .NET 4.0 with Microsoft.Bcl.Async,
-        //but the package doesn't seem to play nicely with the new csproj format.
-        //Possibly caused by: https://github.com/Microsoft/msbuild/issues/1310
         [Test]
         public void Received_for_async_method_can_be_awaited()
         {
@@ -116,7 +112,6 @@ namespace NSubstitute.Acceptance.Specs
         {
             await _something.DidNotReceive().Async();
         }
-#endif
 
         [Test]
         public void Resolve_potentially_ambiguous_matches_by_checking_for_non_default_argument_values()

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports
 {
@@ -20,10 +22,13 @@ namespace NSubstitute.Acceptance.Specs.FieldReports
             var substitute = Substitute.For<IFoo>();
             substitute.Foo().Returns(ret1, ret2);
 
-            var runningTask1 = Task.Run(() => substitute.Foo());
-            var runningTask2 = Task.Run(() => substitute.Foo());
+            var runningTask1 = Task.Factory.StartNew(() => substitute.Foo());
+            var runningTask2 = Task.Factory.StartNew(() => substitute.Foo());
+            var tasks = new[] {runningTask1, runningTask2};
 
-            var results = Task.WhenAll(runningTask1, runningTask2).Result;
+            var results = new List<string>();
+            Task.Factory.StartNew(() => Task.WaitAll(tasks));
+            results.AddRange(tasks.Select(t => t.Result));
 
             Assert.Contains(ret1, results);
             Assert.Contains(ret2, results);

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Threading.Tasks;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports
@@ -22,13 +20,15 @@ namespace NSubstitute.Acceptance.Specs.FieldReports
             var substitute = Substitute.For<IFoo>();
             substitute.Foo().Returns(ret1, ret2);
 
-            var runningTask1 = Task.Factory.StartNew(() => substitute.Foo());
-            var runningTask2 = Task.Factory.StartNew(() => substitute.Foo());
-            var tasks = new[] {runningTask1, runningTask2};
-
-            var results = new List<string>();
-            Task.Factory.StartNew(() => Task.WaitAll(tasks));
-            results.AddRange(tasks.Select(t => t.Result));
+#if NET40
+            var runningTask1 = TaskEx.Run(() => substitute.Foo());
+            var runningTask2 = TaskEx.Run(() => substitute.Foo());
+            var results = TaskEx.WhenAll(runningTask1, runningTask2).Result;
+#else
+            var runningTask1 = Task.Run(() => substitute.Foo());
+            var runningTask2 = Task.Run(() => substitute.Foo());
+            var results = Task.WhenAll(runningTask1, runningTask2).Result;
+#endif
 
             Assert.Contains(ret1, results);
             Assert.Contains(ret2, results);

--- a/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
+++ b/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
@@ -21,10 +21,12 @@
         System.Threading.Tasks.Task<SomeClass> SomeActionAsync();
         System.Threading.Tasks.Task<SomeClass> SomeActionWithParamsAsync(int i, string s);
 
+#if !NET40
         System.Threading.Tasks.ValueTask<int> CountValueTaskAsync();
         System.Threading.Tasks.ValueTask<string> EchoValueTaskAsync(int i);
         System.Threading.Tasks.ValueTask<string> SayValueTaskAsync(string s);
         System.Threading.Tasks.ValueTask<SomeClass> SomeActionValueTaskAsync();
         System.Threading.Tasks.ValueTask<SomeClass> SomeActionWithParamsValueTaskAsync(int i, string s);
+#endif
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
+++ b/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NSubstitute.Acceptance.Specs.Infrastructure;
@@ -125,8 +126,12 @@ namespace NSubstitute.Acceptance.Specs
                 .ToArray();
 
             foreach (var task in tasks) { task.Start(); }
-            var actual = System.Threading.Tasks.Task.WhenAll(tasks).Result;
-            Assert.That(actual, Is.EquivalentTo(expected));
+
+            var results = new List<int>();
+            System.Threading.Tasks.Task.Factory.StartNew(() => System.Threading.Tasks.Task.WaitAll(tasks));
+            results.AddRange(tasks.Select(t => t.Result));
+
+            Assert.That(results, Is.EquivalentTo(expected));
         }
 
         public interface IFoo

--- a/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
+++ b/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NSubstitute.Acceptance.Specs.Infrastructure;
@@ -127,11 +126,12 @@ namespace NSubstitute.Acceptance.Specs
 
             foreach (var task in tasks) { task.Start(); }
 
-            var results = new List<int>();
-            System.Threading.Tasks.Task.Factory.StartNew(() => System.Threading.Tasks.Task.WaitAll(tasks));
-            results.AddRange(tasks.Select(t => t.Result));
-
-            Assert.That(results, Is.EquivalentTo(expected));
+#if NET40
+            var actual = System.Threading.Tasks.TaskEx.WhenAll(tasks).Result;
+#else
+            var actual = System.Threading.Tasks.Task.WhenAll(tasks).Result;
+#endif
+            Assert.That(actual, Is.EquivalentTo(expected));
         }
 
         public interface IFoo

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45;net40</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -13,13 +13,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)'=='net40' ">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net45'">
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup Condition=" '$(TargetFramework)'=='net40' ">
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Bcl" version="1.1.10" />
+    <PackageReference Include="Microsoft.Bcl.Async" version="1.0.168" />
+    <PackageReference Include="Microsoft.Bcl.Build" version="1.0.21" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net45'">
@@ -26,7 +29,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' OR '$(TargetFramework)'=='netcoreapp2.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
@@ -116,6 +116,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.EchoAsync(724).Result, Is.EqualTo("second"));
         }
 
+#if !NET40
         [Test]
         public void Return_result_for_any_arguments_async_ValueTask()
         {
@@ -134,6 +135,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.EchoValueTaskAsync(2).Result, Is.EqualTo("first"));
             Assert.That(_something.EchoValueTaskAsync(724).Result, Is.EqualTo("second"));
         }
+#endif
 
         [Test]
         public void Return_multiple_results_from_funcs_for_any_arguments_async()
@@ -144,6 +146,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.EchoAsync(724).Result, Is.EqualTo("second"));
         }
 
+#if !NET40
         [Test]
         public void Return_multiple_results_from_funcs_for_any_arguments_async_ValueTask()
         {
@@ -152,6 +155,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.EchoValueTaskAsync(2).Result, Is.EqualTo("first"));
             Assert.That(_something.EchoValueTaskAsync(724).Result, Is.EqualTo("second"));
         }
+#endif
 
         [Test]
         public void Return_calculated_results_for_any_arguments()
@@ -227,6 +231,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.SayAsync("something").Result, Is.Null);
         }
 
+#if !NET40
         [Test]
         public void Returns_Null_for_string_parameter_async_ValueTask()
         {
@@ -235,6 +240,7 @@ namespace NSubstitute.Acceptance.Specs
 
             Assert.That(_something.SayValueTaskAsync("something").Result, Is.Null);
         }
+#endif
 
         [Test]
         public void Returns_Null_for_method_returning_class_async()
@@ -244,6 +250,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.SomeActionAsync().Result, Is.Null);
         }
 
+#if !NET40
         [Test]
         public void Returns_Null_for_method_returning_class_async_ValueTask()
         {
@@ -251,6 +258,7 @@ namespace NSubstitute.Acceptance.Specs
 
             Assert.That(_something.SomeActionValueTaskAsync().Result, Is.Null);
         }
+#endif
 
         [Test]
         public void Returns_Null_for_any_args_when_string_parameter_async()
@@ -268,6 +276,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.SomeActionWithParamsAsync(123, "something else").Result, Is.Null);
         }
 
+#if !NET40
         [Test]
         public void Returns_Null_for_any_args_when_string_parameter_async_ValueTask()
         {
@@ -283,6 +292,7 @@ namespace NSubstitute.Acceptance.Specs
 
             Assert.That(_something.SomeActionWithParamsValueTaskAsync(123, "something else").Result, Is.Null);
         }
+#endif
 
         [Test]
         public void Return_a_wrapped_async_result()
@@ -293,6 +303,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountAsync().Result, Is.EqualTo(3));
         }
 
+#if !NET40
         [Test]
         public void Return_a_wrapped_ValueTask_async_result()
         {
@@ -301,6 +312,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountValueTaskAsync(), Is.TypeOf<ValueTask<int>>());
             Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3));
         }
+#endif
 
         [Test]
         public void Return_multiple_async_results_from_funcs()
@@ -316,6 +328,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountAsync().Result, Is.EqualTo(3), "Fourth return");
         }
 
+#if !NET40
         [Test]
         public void Return_multiple_ValueTask_async_results_from_funcs()
         {
@@ -329,6 +342,7 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3), "Third return");
             Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3), "Fourth return");
         }
+#endif
 
         [SetUp]
         public void SetUp()

--- a/tests/NSubstitute.Acceptance.Specs/app.config
+++ b/tests/NSubstitute.Acceptance.Specs/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Here's a first attempt at adding back the .NET 4.0 target. I don't think the changes required were too major.

The main issues:
- No `ValueTask`: These parts of the API (and tests) were just excluded with pre-compilation symbols.
- No `GetTypeInfo`: Added a dummy extension method to reduce precompilation symbols, and get the same results.
- Async API changes: Mostly minor. Two tests have been excluded which should work with Microsoft.Bcl.Async, but I could not get that package working in the new csproj format for the life of me! I think I was hitting https://github.com/Microsoft/msbuild/issues/1310 - but none of the solutions there seemed to work. Open to any ideas here! (cc @jnm2 - your name popped up on that issue! If you have any ideas of how to get Microsoft.Bcl.Async working for the .NET 4.0 build of the test project here - I'd love to hear them!)

Look forward to hearing what you think. 😄 (Fixes #341)