### PR TITLE
Expose sub.Received(Quantity) extension method (#348)

### DIFF
--- a/src/NSubstitute/Core/IReceivedCallsExceptionThrower.cs
+++ b/src/NSubstitute/Core/IReceivedCallsExceptionThrower.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NSubstitute.ReceivedExtensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Core/ReceivedCallsExceptionThrower.cs
+++ b/src/NSubstitute/Core/ReceivedCallsExceptionThrower.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using NSubstitute.Core.Arguments;
 using NSubstitute.Exceptions;
+using NSubstitute.ReceivedExtensions;
 
 namespace NSubstitute.Core
 {

--- a/src/NSubstitute/Extensions/ReceivedExtensions.cs
+++ b/src/NSubstitute/Extensions/ReceivedExtensions.cs
@@ -1,16 +1,77 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using NSubstitute.Core;
 
-namespace NSubstitute.Core
+namespace NSubstitute.ReceivedExtensions
 {
+    public static class ReceivedExtensions
+    {
+        /// <summary>
+        /// Checks this substitute has received the following call the required number of times.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="substitute"></param>
+        /// <param name="requiredQuantity"></param>
+        /// <returns></returns>
+        public static T Received<T>(this T substitute, Quantity requiredQuantity)
+        {
+            var context = SubstitutionContext.Current;
+            var router = context.GetCallRouterFor(substitute);
+            var routeFactory = context.GetRouteFactory();
+            router.SetRoute(x => routeFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity));
+            return substitute;
+        }
+
+        /// <summary>
+        /// Checks this substitute has received the following call with any arguments the required number of times.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="substitute"></param>
+        /// <param name="requiredQuantity"></param>
+        /// <returns></returns>
+        public static T ReceivedWithAnyArgs<T>(this T substitute, Quantity requiredQuantity)
+        {
+            var context = SubstitutionContext.Current;
+            var router = context.GetCallRouterFor(substitute);
+            var routeFactory = context.GetRouteFactory();
+            router.SetRoute(x => routeFactory.CheckReceivedCalls(x, MatchArgs.Any, requiredQuantity));
+            return substitute;
+        }
+    }
+
+    /// <summary>
+    /// Represents a quantity. Primarily used for specifying a required amount of calls to a member.
+    /// </summary>
     public abstract class Quantity
     {
         public static Quantity Exactly(int number) { return number == 0 ? None() : new ExactQuantity(number); }
         public static Quantity AtLeastOne() { return new AnyNonZeroQuantity(); }
         public static Quantity None() { return new NoneQuantity(); }
 
+        /// <summary>
+        /// Returns whether the given collection contains the required quantity of items.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <returns>true if the collection has the required quantity; otherwise false.</returns>
         public abstract bool Matches<T>(IEnumerable<T> items);
+
+        /// <summary>
+        /// Returns whether the given collections needs more items to satisfy the required quantity.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="items"></param>
+        /// <returns>true if the collection needs more items to match this quantity; otherwise false.</returns>
         public abstract bool RequiresMoreThan<T>(IEnumerable<T> items);
+
+        /// <summary>
+        /// Describe this quantity using the given noun variants.
+        /// For example, `Describe("item", "items")` could return the description:
+        /// "more than 1 item, but less than 10 items".
+        /// </summary>
+        /// <param name="singularNoun"></param>
+        /// <param name="pluralNoun"></param>
+        /// <returns>A string describing the required quantity of items identified by the provided noun forms.</returns>
         public abstract string Describe(string singularNoun, string pluralNoun);
 
         private class ExactQuantity : Quantity

--- a/src/NSubstitute/Routing/Handlers/CheckReceivedCallsHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/CheckReceivedCallsHandler.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using NSubstitute.Core;
+using NSubstitute.ReceivedExtensions;
 
 namespace NSubstitute.Routing.Handlers
 {

--- a/src/NSubstitute/Routing/IRouteFactory.cs
+++ b/src/NSubstitute/Routing/IRouteFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NSubstitute.Core;
+using NSubstitute.ReceivedExtensions;
 
 namespace NSubstitute.Routing
 {

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NSubstitute.Core;
+using NSubstitute.ReceivedExtensions;
 using NSubstitute.Routing.Handlers;
 
 namespace NSubstitute.Routing


### PR DESCRIPTION
- Created new NSubstitute.ReceivedExtensions namespace and static class.
- Created Received(Quantity) and ReceivedWithAnyArgs(Quantity) methods.
- Moved Quantity into NSubstitute.ReceivedExtensions (so Quantity can be
  referenced as soon as ReceivedExtensions is; this way Quantity type
  has less chance of conflicting with classes already in the code under
  test). This has added some `using` statements to a few files.
- Updated SubstituteExtensions to use the ReceivedExtensions as this
  simplifies the code.