### PR TITLE
Create IAutoValueProvider factory with all supported providers

### DIFF
--- a/src/NSubstitute/Core/CallRouterFactory.cs
+++ b/src/NSubstitute/Core/CallRouterFactory.cs
@@ -1,34 +1,22 @@
+using System;
 using NSubstitute.Routing;
 
 namespace NSubstitute.Core
 {
     public class CallRouterFactory : ICallRouterFactory
     {
-        private readonly SequenceNumberGenerator _sequenceNumberGenerator;
+        private readonly IThreadLocalContext _threadLocalContext;
         private readonly IRouteFactory _routeFactory;
-        private readonly ICallSpecificationFactory _callSpecificationFactory;
-        private readonly ICallInfoFactory _callInfoFactory;
 
-        public CallRouterFactory(SequenceNumberGenerator sequenceNumberGenerator,
-            IRouteFactory routeFactory,
-            ICallSpecificationFactory callSpecificationFactory,
-            ICallInfoFactory callInfoFactory)
+        public CallRouterFactory(IThreadLocalContext threadLocalContext, IRouteFactory routeFactory)
         {
-            _sequenceNumberGenerator = sequenceNumberGenerator;
-            _routeFactory = routeFactory;
-            _callSpecificationFactory = callSpecificationFactory;
-            _callInfoFactory = callInfoFactory;
+            _threadLocalContext = threadLocalContext ?? throw new ArgumentNullException(nameof(threadLocalContext));
+            _routeFactory = routeFactory ?? throw new ArgumentNullException(nameof(routeFactory));
         }
 
-        public ICallRouter Create(SubstituteConfig config, IThreadLocalContext threadContext, ISubstituteFactory substituteFactory)
+        public ICallRouter Create(ISubstituteState substituteState)
         {
-            var substituteState = new SubstituteState(config,
-                _sequenceNumberGenerator,
-                substituteFactory,
-                _callSpecificationFactory,
-                _callInfoFactory);
-
-            return new CallRouter(substituteState, threadContext, _routeFactory);
+            return new CallRouter(substituteState, _threadLocalContext, _routeFactory);
         }
     }
 }

--- a/src/NSubstitute/Core/ICallRouterFactory.cs
+++ b/src/NSubstitute/Core/ICallRouterFactory.cs
@@ -2,6 +2,6 @@ namespace NSubstitute.Core
 {
     public interface ICallRouterFactory
     {
-        ICallRouter Create(SubstituteConfig config, IThreadLocalContext threadContext, ISubstituteFactory substituteFactory);
+        ICallRouter Create(ISubstituteState substituteState);
     }
 }

--- a/src/NSubstitute/Core/ISubstituteState.cs
+++ b/src/NSubstitute/Core/ISubstituteState.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System.Collections.Generic;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -11,7 +12,7 @@ namespace NSubstitute.Core
         SequenceNumberGenerator SequenceNumberGenerator { get; }
         IConfigureCall ConfigureCall { get; }
         IEventHandlerRegistry EventHandlerRegistry { get; }
-        IAutoValueProvider[] AutoValueProviders { get; }
+        IReadOnlyCollection<IAutoValueProvider> AutoValueProviders { get; }
         ICallResults AutoValuesCallResults { get; }
         ICallBaseExclusions CallBaseExclusions { get; }
         IResultsForType ResultsForType { get; }

--- a/src/NSubstitute/Core/ISubstituteStateFactory.cs
+++ b/src/NSubstitute/Core/ISubstituteStateFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace NSubstitute.Core
+{
+    public interface ISubstituteStateFactory
+    {
+        ISubstituteState Create(SubstituteConfig config, ISubstituteFactory substituteFactory);
+    }
+}

--- a/src/NSubstitute/Core/SubstituteState.cs
+++ b/src/NSubstitute/Core/SubstituteState.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System.Collections.Generic;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -12,7 +13,7 @@ namespace NSubstitute.Core
         public SequenceNumberGenerator SequenceNumberGenerator { get; }
         public IConfigureCall ConfigureCall { get; }
         public IEventHandlerRegistry EventHandlerRegistry { get; }
-        public IAutoValueProvider[] AutoValueProviders { get; }
+        public IReadOnlyCollection<IAutoValueProvider> AutoValueProviders { get; }
         public ICallResults AutoValuesCallResults { get; }
         public IResultsForType ResultsForType { get; }
         public ICustomHandlers CustomHandlers { get; }
@@ -20,12 +21,13 @@ namespace NSubstitute.Core
         public SubstituteState(
             SubstituteConfig option,
             SequenceNumberGenerator sequenceNumberGenerator,
-            ISubstituteFactory substituteFactory,
             ICallSpecificationFactory callSpecificationFactory,
-            ICallInfoFactory callInfoFactory)
+            ICallInfoFactory callInfoFactory,
+            IReadOnlyCollection<IAutoValueProvider> autoValueProviders)
         {
             SubstituteConfig = option;
             SequenceNumberGenerator = sequenceNumberGenerator;
+            AutoValueProviders = autoValueProviders;
 
             var callCollection = new CallCollection();
             ReceivedCalls = callCollection;
@@ -40,14 +42,6 @@ namespace NSubstitute.Core
             ConfigureCall = new ConfigureCall(CallResults, CallActions, getCallSpec);
             EventHandlerRegistry = new EventHandlerRegistry();
 
-            AutoValueProviders = new IAutoValueProvider[] { 
-                new AutoObservableProvider(() => AutoValueProviders),
-                new AutoQueryableProvider(),
-                new AutoSubstituteProvider(substituteFactory),
-                new AutoStringProvider(),
-                new AutoArrayProvider(),
-                new AutoTaskProvider(() => AutoValueProviders),
-            };
         }
     }
 }

--- a/src/NSubstitute/Core/SubstituteStateFactory.cs
+++ b/src/NSubstitute/Core/SubstituteStateFactory.cs
@@ -1,0 +1,34 @@
+﻿using NSubstitute.Routing.AutoValues;
+
+namespace NSubstitute.Core
+{
+    public class SubstituteStateFactory : ISubstituteStateFactory
+    {
+        private readonly SequenceNumberGenerator _sequenceNumberGenerator;
+        private readonly ICallSpecificationFactory _callSpecificationFactory;
+        private readonly ICallInfoFactory _callInfoFactory;
+        private readonly IAutoValueProvidersFactory _autoValueProvidersFactory;
+
+        public SubstituteStateFactory(SequenceNumberGenerator sequenceNumberGenerator,
+            ICallSpecificationFactory callSpecificationFactory,
+            ICallInfoFactory callInfoFactory,
+            IAutoValueProvidersFactory autoValueProvidersFactory)
+        {
+            _sequenceNumberGenerator = sequenceNumberGenerator;
+            _callSpecificationFactory = callSpecificationFactory;
+            _callInfoFactory = callInfoFactory;
+            _autoValueProvidersFactory = autoValueProvidersFactory;
+        }
+
+        public ISubstituteState Create(SubstituteConfig config, ISubstituteFactory substituteFactory)
+        {
+            var autoValueProviders = _autoValueProvidersFactory.CreateProviders(substituteFactory);
+
+            return new SubstituteState(config,
+                _sequenceNumberGenerator,
+                _callSpecificationFactory,
+                _callInfoFactory,
+                autoValueProviders);
+        }
+    }
+}

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -5,6 +5,7 @@ using NSubstitute.Proxies;
 using NSubstitute.Proxies.CastleDynamicProxy;
 using NSubstitute.Proxies.DelegateProxy;
 using NSubstitute.Routing;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
@@ -34,12 +35,14 @@ namespace NSubstitute.Core
 
             var sequenceNumberGenerator = new SequenceNumberGenerator();
             var callInfoFactory = new CallInfoFactory();
-            var callRouterFactory = new CallRouterFactory(sequenceNumberGenerator, RouteFactory, callSpecificationFactory, callInfoFactory);
+            var autoValueProvidersFactory = new AutoValueProvidersFactory();
+            var substituteStateFactory = new SubstituteStateFactory(sequenceNumberGenerator, callSpecificationFactory, callInfoFactory, autoValueProvidersFactory);
+            var callRouterFactory = new CallRouterFactory(ThreadContext, RouteFactory);
             var argSpecificationQueue = new ArgumentSpecificationDequeue(ThreadContext.DequeueAllArgumentSpecifications);
             var dynamicProxyFactory = new CastleDynamicProxyFactory(argSpecificationQueue);
             var delegateFactory = new DelegateProxyFactory(dynamicProxyFactory);
             var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
-            SubstituteFactory = new SubstituteFactory(ThreadContext, callRouterFactory, proxyFactory);
+            SubstituteFactory = new SubstituteFactory(substituteStateFactory, callRouterFactory, proxyFactory);
 #pragma warning disable 618 // Obsolete
             SequenceNumberGenerator = sequenceNumberGenerator;
 #pragma warning restore 618 // Obsolete

--- a/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Core;
@@ -7,9 +8,9 @@ namespace NSubstitute.Routing.AutoValues
 {
     public class AutoObservableProvider : IAutoValueProvider
     {
-        private readonly Func<IAutoValueProvider[]> _autoValueProviders;
+        private readonly Lazy<IReadOnlyCollection<IAutoValueProvider>> _autoValueProviders;
 
-        public AutoObservableProvider(Func<IAutoValueProvider[]> autoValueProviders)
+        public AutoObservableProvider(Lazy<IReadOnlyCollection<IAutoValueProvider>> autoValueProviders)
         {
             _autoValueProviders = autoValueProviders;
         }
@@ -25,7 +26,7 @@ namespace NSubstitute.Routing.AutoValues
                 throw new InvalidOperationException();
 
             Type innerType = type.GetGenericArguments()[0];
-            var valueProvider = _autoValueProviders().FirstOrDefault(vp => vp.CanProvideValueFor(innerType));
+            var valueProvider = _autoValueProviders.Value.FirstOrDefault(vp => vp.CanProvideValueFor(innerType));
             var value = valueProvider == null ? GetDefault(type) : valueProvider.GetValue(innerType);
             return Activator.CreateInstance(
                     typeof(ReturnObservable<>).MakeGenericType(innerType)

--- a/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -7,9 +8,9 @@ namespace NSubstitute.Routing.AutoValues
 {
     public class AutoTaskProvider : IAutoValueProvider
     {
-        private readonly Func<IAutoValueProvider[]> _autoValueProviders;
+        private readonly Lazy<IReadOnlyCollection<IAutoValueProvider>> _autoValueProviders;
 
-        public AutoTaskProvider(Func<IAutoValueProvider[]> autoValueProviders)
+        public AutoTaskProvider(Lazy<IReadOnlyCollection<IAutoValueProvider>> autoValueProviders)
         {
             _autoValueProviders = autoValueProviders;
         }
@@ -27,7 +28,7 @@ namespace NSubstitute.Routing.AutoValues
             if (type.GetTypeInfo().IsGenericType)
             {
                 var taskType = type.GetGenericArguments()[0];
-                var valueProvider = _autoValueProviders().FirstOrDefault(vp => vp.CanProvideValueFor(taskType));
+                var valueProvider = _autoValueProviders.Value.FirstOrDefault(vp => vp.CanProvideValueFor(taskType));
 
                 var value = valueProvider == null ? GetDefault(type) : valueProvider.GetValue(taskType);
                 var taskCompletionSourceType = typeof(TaskCompletionSource<>).MakeGenericType(taskType);

--- a/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using NSubstitute.Core;
+
+namespace NSubstitute.Routing.AutoValues
+{
+    public class AutoValueProvidersFactory : IAutoValueProvidersFactory
+    {
+        public IReadOnlyCollection<IAutoValueProvider> CreateProviders(ISubstituteFactory substituteFactory)
+        {
+            IAutoValueProvider[] result = null;
+            var lazyResult = new Lazy<IReadOnlyCollection<IAutoValueProvider>>(
+                () => result ?? throw new InvalidOperationException("Value was not constructed yet."),
+                LazyThreadSafetyMode.None);
+
+            result = new IAutoValueProvider[]
+            {
+                new AutoObservableProvider(lazyResult),
+                new AutoQueryableProvider(),
+                new AutoSubstituteProvider(substituteFactory),
+                new AutoStringProvider(),
+                new AutoArrayProvider(),
+                new AutoTaskProvider(lazyResult)
+            };
+
+            return result;
+        }
+    }
+}

--- a/src/NSubstitute/Routing/AutoValues/IAutoValueProvidersFactory.cs
+++ b/src/NSubstitute/Routing/AutoValues/IAutoValueProvidersFactory.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using NSubstitute.Core;
+
+namespace NSubstitute.Routing.AutoValues
+{
+    public interface IAutoValueProvidersFactory
+    {
+        IReadOnlyCollection<IAutoValueProvider> CreateProviders(ISubstituteFactory substituteFactory);
+    }
+}


### PR DESCRIPTION
Previously the list of the supported auto-value providers was hardcoded in the `SubstituteState` constructor. Now it's possible to customize that list by injecting customized `IAutoValueProvidersFactory` to the `SubstituteFactory` (via its dependencies). IMO, it should satisfy #150.

That's one more step to control most of the NSubstitute behavior via the single dependency injection point.

Additionally, I've refactored the `CallRouterFactory` to take the `ThreadLocal` dependency via constructor, rather than via parameter.

@dtchepak Please take a look 😉 