### PR TITLE
Optimize CallResults to perform single lookup for result instead of two

### DIFF
--- a/src/NSubstitute/Core/CallResults.cs
+++ b/src/NSubstitute/Core/CallResults.cs
@@ -19,18 +19,16 @@ namespace NSubstitute.Core
             _results.Enqueue(new ResultForCallSpec(callSpecification, result));
         }
 
-        public bool HasResultFor(ICall call)
+        public bool TryGetResult(ICall call, out object result)
         {
+            result = null;
             if (ReturnsVoidFrom(call)) return false;
-            return _results.Any(x => x.IsResultFor(call));
-        }
 
-        public object GetResult(ICall call)
-        {
-            return _results
-                    .Reverse()
-                    .First(x => x.IsResultFor(call))
-                    .GetResult(_callInfoFactory.Create(call));
+            var resultWrapper = _results.Reverse().FirstOrDefault(x => x.IsResultFor(call));
+            if(resultWrapper == null) return false;
+
+            result = resultWrapper.GetResult(_callInfoFactory.Create(call));
+            return true;
         }
 
         public void Clear()
@@ -54,8 +52,8 @@ namespace NSubstitute.Core
                 _resultToReturn = resultToReturn;
             }
 
-            public bool IsResultFor(ICall call) { return _callSpecification.IsSatisfiedBy(call); }
-            public object GetResult(CallInfo callInfo) { return _resultToReturn.ReturnFor(callInfo); }
+            public bool IsResultFor(ICall call) => _callSpecification.IsSatisfiedBy(call);
+            public object GetResult(CallInfo callInfo) => _resultToReturn.ReturnFor(callInfo);
         }
     }
 }

--- a/src/NSubstitute/Core/ICallResults.cs
+++ b/src/NSubstitute/Core/ICallResults.cs
@@ -3,8 +3,7 @@ namespace NSubstitute.Core
     public interface ICallResults
     {
         void SetResult(ICallSpecification callSpecification, IReturn result);
-        bool HasResultFor(ICall call);
-        object GetResult(ICall call);
+        bool TryGetResult(ICall call, out object result);
 	    void Clear();
     }
 }

--- a/src/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -28,9 +28,9 @@ namespace NSubstitute.Routing.Handlers
 
         public RouteAction Handle(ICall call)
         {
-            if (_callResults.HasResultFor(call))
+            if (_callResults.TryGetResult(call, out var cachedResult))
             {
-                return RouteAction.Return(_callResults.GetResult(call));
+                return RouteAction.Return(cachedResult);
             }
 
             var type = call.GetReturnType();

--- a/src/NSubstitute/Routing/Handlers/ReturnConfiguredResultHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnConfiguredResultHandler.cs
@@ -13,11 +13,9 @@ namespace NSubstitute.Routing.Handlers
 
         public RouteAction Handle(ICall call)
         {
-            if (_callResults.HasResultFor(call))
-            {
-                return RouteAction.Return(_callResults.GetResult(call));
-            }
-            return RouteAction.Continue();
+            return _callResults.TryGetResult(call, out var configuredResult) 
+                ? RouteAction.Return(configuredResult)
+                : RouteAction.Continue();
         }
     }
 }


### PR DESCRIPTION
Currently `ICallResults` API provides two methods - one to check whether the result is present, other - get the result. I've found that currently we always use those methods one-by-one, so decided to improve that. Probably, the performance benefit is minimal, but code readability is better now and you stop thinking that it should be optimized 😅 

Notice, I've introduced a breaking change in API (added a new method and removed a few existing), therefore changes might be released in next major only.

Let me know if you have any concerns regarding the change 😉