### PR TITLE
Add synchronization to delegate wrapper builder

### DIFF
--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -60,6 +60,14 @@ namespace NSubstitute.Proxies.DelegateProxy
 
         private Type GenerateDelegateContainerInterface(Type delegateType)
         {
+            lock (_moduleBuilder)
+            {
+                return GenerateDelegateContainerInterfaceNoLock(delegateType);
+            }
+        }
+
+        private Type GenerateDelegateContainerInterfaceNoLock(Type delegateType)
+        {
             var delegateSignature = delegateType.GetMethod("Invoke");
 
             var typeSuffixCounter = Interlocked.Increment(ref _typeSuffixCounter);


### PR DESCRIPTION
It appears that Reflection.Emit API is not thread safe, therefore added extra sync around the code.

On .NET Framework it works fine even without locks, as internally locks are used. However, that is not guaranteed for other platforms/runtimes.