### PR TITLE
Use original arguments when modified value is not required

### DIFF
--- a/src/NSubstitute/Core/CallRouter.cs
+++ b/src/NSubstitute/Core/CallRouter.cs
@@ -90,7 +90,7 @@ namespace NSubstitute.Core
 
         private static bool IsSpecifyingACall(ICall call, IRoute currentRoute)
         {
-            var args = call.GetArguments() ?? EmptyArgs;
+            var args = call.GetOriginalArguments() ?? EmptyArgs;
             var argSpecs = call.GetArgumentSpecifications() ?? EmptyArgSpecs;
             return currentRoute.IsRecordReplayRoute && args.Any() && argSpecs.Any();
         }

--- a/src/NSubstitute/Core/PropertyHelper.cs
+++ b/src/NSubstitute/Core/PropertyHelper.cs
@@ -42,7 +42,7 @@ namespace NSubstitute.Core
             }
 
             var getter = propertyInfo.GetGetMethod();
-            var getterArgs = SkipLast(callToSetter.GetArguments());
+            var getterArgs = SkipLast(callToSetter.GetOriginalArguments());
             var getterArgumentSpecifications = GetGetterCallSpecificationsFromSetterCall(callToSetter);
 
             return _callFactory.Create(getter, getterArgs, callToSetter.Target(), getterArgumentSpecifications);

--- a/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
+++ b/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
@@ -130,7 +130,7 @@ namespace NSubstitute.Core.SequenceChecking
             {
                 var methodInfo = call.GetMethodInfo();
                 var args = methodInfo.GetParameters()
-                            .Zip(call.GetArguments(), (p, a) => new ArgAndParamInfo(p, a))
+                            .Zip(call.GetOriginalArguments(), (p, a) => new ArgAndParamInfo(p, a))
                             .ToArray();
                 return _callFormatter.Format(methodInfo, FormatArgs(args));
             }


### PR DESCRIPTION
Reviewed the `call.GetArguments()` and `call.GetOriginalArguments()` usage and changed code to use the latter one whenever required.

@alexandrnikitin It's a part of the follow up you [asked me about](https://github.com/nsubstitute/NSubstitute/pull/361#issuecomment-370337017).