### PR TITLE
Minor performance improvements

### DIFF
--- a/src/NSubstitute/Core/CallActions.cs
+++ b/src/NSubstitute/Core/CallActions.cs
@@ -39,10 +39,14 @@ namespace NSubstitute.Core
 	    }
 
 	    public void InvokeMatchingActions(ICall call)
-        {
-            var callInfo = _callInfoFactory.Create(call);
+	    {
+	        CallInfo callInfo = null;
             foreach (var action in _actions.Where(x => x.IsSatisfiedBy(call)))
             {
+                // Optimization. Initialize call lazily, as most of times there are no callbacks.
+                if (callInfo == null)
+                    callInfo = _callInfoFactory.Create(call);
+
                 action.Invoke(callInfo);
             }
         }

--- a/src/NSubstitute/Core/CallActions.cs
+++ b/src/NSubstitute/Core/CallActions.cs
@@ -33,19 +33,24 @@ namespace NSubstitute.Core
             }
         }
 
-	    public void Clear()
-	    {
-		    _actions.Clear();
-	    }
+        public void Clear()
+        {
+            _actions.Clear();
+        }
 
-	    public void InvokeMatchingActions(ICall call)
-	    {
-	        CallInfo callInfo = null;
-            foreach (var action in _actions.Where(x => x.IsSatisfiedBy(call)))
+        public void InvokeMatchingActions(ICall call)
+        {
+            CallInfo callInfo = null;
+            foreach (var action in _actions)
             {
+                if (!action.IsSatisfiedBy(call))
+                    continue;
+
                 // Optimization. Initialize call lazily, as most of times there are no callbacks.
                 if (callInfo == null)
+                {
                     callInfo = _callInfoFactory.Create(call);
+                }
 
                 action.Invoke(callInfo);
             }

--- a/src/NSubstitute/Core/CallInfoFactory.cs
+++ b/src/NSubstitute/Core/CallInfoFactory.cs
@@ -14,12 +14,12 @@ namespace NSubstitute.Core
         private static IEnumerable<Argument> GetArgumentsFromCall(ICall call)
         {
             var values = call.GetArguments();
-            var types = call.GetParameterInfos().Select(x => x.ParameterType).ToArray();
+            var parameterInfos = call.GetParameterInfos();
 
             for (var index = 0; index < values.Length; index++)
             {
                 var i = index;
-                yield return new Argument(types[i], () => values[i], x => values[i] = x);
+                yield return new Argument(parameterInfos[i].ParameterType, () => values[i], x => values[i] = x);
             }
         }
     }

--- a/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
@@ -24,11 +24,11 @@ namespace NSubstitute.Routing.Handlers
 
         private void If(ICall call, Func<ICall, Predicate<EventInfo>> meetsThisSpecification, Action<string, object> takeThisAction)
         {
-            var events = GetEvents(call, meetsThisSpecification);
-            if (events.Any())
+            var matchingEvent = GetEvents(call, meetsThisSpecification).FirstOrDefault();
+            if (matchingEvent != null)
             {
-                takeThisAction(events.First().Name, call.GetArguments()[0]);
-            }            
+                takeThisAction(matchingEvent.Name, call.GetArguments()[0]);
+            }
         }
 
         private Predicate<EventInfo> IsEventSubscription(ICall call)

--- a/src/NSubstitute/Routing/Route.cs
+++ b/src/NSubstitute/Routing/Route.cs
@@ -1,35 +1,40 @@
 using System.Collections.Generic;
-using System.Linq;
 using NSubstitute.Core;
 
 namespace NSubstitute.Routing
 {
-    public enum RouteType { Other, RecordReplay };
+    public enum RouteType { Other, RecordReplay }
 
     public class Route : IRoute
     {
-        private readonly bool _isRecordReplayRoute;
-        private readonly IEnumerable<ICallHandler> _handlers;
+        private readonly ICallHandler[] _handlers;
 
-        public Route(IEnumerable<ICallHandler> handlers) : this(RouteType.Other, handlers) { }
+        public Route(ICallHandler[] handlers) : this(RouteType.Other, handlers) { }
 
-        public Route(RouteType routeType, IEnumerable<ICallHandler> handlers)
+        public Route(RouteType routeType, ICallHandler[] handlers)
         {
-            _isRecordReplayRoute = routeType == RouteType.RecordReplay;
+            IsRecordReplayRoute = routeType == RouteType.RecordReplay;
             _handlers = handlers;
         }
 
-        public bool IsRecordReplayRoute { get { return _isRecordReplayRoute; } }
+        public bool IsRecordReplayRoute { get; }
 
-        public IEnumerable<ICallHandler> Handlers
-        {
-            get { return _handlers; }
-        }
+        public IEnumerable<ICallHandler> Handlers => _handlers;
 
         public object Handle(ICall call)
         {
-            var result = Handlers.Select(x => x.Handle(call)).FirstOrDefault(x => x.HasReturnValue);
-            return result == null ? null : result.ReturnValue;
+            // This is a hot method which is invoked frequently and has major impact on performance.
+            // Therefore, the LINQ cycle was unwinded to for loop.
+            for (int i = 0; i < _handlers.Length; i++)
+            {
+                var result = _handlers[i].Handle(call);
+                if (result.HasReturnValue)
+                {
+                    return result.ReturnValue;
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
I benchmarked the code and found a couple of hot places that could improve call dispatch performance a bit. Also change inside the `Router.Route()` method allows to easily debug code and makes call stack nicer.

Benchmark results:
```
BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3914066 Hz, Resolution=255.4888 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0

BASE:
                            Method |        Mean |      Error |     StdDev |
---------------------------------- |------------:|-----------:|-----------:|
 InvokeRegularMethodInterfaceProxy | 3,974.54 ns | 48.6592 ns | 45.5159 ns |
     InvokeRegularMethodClassProxy | 6,180.20 ns | 39.3871 ns | 34.9156 ns |

     

FIRST COMMIT:
                            Method |     Mean |     Error |    StdDev |
---------------------------------- |---------:|----------:|----------:|
 InvokeRegularMethodInterfaceProxy | 3.335 us | 0.0315 us | 0.0294 us |
     InvokeRegularMethodClassProxy | 5.636 us | 0.0590 us | 0.0552 us |
     
     
SECOND:
                            Method |     Mean |     Error |    StdDev |
---------------------------------- |---------:|----------:|----------:|
 InvokeRegularMethodInterfaceProxy | 3.236 us | 0.0643 us | 0.0601 us |
     InvokeRegularMethodClassProxy | 5.353 us | 0.1326 us | 0.1176 us |
```

@dtchepak Please take a look.