### PR TITLE
Allow to run arbitrary queries on ThreadLocalContext

### DIFF
--- a/src/NSubstitute/Core/CallSpecAndTarget.cs
+++ b/src/NSubstitute/Core/CallSpecAndTarget.cs
@@ -2,8 +2,8 @@ namespace NSubstitute.Core
 {
     public class CallSpecAndTarget
     {
-        public ICallSpecification CallSpecification { get; private set; }
-        public object Target { get; private set; }
+        public ICallSpecification CallSpecification { get; }
+        public object Target { get; }
 
         public CallSpecAndTarget(ICallSpecification callSpecification, object target)
         {

--- a/src/NSubstitute/Core/IQuery.cs
+++ b/src/NSubstitute/Core/IQuery.cs
@@ -1,0 +1,7 @@
+﻿namespace NSubstitute.Core
+{
+    public interface IQuery
+    {
+        void RegisterCall(ICall call);
+    }
+}

--- a/src/NSubstitute/Core/ISubstitutionContext.cs
+++ b/src/NSubstitute/Core/ISubstitutionContext.cs
@@ -50,7 +50,7 @@ namespace NSubstitute.Core
         Func<ICall, object[]> DequeuePendingRaisingEventArguments();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RunQuery) + "() method instead.")]
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RunInQueryContext) + "() method instead.")]
         IQueryResults RunQuery(Action calls);
 
         [Obsolete("This property is obsolete and will be removed in a future version of the product. " +
@@ -58,7 +58,8 @@ namespace NSubstitute.Core
         bool IsQuerying { get; }
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.AddToQuery) + "() method instead.")]
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RegisterInContextQuery) + "() method instead.",
+                  error: true)]
         void AddToQuery(object target, ICallSpecification callSpecification);
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +

--- a/src/NSubstitute/Core/IThreadLocalContext.cs
+++ b/src/NSubstitute/Core/IThreadLocalContext.cs
@@ -22,7 +22,10 @@ namespace NSubstitute.Core
         Func<ICall, object[]> UsePendingRaisingEventArgumentsFactory();
 
         bool IsQuerying { get; }
-        IQueryResults RunQuery(Action calls);
-        void AddToQuery(object target, ICallSpecification callSpecification);
+        /// <summary>
+        /// Invokes the passed callback in a context of the specified query.
+        /// </summary>
+        void RunInQueryContext(Action calls, IQuery query);
+        void RegisterInContextQuery(ICall call);
     }
 }

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -151,13 +151,24 @@ namespace NSubstitute.Core
             ThreadContext.UsePendingRaisingEventArgumentsFactory();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.AddToQuery) + "() method instead.")]
-        public void AddToQuery(object target, ICallSpecification callSpecification) =>
-            ThreadContext.AddToQuery(target, callSpecification);
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RegisterInContextQuery) + "() method instead.",
+                  error: true)]
+        public void AddToQuery(object target, ICallSpecification callSpecification)
+        {
+            // We cannot simulate the API anymore as it changed drastically.
+            // That should be fine, as this method was expected to be called from the NSubstitute core only.
+            throw new NotSupportedException(
+                "This API was obsolete and is not supported anymore. " +
+                "Please Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RegisterInContextQuery) + "() method instead.");
+        }
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RunQuery) + "() method instead.")]
-        public IQueryResults RunQuery(Action calls) =>
-            ThreadContext.RunQuery(calls);
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RunInQueryContext) + "() method instead.")]
+        public IQueryResults RunQuery(Action calls)
+        {
+            var query = new Query();
+            ThreadContext.RunInQueryContext(calls, query);
+            return query.Result();
+        }
     }
 }

--- a/src/NSubstitute/Core/ThreadLocalContext.cs
+++ b/src/NSubstitute/Core/ThreadLocalContext.cs
@@ -12,7 +12,7 @@ namespace NSubstitute.Core
         private readonly RobustThreadLocal<ICallRouter> _lastCallRouter;
         private readonly RobustThreadLocal<IList<IArgumentSpecification>> _argumentSpecifications;
         private readonly RobustThreadLocal<Func<ICall, object[]>> _getArgumentsForRaisingEvent;
-        private readonly RobustThreadLocal<Query> _currentQuery;
+        private readonly RobustThreadLocal<IQuery> _currentQuery;
         private readonly RobustThreadLocal<PendingSpecificationInfo> _pendingSpecificationInfo;
         public IPendingSpecification PendingSpecification { get; }
 
@@ -21,7 +21,7 @@ namespace NSubstitute.Core
             _lastCallRouter = new RobustThreadLocal<ICallRouter>();
             _argumentSpecifications = new RobustThreadLocal<IList<IArgumentSpecification>>(() => new List<IArgumentSpecification>());
             _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object[]>>();
-            _currentQuery = new RobustThreadLocal<Query>();
+            _currentQuery = new RobustThreadLocal<IQuery>();
             _pendingSpecificationInfo = new RobustThreadLocal<PendingSpecificationInfo>();
 
             PendingSpecification = new PendingSpecificationWrapper(_pendingSpecificationInfo);
@@ -96,9 +96,8 @@ namespace NSubstitute.Core
             return result;
         }
 
-        public IQueryResults RunQuery(Action calls)
+        public void RunInQueryContext(Action calls, IQuery query)
         {
-            var query = new Query();
             _currentQuery.Value = query;
             try
             {
@@ -108,18 +107,17 @@ namespace NSubstitute.Core
             {
                 _currentQuery.Value = null;
             }
-            return query.Result();
         }
 
         public bool IsQuerying => _currentQuery.Value != null;
 
-        public void AddToQuery(object target, ICallSpecification callSpecification)
+        public void RegisterInContextQuery(ICall call)
         {
             var query = _currentQuery.Value;
             if (query == null)
                 throw new NotRunningAQueryException();
 
-            query.Add(callSpecification, target);
+            query.RegisterCall(call);
         }
 
         private class PendingSpecificationWrapper : IPendingSpecification

--- a/src/NSubstitute/Received.cs
+++ b/src/NSubstitute/Received.cs
@@ -14,8 +14,9 @@ namespace NSubstitute
         /// <param name="calls">Action containing calls to substitutes in the expected order</param>
         public static void InOrder(Action calls)
         {
-            var queryResult = SubstitutionContext.Current.ThreadContext.RunQuery(calls);
-            new SequenceInOrderAssertion().Assert(queryResult);
+            var query = new Query();
+            SubstitutionContext.Current.ThreadContext.RunInQueryContext(calls, query);
+            new SequenceInOrderAssertion().Assert(query.Result());
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/AddCallToQueryResultHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/AddCallToQueryResultHandler.cs
@@ -5,19 +5,15 @@ namespace NSubstitute.Routing.Handlers
     public class AddCallToQueryResultHandler : ICallHandler
     {
         private readonly IThreadLocalContext _threadContext;
-        private readonly ICallSpecificationFactory _callSpecificationFactory;
 
-        public AddCallToQueryResultHandler(IThreadLocalContext threadContext, ICallSpecificationFactory callSpecificationFactory)
+        public AddCallToQueryResultHandler(IThreadLocalContext threadContext)
         {
             _threadContext = threadContext;
-            _callSpecificationFactory = callSpecificationFactory;
         }
 
         public RouteAction Handle(ICall call)
         {
-            var target = call.Target();
-            var callSpec = _callSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall);
-            _threadContext.AddToQuery(target, callSpec);
+            _threadContext.RegisterInContextQuery(call);
             return RouteAction.Continue();
         }
     }

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -19,7 +19,7 @@ namespace NSubstitute.Routing
         {
             return new Route(new ICallHandler[] {
                 new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
-                , new AddCallToQueryResultHandler(_threadLocalContext, state.CallSpecificationFactory)
+                , new AddCallToQueryResultHandler(_threadLocalContext)
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , ReturnDefaultForReturnTypeHandler()


### PR DESCRIPTION
Enabler for #220

Refactored `ThreadLocalContext` to allow to run arbitrary queries on it. Now I don't return any result from the method, because I know nothing about potential query result. Instead, the caller is responsible from extracting the query results from the passed query object.

Additionally, I've changed signature to receive `ICall` instead - the previous signature was _very specific_ to the kind of query we used.

@dtchepak Please take a look