### PR TITLE
Improve delegate proxy generation

### DIFF
--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using Castle.DynamicProxy;
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
@@ -33,6 +34,15 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             var proxy = CreateProxyUsingCastleProxyGenerator(typeToProxy, additionalInterfaces, constructorArguments, interceptor, proxyGenerationOptions);
             interceptor.StartIntercepting();
             return proxy;
+        }
+
+        /// <summary>
+        /// Allows to dynamically create a type in runtime. Returns an instance of <see cref="TypeBuilder"/>,
+        /// so type could be customized and built later.
+        /// </summary>
+        public TypeBuilder DefineDynamicType(string typeName, TypeAttributes flags)
+        {
+            return _proxyGenerator.ProxyBuilder.ModuleScope.DefineType(true, typeName, flags);
         }
 
         private object CreateProxyUsingCastleProxyGenerator(Type typeToProxy, Type[] additionalInterfaces,

--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -7,25 +7,20 @@ using System.Reflection.Emit;
 using System.Threading;
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
+using NSubstitute.Proxies.CastleDynamicProxy;
 
 namespace NSubstitute.Proxies.DelegateProxy
 {
     public class DelegateProxyFactory : IProxyFactory
     {
         private const string MethodNameInsideProxyContainer = "Invoke";
-        private readonly IProxyFactory _objectProxyFactory;
-        private readonly ModuleBuilder _moduleBuilder;
+        private readonly CastleDynamicProxyFactory _castleObjectProxyFactory;
         private readonly ConcurrentDictionary<Type, Type> _delegateContainerCache = new ConcurrentDictionary<Type, Type>();
         private long _typeSuffixCounter;
 
-        public DelegateProxyFactory(IProxyFactory objectProxyFactory)
+        public DelegateProxyFactory(CastleDynamicProxyFactory objectProxyFactory)
         {
-            _objectProxyFactory = objectProxyFactory;
-
-            const string dynamicAssemblyName = "NSubsituteDelegateProxyTypes";
-            _moduleBuilder = AssemblyBuilder
-                .DefineDynamicAssembly(new AssemblyName(dynamicAssemblyName), AssemblyBuilderAccess.Run)
-                .DefineDynamicModule(dynamicAssemblyName);
+            _castleObjectProxyFactory = objectProxyFactory;
         }
         
         public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
@@ -54,26 +49,27 @@ namespace NSubstitute.Proxies.DelegateProxy
             var delegateContainer = _delegateContainerCache.GetOrAdd(delegateType, GenerateDelegateContainerInterface);
             var invokeMethod = delegateContainer.GetMethod(MethodNameInsideProxyContainer);
 
-            var proxy = _objectProxyFactory.GenerateProxy(callRouter, delegateContainer, Type.EmptyTypes, null);
+            var proxy = _castleObjectProxyFactory.GenerateProxy(callRouter, delegateContainer, Type.EmptyTypes, null);
             return invokeMethod.CreateDelegate(delegateType, proxy);
         }
 
         private Type GenerateDelegateContainerInterface(Type delegateType)
         {
-            lock (_moduleBuilder)
-            {
-                return GenerateDelegateContainerInterfaceNoLock(delegateType);
-            }
-        }
-
-        private Type GenerateDelegateContainerInterfaceNoLock(Type delegateType)
-        {
             var delegateSignature = delegateType.GetMethod("Invoke");
 
             var typeSuffixCounter = Interlocked.Increment(ref _typeSuffixCounter);
-            var typeName = "DelegateContainer_" + typeSuffixCounter.ToString(CultureInfo.InvariantCulture);
+            var delegateTypeName = delegateType.GetTypeInfo().IsGenericType
+                ? delegateType.Name.Substring(0, delegateType.Name.IndexOf("`", StringComparison.Ordinal))
+                : delegateType.Name;
+            var typeName = string.Format(
+                "DelegateContainer_{0}_{1}",
+                delegateTypeName,
+                typeSuffixCounter.ToString(CultureInfo.InvariantCulture));
 
-            var typeBuilder = _moduleBuilder.DefineType( typeName, TypeAttributes.Abstract | TypeAttributes.Interface | TypeAttributes.Public);
+            var typeBuilder = _castleObjectProxyFactory.DefineDynamicType(
+                typeName,
+                TypeAttributes.Abstract | TypeAttributes.Interface | TypeAttributes.Public);
+
             var methodBuilder = typeBuilder
                 .DefineMethod(
                     MethodNameInsideProxyContainer,

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -346,6 +346,19 @@ namespace NSubstitute.Acceptance.Specs
             });
         }
 
+        public delegate string DelegateWithOutParameter(string input, out string result);
+
+        [Test]
+        public void Should_recognize_out_parameters_for_delegate_and_match_specification()
+        {
+            var subs = Substitute.For<DelegateWithOutParameter>();
+
+            subs.Invoke(Arg.Any<string>(), out string _).Returns("42");
+
+            var result = subs("foo", out string _);
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
         [SetUp]
         public void SetUp()
         {

--- a/tests/NSubstitute.Acceptance.Specs/PerfTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/PerfTests.cs
@@ -85,6 +85,18 @@ namespace NSubstitute.Acceptance.Specs
             }
         }
 
+        [Test]
+        public void Delegate_proxy_container_is_cached()
+        {
+            var subs1 = Substitute.For<Func<int, byte>>();
+            var subs2 = Substitute.For<Func<int, byte>>();
+
+            var containerType1 = subs1.Target.GetType();
+            var containerType2 = subs2.Target.GetType();
+
+            Assert.That(containerType1, Is.EqualTo(containerType2));
+        }
+
         public interface IFoo { int GetInt(string s); }
         public interface IBar { int GetInt<T>(T t); }
         public interface IByteArraySource { byte[] GetArray(); }


### PR DESCRIPTION
It's always great to use somebody else's experience and improve your own product, even if you are the competitors 😅 Today I've reviewed how Moq create delegate proxies and found that we can improve our own implementation:
1. We can re-use Castle's type generator and do not define our own dynamic assembly. That's a win for both the performance and the maintenance.
2. I found that I've skipped the method attributes copy, so `out` parameters were not recognized for our delegates. Fixed that.

Fixed both the issues in this PR and simplified the code a bit 😃 