### PR TITLE
Add the Configure() hint extension method

### DIFF
--- a/src/NSubstitute/Extensions/ConfigurationExtensions.cs
+++ b/src/NSubstitute/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+﻿using NSubstitute.Core;
+
+namespace NSubstitute.Extensions
+{
+    public static class ConfigurationExtensions
+    {
+        /// <summary>
+        /// A hint for the NSubstitute that the subsequent method/property call is about to be configured.
+        /// <para>
+        /// NOTICE, you _don't need_ to invoke this method for the basic configuration scenarios.
+        /// Ensure you don't overuse this method and it's applied only if strictly required.
+        /// </para>
+        /// <remarks>
+        /// Due to the NSubstitute configuration syntax it's often impossible to recognize during the method call
+        /// dispatch whether this is a setup phase or a regular method call.
+        /// Usually, it doesn't matter, however sometimes method invocation could lead to undesired side effects
+        /// (e.g. the previously configured value is returned, base method is invoked). In that case you might want to
+        /// provide NSubstitute with a hint that you are configuring the method, so it treats call in a special mode.
+        /// </remarks>
+        /// </summary>
+        public static T Configure<T>(this T substitute) where T : class
+        {
+            var context = SubstitutionContext.Current;
+            var router = context.GetCallRouterFor(substitute);
+            var routeFactory = context.GetRouteFactory();
+
+            router.SetRoute(state => routeFactory.RecordCallSpecification(state));
+
+            return substitute;
+        }
+    }
+}

--- a/tests/NSubstitute.Acceptance.Specs/ConfigurationExtensionTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ConfigurationExtensionTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.Core;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.Extensions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    public class ConfigurationExtensionTests
+    {
+        public class TypeWithThrowingMembers
+        {
+            public virtual int GetValue() => throw new NotImplementedException();
+            public virtual int Value => throw new NotImplementedException();
+        }
+
+        public class ThrowingCallHandler : ICallHandler
+        {
+            public RouteAction Handle(ICall call) => throw new NotSupportedException();
+        }
+
+        [Test]
+        public void Should_not_return_the_previously_configured_result()
+        {
+            // Arrange
+            var mock = Substitute.For<ISomething>();
+
+            // Act
+            mock.Echo(Arg.Any<int>()).Returns("1", "2", "3");
+            mock.Configure().Echo(42).Returns("42");
+
+            // Assert
+            Assert.That(mock.Echo(10), Is.EqualTo("1"));
+            Assert.That(mock.Echo(10), Is.EqualTo("2"));
+            Assert.That(mock.Echo(42), Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Should_be_possible_to_reconfigure_configured_throwing_calls()
+        {
+            // Arrange
+            var mock = Substitute.For<ISomething>();
+
+            // Act
+            mock.Echo(Arg.Any<int>()).Throws<InvalidOperationException>();
+            mock.Configure().Echo(42).Returns("42");
+
+            // Assert
+            Assert.That(mock.Echo(42), Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void Should_be_possible_to_configure_base_throwing_method()
+        {
+            // Arrange
+            var mock = Substitute.ForPartsOf<TypeWithThrowingMembers>();
+
+            // Act
+            mock.Configure().GetValue().Returns(42);
+
+            // Assert
+            Assert.That(mock.GetValue(), Is.EqualTo(42));
+        }
+
+        [Test]
+        public void Should_be_possible_to_configure_base_throwing_property()
+        {
+            // Arrange
+            var mock = Substitute.ForPartsOf<TypeWithThrowingMembers>();
+
+            // Act
+            mock.Configure().Value.Returns(42);
+
+            // Assert
+            Assert.That(mock.Value, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void Should_be_possible_to_disable_custom_call_handler_for_specification_call()
+        {
+            // Arrange
+            var mock = Substitute.For<ISomething>();
+
+            var callRouter = SubstitutionContext.Current.GetCallRouterFor(mock);
+            callRouter.RegisterCustomCallHandlerFactory(_ => new ThrowingCallHandler());
+
+            // Act
+            mock.Configure().Count().Returns(42);
+
+            // Assert
+            Assert.That(mock.Count(), Is.EqualTo(42));
+        }
+    }
+}


### PR DESCRIPTION
Closes #350

As discussed in #350, added the `Configure()` extension method, that sets the next route to `RecordCallSpecification` one. That allows to avoid undesired side-effects during the method configuration (e.g. do not "steal" the previously configured return value).

Method should be invoked _before_ the actual method call. Expected invocation chain:

```c#
substitute.Configure().GetValue().Returns(42);
substitute.Configure().GetValue(1, "2", 3UL).Returns(42);
substitute.Configure().Value.Returns(42);
```

Added a warning to the method doc that this method should be used in exceptional cases only.

Let me know if you see other things to improve 😉