### PR TITLE
Introduce proxy id to simplify identification

### DIFF
--- a/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-
-namespace NSubstitute.Core.Arguments
+﻿namespace NSubstitute.Core.Arguments
 {
     public class ArgumentFormatter : IArgumentFormatter
     {
@@ -17,18 +13,8 @@ namespace NSubstitute.Core.Arguments
             if (arg == null) return "<null>";
             if (arg is string) return string.Format("\"{0}\"", arg);
             var standardToString = arg.ToString();
-            if (standardToString == arg.GetType().ToString()) return FormatType(arg.GetType());
+            if (standardToString == arg.GetType().ToString()) return arg.GetType().GetNonMangledTypeName();
             return standardToString;
        }
-
-        private string FormatType(Type type)
-        {
-            var typeName = type.Name;
-            if (!type.GetTypeInfo().IsGenericType) return typeName;
-
-            typeName = typeName.Substring(0, typeName.IndexOf('`'));
-            var genericArgTypes = type.GetGenericArguments().Select(x => FormatType(x));
-            return string.Format("{0}<{1}>", typeName, string.Join(", ", genericArgTypes.ToArray()));
-        }
     }
 }

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -42,5 +42,16 @@ namespace NSubstitute.Core
                 return enumerator.MoveNext() ? Maybe.Just(enumerator.Current) : Maybe.Nothing<T>();
             }
         }
+
+        internal static string GetNonMangledTypeName(this Type type)
+        {
+            var typeName = type.Name;
+            if (!type.GetTypeInfo().IsGenericType)
+                return typeName;
+
+            typeName = typeName.Substring(0, typeName.IndexOf('`'));
+            var genericArgTypes = type.GetGenericArguments().Select(GetNonMangledTypeName);
+            return string.Format("{0}<{1}>", typeName, string.Join(", ", genericArgTypes));
+        }
     }
 }

--- a/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
+++ b/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
@@ -104,21 +104,9 @@ namespace NSubstitute.Core.SequenceChecking
 
                 var delegateType = MethodInfo.GetCustomAttribute<ProxiedDelegateTypeAttribute>()?.DelegateType;
                 var declaringTypeName = delegateType != null
-                    ? FormatDelegateTypeName(delegateType)
+                    ? delegateType.GetNonMangledTypeName()
                     : MethodInfo.DeclaringType.Name;
                 return string.Format("{1}{0}.{2}", declaringTypeName, instanceIdentifier, call);
-            }
-
-            private static string FormatDelegateTypeName(Type delegateType)
-            {
-                if (!delegateType.GetTypeInfo().IsGenericType)
-                    return delegateType.Name;
-
-                var genericArgs = delegateType.GetGenericArguments();
-                var mangledName = delegateType.Name;
-                return string.Format("{0}<{1}>",
-                    new string(mangledName.TakeWhile(c => c != '`').ToArray()),
-                    string.Join(", ", genericArgs.Select(x => x.Name).ToArray()));
             }
 
             private string Format(CallSpecAndTarget x)

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -25,14 +26,22 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
         {
             VerifyClassHasNotBeenPassedAsAnAdditionalInterface(additionalInterfaces);
 
-            var interceptor = new CastleForwardingInterceptor(
+            var proxyIdInterceptor = new ProxyIdInterceptor(typeToProxy);
+            var forwardingInterceptor = new CastleForwardingInterceptor(
                 new CastleInvocationMapper(
                     new CallFactory(),
                     _argSpecificationDequeue),
                 callRouter);
+
             var proxyGenerationOptions = GetOptionsToMixinCallRouter(callRouter);
-            var proxy = CreateProxyUsingCastleProxyGenerator(typeToProxy, additionalInterfaces, constructorArguments, interceptor, proxyGenerationOptions);
-            interceptor.StartIntercepting();
+            var proxy = CreateProxyUsingCastleProxyGenerator(
+                typeToProxy,
+                additionalInterfaces,
+                constructorArguments,
+                new IInterceptor[] {proxyIdInterceptor, forwardingInterceptor},
+                proxyGenerationOptions);
+
+            forwardingInterceptor.StartIntercepting();
             return proxy;
         }
 
@@ -47,15 +56,28 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 
         private object CreateProxyUsingCastleProxyGenerator(Type typeToProxy, Type[] additionalInterfaces,
                                                             object[] constructorArguments,
-                                                            IInterceptor interceptor,
+                                                            IInterceptor[] interceptors,
                                                             ProxyGenerationOptions proxyGenerationOptions)
         {
             if (typeToProxy.GetTypeInfo().IsInterface)
             {
                 VerifyNoConstructorArgumentsGivenForInterface(constructorArguments);
-                return _proxyGenerator.CreateInterfaceProxyWithoutTarget(typeToProxy, additionalInterfaces, proxyGenerationOptions, interceptor);
+
+                var interfaces = new List<Type> {typeToProxy};
+                if (additionalInterfaces != null)
+                    interfaces.AddRange(additionalInterfaces);
+
+                // We need to create a proxy for the object type, so we can intercept the ToString() method.
+                // Therefore, we put the desired primary interface to the secondary list.
+                typeToProxy = typeof(object);
+                additionalInterfaces = interfaces.ToArray();
             }
-            return _proxyGenerator.CreateClassProxy(typeToProxy, additionalInterfaces, proxyGenerationOptions, constructorArguments, interceptor);
+
+            return _proxyGenerator.CreateClassProxy(typeToProxy,
+                additionalInterfaces,
+                proxyGenerationOptions,
+                constructorArguments,
+                interceptors);
         }
 
         private ProxyGenerationOptions GetOptionsToMixinCallRouter(ICallRouter callRouter)
@@ -65,10 +87,30 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             return options;
         }
 
+        private static void VerifyNoConstructorArgumentsGivenForInterface(object[] constructorArguments)
+        {
+            if (constructorArguments != null && constructorArguments.Length > 0)
+            {
+                throw new SubstituteException("Can not provide constructor arguments when substituting for an interface.");
+            }
+        }
+
+        private static void VerifyClassHasNotBeenPassedAsAnAdditionalInterface(Type[] additionalInterfaces)
+        {
+            if (additionalInterfaces != null && additionalInterfaces.Any(x => x.GetTypeInfo().IsClass))
+            {
+                throw new SubstituteException("Can not substitute for multiple classes. To substitute for multiple types only one type can be a concrete class; other types can only be interfaces.");
+            }
+        }
+
         private class AllMethodsExceptCallRouterCallsHook : AllMethodsHook
         {
             public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
             {
+                // Always intercept object.ToString() as we would like to return proxy id as a result.
+                if (ProxyIdInterceptor.IsDefaultToStringMethod(methodInfo))
+                    return true;
+
                 return IsNotCallRouterMethod(methodInfo)
                     && IsNotBaseObjectMethod(methodInfo)
                     && base.ShouldInterceptMethod(type, methodInfo);
@@ -81,23 +123,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 
             private static bool IsNotBaseObjectMethod(MethodInfo methodInfo)
             {
-                return methodInfo.GetBaseDefinition().DeclaringType != typeof (object);
-            }
-        }
-
-        private void VerifyNoConstructorArgumentsGivenForInterface(object[] constructorArguments)
-        {
-            if (constructorArguments != null && constructorArguments.Length > 0)
-            {
-                throw new SubstituteException("Can not provide constructor arguments when substituting for an interface.");
-            }
-        }
-
-        private void VerifyClassHasNotBeenPassedAsAnAdditionalInterface(Type[] additionalInterfaces)
-        {
-            if (additionalInterfaces != null && additionalInterfaces.Any(x => x.GetTypeInfo().IsClass))
-            {
-                throw new SubstituteException("Can not substitute for multiple classes. To substitute for multiple types only one type can be a concrete class; other types can only be interfaces.");
+                return methodInfo.GetBaseDefinition().DeclaringType != typeof(object);
             }
         }
     }

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/ProxyIdInterceptor.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/ProxyIdInterceptor.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using Castle.DynamicProxy;
+using NSubstitute.Core;
+
+namespace NSubstitute.Proxies.CastleDynamicProxy
+{
+    public class ProxyIdInterceptor : IInterceptor
+    {
+        private readonly Type _primaryProxyType;
+        private string _cachedProxyId;
+
+        public ProxyIdInterceptor(Type primaryProxyType)
+        {
+            _primaryProxyType = primaryProxyType ?? throw new ArgumentNullException(nameof(primaryProxyType));
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (IsDefaultToStringMethod(invocation.Method))
+            {
+                invocation.ReturnValue = _cachedProxyId ?? (_cachedProxyId = GenerateId(invocation));
+                return;
+            }
+
+            invocation.Proceed();
+        }
+
+        private string GenerateId(IInvocation invocation)
+        {
+            var proxy = invocation.InvocationTarget;
+
+            var shortTypeName = _primaryProxyType.GetNonMangledTypeName();
+            var proxyHashCode = proxy.GetHashCode();
+
+            return string.Format(CultureInfo.InvariantCulture, "Substitute.{0}|{1:x8}", shortTypeName, proxyHashCode);
+        }
+
+        public static bool IsDefaultToStringMethod(MethodInfo methodInfo)
+        {
+            return methodInfo.DeclaringType == typeof(object)
+                   && string.Equals(methodInfo.Name, nameof(ToString), StringComparison.Ordinal)
+                   && methodInfo.GetParameters().Length == 0;
+        }
+    }
+}

--- a/tests/NSubstitute.Acceptance.Specs/PerfTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/PerfTests.cs
@@ -97,6 +97,18 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(containerType1, Is.EqualTo(containerType2));
         }
 
+        [Test]
+        public void ProxyTypeIsCached()
+        {
+            var proxy1 = Substitute.For<IFoo>();
+            var proxy2 = Substitute.For<IFoo>();
+
+            var type1 = proxy1.GetType();
+            var type2 = proxy2.GetType();
+
+            Assert.That(type1, Is.EqualTo(type2));
+        }
+
         public interface IFoo { int GetInt(string s); }
         public interface IBar { int GetInt<T>(T t); }
         public interface IByteArraySource { byte[] GetArray(); }

--- a/tests/NSubstitute.Acceptance.Specs/ProxyIdentification.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ProxyIdentification.cs
@@ -1,0 +1,99 @@
+﻿using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    public class ProxyIdentification
+    {
+        [Test]
+        public void ProxyIdShouldContainTypeName()
+        {
+            var sut = Substitute.For<IInterface>();
+
+            var formatted = sut.ToString();
+
+            Assert.That(formatted, Contains.Substring(nameof(IInterface)));
+        }
+
+        [Test]
+        public void IdContainsPrimaryTypeOnly()
+        {
+            var proxy = Substitute.For<IInterface, IOtherInterface>();
+
+            var id = proxy.ToString();
+
+            Assert.That(id, Does.Not.Contain(nameof(IOtherInterface)));
+        }
+
+        [Test]
+        public void ProxyIdShouldBeUnique()
+        {
+            var proxy1 = Substitute.For<IInterface>();
+            var proxy2 = Substitute.For<IInterface>();
+
+            var id1 = proxy1.ToString();
+            var id2 = proxy2.ToString();
+
+            Assert.That(id1, Is.Not.EqualTo(id2));
+        }
+
+        [Test]
+        public void ShouldGenerateIdForTypeWithDefaultToString()
+        {
+            var proxy1 = Substitute.For<ClassWithDefaultToString>();
+            var proxy2 = Substitute.For<ClassWithDefaultToString>();
+
+            var id1 = proxy1.ToString();
+            var id2 = proxy2.ToString();
+
+            Assert.That(id1, Is.Not.EqualTo(id2));
+        }
+
+        [Test]
+        public void ShouldNotGenerateIdForTypesWithOverloadedToString()
+        {
+            var proxy = Substitute.For<ClassWithOverloadedToString>();
+
+            var id = proxy.ToString();
+
+            Assert.That(id, Is.EqualTo(ClassWithOverloadedToString.ToStringValue));
+        }
+
+        [Test]
+        public void ShouldContainFullGenericTypeName()
+        {
+            var proxy = Substitute.For<IGenericInterface<byte>>();
+
+            var id = proxy.ToString();
+
+            Assert.That(id, Contains.Substring("IGenericInterface<Byte>"));
+        }
+
+        public interface IInterface
+        {
+            int SomeMethod();
+        }
+
+        public interface IOtherInterface
+        {
+            int SomeMethod();
+        }
+
+        public interface IGenericInterface<T>
+        {
+            T SomeMethod();
+        }
+
+        public class ClassWithDefaultToString
+        {
+            public virtual int SomeMethod() => 0;
+        }
+
+        public class ClassWithOverloadedToString
+        {
+            public const string ToStringValue = "42";
+
+            public virtual int SomeMethod() => 0;
+            public override string ToString() => ToStringValue;
+        }
+    }
+}


### PR DESCRIPTION
Closes #44

In this PR I've implemented the proxy id feature. which allows to recognize the particular instance of the proxy. The ID looks like following:
```
Substitute.PrimaryProxyType#42
```

Where `PrimaryProxyType` - the short type name of the primary proxy type, `#42` - auto-incremented field (global counter, not per type).

To achieve the desired behavior I've changed the following:
1. Always make a substitute for the class. If interfaces are specified only, we substitute for the `System.Object`. That is required to intercept the `ToString()` method, otherwise Castle doesn't hook it.
2. Add the `ProxyIdInterceptor` to return proxy id when `ToString()` is called. Given that our interceptor participates earlier than forwarding one, calls to the `ToString()` are transparent for the NSubstutite core.
3. We do not intercept `ToString()` if type has its own implementation.

I've tested the code and it works fine in VS debugger - proxy ID is shown for the debugger view:
![image](https://user-images.githubusercontent.com/1074182/37346189-594500c4-26d7-11e8-95e9-5f572abbc516.png)

Due to some reasons Rider doesn't want to evaluate `ToString()`, however we can still see the proxy ID:
![image](https://user-images.githubusercontent.com/1074182/37346279-96923d7a-26d7-11e8-97b0-67b81d40be76.png)

Hope one day they will improve their evaluator and it will invoke the complex `ToString()` method as well.

Of course, everything works fine with assertions, as they invoke `ToString()` method:
```c#
        [Test]
        public void CollectionAssertion()
        {
            var array = new[] {Substitute.For<IInterface>(), Substitute.For<IInterface>()};
            var item = Substitute.For<IInterface>();
            
            Assert.That(array, Contains.Item(item));
        }
```
and error:
```
  Expected: some item equal to <NSubstitute.Proxy.IInterface#3>
  But was:  < <NSubstitute.Proxy.IInterface#1>, <NSubstitute.Proxy.IInterface#2> >
```

-----
I don't like a bit that now we are always forced to create proxy for the class. However, that should not affect the performance too much and the benefit seems to worth it.

@alexandrnikitin @dtchepak Please take a look and let me know your opinion. Thanks 🌹 