### PR TITLE
Refactor ICall creation and argument matchers queue usage

### DIFF
--- a/src/NSubstitute/Core/ArgumentSpecificationDequeue.cs
+++ b/src/NSubstitute/Core/ArgumentSpecificationDequeue.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NSubstitute.Core.Arguments;
+
+namespace NSubstitute.Core
+{
+    public class ArgumentSpecificationDequeue : IArgumentSpecificationDequeue
+    {
+        private readonly Func<IList<IArgumentSpecification>> _dequeueAllQueuedArgSpecs;
+
+        public ArgumentSpecificationDequeue(Func<IList<IArgumentSpecification>> dequeueAllQueuedArgSpecs)
+        {
+            _dequeueAllQueuedArgSpecs = dequeueAllQueuedArgSpecs;
+        }
+        
+        public IList<IArgumentSpecification> DequeueAllArgumentSpecificationsForMethod(MethodInfo methodInfo)
+        {
+            if (methodInfo.GetParameters().Length == 0)
+                return new List<IArgumentSpecification>();
+
+            var queuedArgSpecifications = _dequeueAllQueuedArgSpecs.Invoke();
+            return queuedArgSpecifications;
+        }
+    }
+}

--- a/src/NSubstitute/Core/Call.cs
+++ b/src/NSubstitute/Core/Call.cs
@@ -18,37 +18,20 @@ namespace NSubstitute.Core
         private long? _sequenceNumber;
         private readonly Func<object> _baseMethod;
 
-        public Call(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecsForCall, Func<object> baseMethod = null) 
+        public Call(MethodInfo methodInfo,
+            object[] arguments,
+            object target,
+            IList<IArgumentSpecification> argumentSpecifications,
+            IParameterInfo[] parameterInfos,
+            Func<object> baseMethod)
         {
-            _methodInfo = methodInfo;
-            _arguments = arguments;
+            _methodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+            _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
             _originalArguments = arguments.ToArray();
-            _target = target;
-            _parameterInfos = GetParameterInfosFrom(_methodInfo);
-            _argumentSpecifications = argumentSpecsForCall;
+            _target = target ?? throw new ArgumentNullException(nameof(target));
+            _argumentSpecifications = argumentSpecifications ?? throw new ArgumentNullException(nameof(argumentSpecifications));
+            _parameterInfos = parameterInfos ?? throw new ArgumentNullException(nameof(parameterInfos));
             _baseMethod = baseMethod;
-        }
-
-        public Call(MethodInfo methodInfo, object[] arguments, object target, IParameterInfo[] parameterInfos)
-        {
-            _methodInfo = methodInfo;
-            _arguments = arguments;
-            _originalArguments = arguments.ToArray();
-            _target = target;
-            _parameterInfos = parameterInfos ?? GetParameterInfosFrom(_methodInfo);
-            _argumentSpecifications = (_parameterInfos.Length == 0) ? EmptyList() : SubstitutionContext.Current.DequeueAllArgumentSpecifications();
-        }
-
-        private IList<IArgumentSpecification> EmptyList()
-        {
-            return new List<IArgumentSpecification>();
-        }
-
-        private IParameterInfo[] GetParameterInfosFrom(MethodInfo methodInfo)
-        {
-            var parameters = methodInfo.GetParameters();
-            if (parameters == null) return new IParameterInfo[0];
-            return parameters.Select(x => new ParameterInfoWrapper(x)).ToArray();
         }
 
         public IParameterInfo[] GetParameterInfos()

--- a/src/NSubstitute/Core/CallFactory.cs
+++ b/src/NSubstitute/Core/CallFactory.cs
@@ -1,30 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using NSubstitute.Core.Arguments;
 
 namespace NSubstitute.Core
 {
-    public class CallFactory
+    public class CallFactory : ICallFactory
     {
-        private readonly ISubstitutionContext _context;
-
-        public CallFactory() : this(SubstitutionContext.Current) { }
-
-        public CallFactory(ISubstitutionContext context)
+        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object> baseMethod)
         {
-            _context = context;
+            var parameterInfos = GetParameterInfoFromMethod(methodInfo);
+            return new Call(methodInfo, arguments, target, argumentSpecifications, parameterInfos, baseMethod);
+        }
+        
+        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, IParameterInfo[] parameterInfos)
+        {
+            return new Call(methodInfo, arguments, target, argumentSpecifications, parameterInfos, baseMethod: null);
         }
 
-        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, Func<object> baseMethod)
+        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications)
         {
-            var argSpecs = (methodInfo.GetParameters().Length == 0) ? EmptyList() : _context.DequeueAllArgumentSpecifications();
-            return new Call(methodInfo, arguments, target, argSpecs, baseMethod);
+            var parameterInfos = GetParameterInfoFromMethod(methodInfo);
+            return new Call(methodInfo, arguments, target, argumentSpecifications, parameterInfos, baseMethod: null);
         }
 
-        private IList<IArgumentSpecification> EmptyList()
+        private static IParameterInfo[] GetParameterInfoFromMethod(MethodInfo methodInfo)
         {
-            return new List<IArgumentSpecification>();
+            return methodInfo.GetParameters().Select(x => new ParameterInfoWrapper(x)).ToArray();
         }
     }
 }

--- a/src/NSubstitute/Core/IArgumentSpecificationDequeue.cs
+++ b/src/NSubstitute/Core/IArgumentSpecificationDequeue.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using NSubstitute.Core.Arguments;
+
+namespace NSubstitute.Core
+{
+    public interface IArgumentSpecificationDequeue
+    {
+        IList<IArgumentSpecification> DequeueAllArgumentSpecificationsForMethod(MethodInfo methodInfo);
+    }
+}

--- a/src/NSubstitute/Core/ICallFactory.cs
+++ b/src/NSubstitute/Core/ICallFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NSubstitute.Core.Arguments;
+
+namespace NSubstitute.Core
+{
+    public interface ICallFactory
+    {
+        ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object> baseMethod);
+        ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, IParameterInfo[] parameterInfos);
+        ICall Create(MethodInfo methodInfo, object[] getterArgs, object target, IList<IArgumentSpecification> getArgumentSpecifications);
+    }
+}

--- a/src/NSubstitute/Core/PropertyHelper.cs
+++ b/src/NSubstitute/Core/PropertyHelper.cs
@@ -6,6 +6,13 @@ namespace NSubstitute.Core
 {
     public class PropertyHelper : IPropertyHelper
     {
+        private readonly ICallFactory _callFactory;
+
+        public PropertyHelper(ICallFactory callFactory)
+        {
+            _callFactory = callFactory;
+        }
+        
         public bool IsCallToSetAReadWriteProperty(ICall call)
         {
             var propertySetter = GetPropertyFromSetterCallOrNull(call);
@@ -32,7 +39,7 @@ namespace NSubstitute.Core
             var setterArgs = callToSetter.GetArguments();
             var getter = propertyInfo.GetGetMethod();
             var getterArgs = setterArgs.Take(setterArgs.Length - 1).ToArray();
-            return new Call(getter, getterArgs, callToSetter.Target(), callToSetter.GetArgumentSpecifications());
+            return _callFactory.Create(getter, getterArgs, callToSetter.Target(), callToSetter.GetArgumentSpecifications());
         }
     }
 }

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -30,8 +30,9 @@ namespace NSubstitute.Core
         SubstitutionContext()
         {
             var callRouterFactory = new CallRouterFactory();
-            var dynamicProxyFactory = new CastleDynamicProxyFactory();
-            var delegateFactory = new DelegateProxyFactory();
+            var argSpecificationQueue = new ArgumentSpecificationDequeue(DequeueAllArgumentSpecifications);
+            var dynamicProxyFactory = new CastleDynamicProxyFactory(argSpecificationQueue);
+            var delegateFactory = new DelegateProxyFactory(argSpecificationQueue);
             var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
             var callRouteResolver = new CallRouterResolver();
             _substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver);

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -9,11 +9,13 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 {
     public class CastleDynamicProxyFactory : IProxyFactory
     {
-        readonly ProxyGenerator _proxyGenerator;
-        readonly AllMethodsExceptCallRouterCallsHook _allMethodsExceptCallRouterCallsHook;
+        private readonly IArgumentSpecificationDequeue _argSpecificationDequeue;
+        private readonly ProxyGenerator _proxyGenerator;
+        private readonly AllMethodsExceptCallRouterCallsHook _allMethodsExceptCallRouterCallsHook;
 
-        public CastleDynamicProxyFactory()
+        public CastleDynamicProxyFactory(IArgumentSpecificationDequeue argSpecificationDequeue)
         {
+            _argSpecificationDequeue = argSpecificationDequeue;
             _proxyGenerator = new ProxyGenerator();
             _allMethodsExceptCallRouterCallsHook = new AllMethodsExceptCallRouterCallsHook();
         }
@@ -22,7 +24,11 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
         {
             VerifyClassHasNotBeenPassedAsAnAdditionalInterface(additionalInterfaces);
 
-            var interceptor = new CastleForwardingInterceptor(new CastleInvocationMapper(), callRouter);
+            var interceptor = new CastleForwardingInterceptor(
+                new CastleInvocationMapper(
+                    new CallFactory(),
+                    _argSpecificationDequeue),
+                callRouter);
             var proxyGenerationOptions = GetOptionsToMixinCallRouter(callRouter);
             var proxy = CreateProxyUsingCastleProxyGenerator(typeToProxy, additionalInterfaces, constructorArguments, interceptor, proxyGenerationOptions);
             interceptor.StartIntercepting();

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
@@ -6,7 +6,14 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 {
     public class CastleInvocationMapper
     {
-        readonly static CallFactory CallFactory = new CallFactory();
+        readonly ICallFactory _callFactory;
+        private readonly IArgumentSpecificationDequeue _argSpecificationDequeue;
+
+        public CastleInvocationMapper(ICallFactory callFactory, IArgumentSpecificationDequeue argSpecificationDequeue)
+        {
+            _callFactory = callFactory;
+            _argSpecificationDequeue = argSpecificationDequeue;
+        }
 
         public virtual ICall Map(IInvocation castleInvocation)
         {
@@ -21,7 +28,8 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
                 baseMethod = () => result.Value;
             }
 
-            return CallFactory.Create(castleInvocation.Method, castleInvocation.Arguments, castleInvocation.Proxy, baseMethod);
+            var queuedArgSpecifications = _argSpecificationDequeue.DequeueAllArgumentSpecificationsForMethod(castleInvocation.Method);
+            return _callFactory.Create(castleInvocation.Method, castleInvocation.Arguments, castleInvocation.Proxy, queuedArgSpecifications, baseMethod);
         }
     }
 }

--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -10,6 +10,13 @@ namespace NSubstitute.Proxies.DelegateProxy
 {
     public class DelegateProxyFactory : IProxyFactory
     {
+        private readonly IArgumentSpecificationDequeue _argSpecificationDequeue;
+
+        public DelegateProxyFactory(IArgumentSpecificationDequeue argSpecificationDequeue)
+        {
+            _argSpecificationDequeue = argSpecificationDequeue;
+        }
+        
         public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
         {
             if (HasItems(additionalInterfaces))
@@ -35,7 +42,7 @@ namespace NSubstitute.Proxies.DelegateProxy
             var delegateMethodToProxy = delegateType.GetMethod("Invoke");
 
             var proxyParameterTypes = delegateMethodToProxy.GetParameters().Select(x => new ParameterInfoWrapper(x)).ToArray();
-            var delegateCall = new DelegateCall(callRouter, delegateType, delegateMethodToProxy.ReturnType, proxyParameterTypes);
+            var delegateCall = new DelegateCall(callRouter, delegateType, delegateMethodToProxy.ReturnType, proxyParameterTypes, new CallFactory(), _argSpecificationDequeue);
             var invokeOnDelegateCall = delegateCall.MethodToInvoke;
 
             ParameterExpression[] proxyParameters = delegateMethodToProxy.GetParameters().Select(x => Expression.Parameter(x.ParameterType, x.Name)).ToArray();

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -57,7 +57,7 @@ namespace NSubstitute.Routing
         {
             return new Route(new ICallHandler[] {
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
-                , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
+                , new PropertySetterHandler(new PropertyHelper(new CallFactory()), state.ConfigureCall)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
@@ -70,7 +70,7 @@ namespace NSubstitute.Routing
                 , new TrackLastCallHandler(state.PendingSpecification)
                 , new RecordCallHandler(state.CallCollection, state.SequenceNumberGenerator)
                 , new EventSubscriptionHandler(state.EventHandlerRegistry)
-                , new PropertySetterHandler(new PropertyHelper(), state.ConfigureCall)
+                , new PropertySetterHandler(new PropertyHelper(new CallFactory()), state.ConfigureCall)
                 , new DoActionsCallHandler(state.CallActions)
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)


### PR DESCRIPTION
Currently there is a bit of mess in the code related to the `Call` construction:
1. Sometimes `CallFactory` is used, sometimes instance is activated directly.
2. Sometimes queued argument specifications are dequeued in the `Call` constructor, sometimes they are dequeued by caller.
3. Static argument specification queue is used directly deeply inside the code, increasing the code coupling.

Therefore, I decided to refactor that part a bit, so that:
1. `ICallFactory` is always used to create the Call instances;
2. Added a special `IArgumentSpecificationDequeue` instance, used to dequeue the pending specifications. That allows to ensure that:
    - we have a single place that works with the queue (and can perform the verification)
    - we don't use the static context directly, rather dependency is passed via the graph.

It improves the dependency flow (there are no circular dependencies, when `SubstitutionContext` creates `CallFactory` which later uses `SubstitionContext.Current`). Also because I moved dequeue logic to a single place, later we will be able to improve the validation logic (e.g. fail if there are more specs than method arguments).

Code adds a bit of breaking changes related to constructor signatures, however that should be fine as we are creating a new major version.