### PR TITLE
Remove non-used PendingSpecificationInfo property

### DIFF
--- a/src/NSubstitute/Core/ThreadLocalContext.cs
+++ b/src/NSubstitute/Core/ThreadLocalContext.cs
@@ -27,12 +27,6 @@ namespace NSubstitute.Core
             PendingSpecification = new PendingSpecificationWrapper(_pendingSpecificationInfo);
         }
 
-        public PendingSpecificationInfo PendingSpecificationInfo
-        {
-            get => _pendingSpecificationInfo.Value;
-            set => _pendingSpecificationInfo.Value = value;
-        }
-
         public void SetLastCallRouter(ICallRouter callRouter)
         {
             _lastCallRouter.Value = callRouter;


### PR DESCRIPTION
A leftover after the #383. This member is not used anymore, however I forgot to remove it.