### PR TITLE
Fix ArgumentNullException on the finalizer thread

### DIFF
--- a/src/NSubstitute/Core/RobustThreadLocal.cs
+++ b/src/NSubstitute/Core/RobustThreadLocal.cs
@@ -8,23 +8,44 @@ namespace NSubstitute.Core
     /// These can occur if the Value property is accessed from the finalizer thread. Because we can't detect this, we'll
     /// just swallow the exception (the finalizer thread won't be using any of the values from thread local storage anyway).
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    class RobustThreadLocal<T>
+    internal class RobustThreadLocal<T>
     {
-        readonly ThreadLocal<T> _threadLocal;
-        public RobustThreadLocal() { _threadLocal = new ThreadLocal<T>(); }
-        public RobustThreadLocal(Func<T> initialValue) { _threadLocal = new ThreadLocal<T>(initialValue); }
+        private readonly ThreadLocal<T> _threadLocal;
+        private readonly Func<T> _initalValueFactory;
+
+        public RobustThreadLocal()
+        {
+            _threadLocal = new ThreadLocal<T>();
+        }
+
+        public RobustThreadLocal(Func<T> initialValueFactory)
+        {
+            _initalValueFactory = initialValueFactory ?? throw new ArgumentNullException(nameof(initialValueFactory));
+            _threadLocal = new ThreadLocal<T>(initialValueFactory);
+        }
+
         public T Value
         {
             get
             {
-                try { return _threadLocal.Value; }
-                catch (ObjectDisposedException) { return default(T); }
+                try
+                {
+                    return _threadLocal.Value;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return _initalValueFactory != null ? _initalValueFactory.Invoke() : default(T);
+                }
             }
             set
             {
-                try { _threadLocal.Value = value; }
-                catch (ObjectDisposedException) { }
+                try
+                {
+                    _threadLocal.Value = value;
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #381.

It's incorrect to return `null` when thread local value is not available - the caller doesn't expect that and later fails on the null guard. Therefore, code was fixed to return the initial value if unable to read the current value.

Unfortunately, I was unable to write a unit test to verify that. The order of the finalization is not predictable and I was unable to force it to finalize `ThreadLocal<>` before finalizing the substitute.