### PR TITLE
Refactor CallRouter for better readability

### DIFF
--- a/src/NSubstitute/Core/CallRouter.cs
+++ b/src/NSubstitute/Core/CallRouter.cs
@@ -54,10 +54,16 @@ namespace NSubstitute.Core
         {
             _context.LastCallRouter(this);
 
+            var pendingRaisingEventArgs = _context.DequeuePendingRaisingEventArguments();
+
             IRoute routeToUseForThisCall;
             if (_context.IsQuerying)
             {
                 routeToUseForThisCall = GetQueryRoute();
+            }
+            else if (pendingRaisingEventArgs != null)
+            {
+                routeToUseForThisCall = GetRaiseEventRoute(pendingRaisingEventArgs);
             }
             else if (IsSpecifyingACall(call, _currentRoute))
             {
@@ -75,6 +81,11 @@ namespace NSubstitute.Core
         private IRoute GetQueryRoute()
         {
             return _routeFactory.CallQuery(_substituteState);
+        }
+
+        private IRoute GetRaiseEventRoute(Func<ICall, object[]> argumentsFactory)
+        {
+            return _routeFactory.RaiseEvent(_substituteState, argumentsFactory);
         }
 
         private static bool IsSpecifyingACall(ICall call, IRoute currentRoute)

--- a/src/NSubstitute/Core/ISubstitutionContext.cs
+++ b/src/NSubstitute/Core/ISubstitutionContext.cs
@@ -16,6 +16,7 @@ namespace NSubstitute.Core
         void EnqueueArgumentSpecification(IArgumentSpecification spec);
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();
         void RaiseEventForNextCall(Func<ICall, object[]> getArguments);
+        Func<ICall, object[]> DequeuePendingRaisingEventArguments();
         IQueryResults RunQuery(Action calls);
         bool IsQuerying { get; }
         void AddToQuery(object target, ICallSpecification callSpecification);

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -80,17 +80,6 @@ namespace NSubstitute.Core
         public void LastCallRouter(ICallRouter callRouter)
         {
             _lastCallRouter.Value = callRouter;
-            RaiseEventIfSet(callRouter);
-        }
-
-        void RaiseEventIfSet(ICallRouter callRouter)
-        {
-            if (_getArgumentsForRaisingEvent.Value != null)
-            {
-                var routes = new RouteFactory();
-                callRouter.SetRoute(x => routes.RaiseEvent(x, _getArgumentsForRaisingEvent.Value));
-                _getArgumentsForRaisingEvent.Value = null;
-            }
         }
 
         public ICallRouter GetCallRouterFor(object substitute)
@@ -113,6 +102,13 @@ namespace NSubstitute.Core
         public void RaiseEventForNextCall(Func<ICall, object[]> getArguments)
         {
             _getArgumentsForRaisingEvent.Value = getArguments;
+        }
+
+        public Func<ICall, object[]> DequeuePendingRaisingEventArguments()
+        {
+            var result = _getArgumentsForRaisingEvent.Value;
+            _getArgumentsForRaisingEvent.Value = null;
+            return result;
         }
 
         public void AddToQuery(object target, ICallSpecification callSpecification)


### PR DESCRIPTION
I've always struggled when I tried to understand the logic of the `Route` method. The main challenge is that we called `UseSomeRouteForNextCall()` and after that immediately consumed the route, meaning that in fact we use route for _this_ call. Therefore, I found that logic might be heavily simplified, so instead of setting the route globally, we simply assign in to the local variable.

The logic of the method haven't changed, however now it's much easier to read it.

**UPDATE**

Additionally, I've moved the event raise logic to the `CallRouter`. It looks non-natural that route selection logic is spread across two different classes. Moreover, it's __very__ unclear, that `_context.LastCallRouter(this)` in fact changes the route for the passed router. Now route selection logic is located in the single place, making it less possible to make a bug.