### PR TITLE
Improve MatchArg debug display

### DIFF
--- a/src/NSubstitute/Core/MatchArgs.cs
+++ b/src/NSubstitute/Core/MatchArgs.cs
@@ -1,10 +1,21 @@
+using System.Diagnostics;
+
 namespace NSubstitute.Core
 {
+    [DebuggerDisplay("{" + nameof(GetDebugDisplayName) + "}")]
     public class MatchArgs
     {
-        private MatchArgs() { }
-
         public static readonly MatchArgs AsSpecifiedInCall = new MatchArgs();
         public static readonly MatchArgs Any = new MatchArgs();
+
+        private MatchArgs() { }
+
+        private string GetDebugDisplayName()
+        {
+            if (this == AsSpecifiedInCall) return nameof(AsSpecifiedInCall);
+            if (this == Any) return nameof(Any);
+
+            return "UNKNOWN";
+        }
     }
 }


### PR DESCRIPTION
Currently when you debug the code it's impossible to understand the current value of `MatchArgs` parameter. Improved that by adding the Debugger Display.

It doesn't change the logic somehow.