### PR TITLE
Refactor primary type lookup logic for better readability

### DIFF
--- a/src/NSubstitute/Core/SubstituteFactory.cs
+++ b/src/NSubstitute/Core/SubstituteFactory.cs
@@ -42,7 +42,7 @@ namespace NSubstitute.Core
         public object CreatePartial(Type[] typesToProxy, object[] constructorArguments)
         {
             var primaryProxyType = GetPrimaryProxyType(typesToProxy);
-            if (primaryProxyType.GetTypeInfo().IsSubclassOf(typeof (Delegate)) || !primaryProxyType.GetTypeInfo().IsClass)
+            if (primaryProxyType.GetTypeInfo().IsSubclassOf(typeof(Delegate)) || !primaryProxyType.GetTypeInfo().IsClass)
             {
                 throw new CanNotPartiallySubForInterfaceOrDelegateException(primaryProxyType);
             }
@@ -60,9 +60,9 @@ namespace NSubstitute.Core
 
         private Type GetPrimaryProxyType(Type[] typesToProxy)
         {
-            if (typesToProxy.Any(x => x.GetTypeInfo().IsSubclassOf(typeof(Delegate)))) return typesToProxy.First(x => x.GetTypeInfo().IsSubclassOf(typeof(Delegate)));
-            if (typesToProxy.Any(x => x.GetTypeInfo().IsClass)) return typesToProxy.First(x => x.GetTypeInfo().IsClass);
-            return typesToProxy.First();
+            return typesToProxy.FirstOrDefault(t => t.GetTypeInfo().IsSubclassOf(typeof(Delegate)))
+                ?? typesToProxy.FirstOrDefault(t => t.GetTypeInfo().IsClass)
+                ?? typesToProxy.First();
         }
 
         public ICallRouter GetCallRouterCreatedFor(object substitute)


### PR DESCRIPTION
Small code refactor to both improve the readability and performance (as we proceed the sequence once).

Probably, a single review is enough for this change - it's very tiny.