### PR TITLE
Fix one configuration could prevent from other configuration

### DIFF
--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -58,7 +58,6 @@ namespace NSubstitute.Routing
             return new Route(new ICallHandler[] {
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
                 , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
-                , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
@@ -1,0 +1,27 @@
+﻿using NSubstitute.Acceptance.Specs.Infrastructure;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue225_ConfiguredValueIsUsedInSubsequentSetups
+    {
+        [Test]
+        public void ShouldNotUseTheConfiguredValueDuringSubsequentSetup()
+        {
+            // Arrange
+            var target = Substitute.For<ISomething>();
+            
+            // Act
+            target.Echo(Arg.Is(0)).Returns("00", "01", "02");
+            target.Echo(Arg.Is(1)).Returns("10", "11", "12");
+
+            // Assert
+            Assert.AreEqual("00", target.Echo(0));
+            Assert.AreEqual("10", target.Echo(1));
+            Assert.AreEqual("01", target.Echo(0));
+            Assert.AreEqual("11", target.Echo(1));
+            Assert.AreEqual("02", target.Echo(0));
+            Assert.AreEqual("12", target.Echo(1));
+        } 
+    }
+}

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue291_CannotReconfigureThrowingConfiguration
+    {
+        // Based on: http://stackoverflow.com/q/42686269/906
+
+        public interface IRequest { }
+        public interface IResponse { }
+        public interface IDeliver { IResponse Send(IRequest msg); }
+
+        public class Message1 : IRequest { }
+        public class Message2 : IRequest { }
+        public class Response : IResponse { }
+
+        [Test]
+        public void ShouldBePossibleToReConfigureThrowingConfiguration()
+        {
+            // Arrange
+            var response = new Response();
+            var deliver = Substitute.For<IDeliver>();
+            
+            // Act
+            deliver.Send(Arg.Any<Message1>()).Throws<InvalidOperationException>();
+            deliver.Send(Arg.Any<Message2>()).Returns(response);
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => deliver.Send(new Message1()));
+            Assert.AreSame(response, deliver.Send(new Message2()));
+        }
+
+        [Test]
+        public void ShouldBePossibleToConfigureConstantAfterThrowForAny()
+        {
+            // Arrange
+            var something = Substitute.For<ISomething>();
+            
+            // Act
+            something.Echo(Arg.Any<int>()).Throws<InvalidOperationException>();
+            something.Echo(Arg.Is(42)).Returns("42");
+            
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => something.Echo(100));
+            Assert.AreEqual("42", something.Echo(42));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #291 and fixes #225.

Found a great and logical way to fix the issue #291. 

Previously we returned the already configured value for the specifying call. There is no sense to do that, as the returned value is later discarded when extensions like `Returns()` are used. Therefore, fixed issue by simply stopping to return the configured value is the specifying call.

No tests started to fail, meaning that none of the knowing scenario was broken. I've also investigated the git history, but it seems that the reasons are mostly historical and it has been so from the beginning.

Let me know if you see any potential scenario that could be broken because of this change.

P.S. It appeared that it also fixes the scenario #225, so added tests for it as well.
P.P.S. OK, it appeared that idea isn't that new and PR also closes #146 as well 😅
P.P.P.S. Does this issue also answers to #177 so we can close it as well? If you start to use `Arg.Is(x)`, it will work fine as this is basically our scenario:
```c#
calc.Add(Arg.Any<int>, Arg.Any<int>()).Returns(3, 4);
calc.Add(Arg.Is(2), Arg.Is(1)).Returns(3, 5); // Arg.Is(1) might be replaced with "1".

Assert.That(calc.Add(3,1), Is.EqualTo(3));
```