### PR TITLE
Add quick test whether method is event/property part

### DIFF
--- a/src/NSubstitute/Core/ReflectionExtensions.cs
+++ b/src/NSubstitute/Core/ReflectionExtensions.cs
@@ -8,6 +8,8 @@ namespace NSubstitute.Core
     {
         public static PropertyInfo GetPropertyFromSetterCallOrNull(this MethodInfo call)
         {
+            if(!CanBePropertySetterCall(call)) return null;
+
             var properties = call.DeclaringType.GetProperties();
             return properties.FirstOrDefault(x => x.GetSetMethod() == call);
         }
@@ -21,6 +23,14 @@ namespace NSubstitute.Core
         public static bool IsParams(this ParameterInfo parameterInfo)
         {
             return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
+        }
+
+        private static bool CanBePropertySetterCall(MethodInfo call)
+        {
+            // It's safe to verify method prefix and signature as according to the ECMA-335 II.22.28:
+            // 10. Any setter method for a property whose Name is xxx shall be called set_xxx [CLS]
+            // 13. Any getter and setter methods shall have Method.Flags.SpecialName = 1 [CLS] 
+            return call.IsSpecialName && call.Name.StartsWith("set_", StringComparison.Ordinal);
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
@@ -17,12 +17,30 @@ namespace NSubstitute.Routing.Handlers
 
         public RouteAction Handle(ICall call)
         {
-            If(call, IsEventSubscription, _eventHandlerRegistry.Add);
-            If(call, IsEventUnsubscription, _eventHandlerRegistry.Remove);
+            if (CanBeSubscribeUnsubscribeCall(call))
+            {
+                If(call, IsEventSubscription, _eventHandlerRegistry.Add);
+                If(call, IsEventUnsubscription, _eventHandlerRegistry.Remove);
+            }
+
             return RouteAction.Continue();
         }
 
-        private void If(ICall call, Func<ICall, Predicate<EventInfo>> meetsThisSpecification, Action<string, object> takeThisAction)
+        private static bool CanBeSubscribeUnsubscribeCall(ICall call)
+        {
+            var methodInfo = call.GetMethodInfo();
+            var methodName = methodInfo.Name;
+            
+            // It's safe to verify method prefix and signature as according to the ECMA-335 II.22.28:
+            // 18. Any AddOn method for an event whose Name is xxx shall have the signature: void add_xxx (<DelegateType> handler) (§I.10.4) [CLS] 
+            // 19. Any RemoveOn method for an event whose Name is xxx shall have the signature: void remove_xxx(<DelegateType> handler) (§I.10.4) [CLS]
+            return methodInfo.IsSpecialName && 
+                   methodInfo.ReturnType == typeof(void) &&
+                   ( methodName.StartsWith("add_", StringComparison.Ordinal) ||
+                     methodName.StartsWith("remove_", StringComparison.Ordinal));
+        }
+
+        private static void If(ICall call, Func<ICall, Predicate<EventInfo>> meetsThisSpecification, Action<string, object> takeThisAction)
         {
             var matchingEvent = GetEvents(call, meetsThisSpecification).FirstOrDefault();
             if (matchingEvent != null)
@@ -31,17 +49,17 @@ namespace NSubstitute.Routing.Handlers
             }
         }
 
-        private Predicate<EventInfo> IsEventSubscription(ICall call)
+        private static Predicate<EventInfo> IsEventSubscription(ICall call)
         {
             return x => call.GetMethodInfo() == x.GetAddMethod();
         }
 
-        private Predicate<EventInfo> IsEventUnsubscription(ICall call)
+        private static Predicate<EventInfo> IsEventUnsubscription(ICall call)
         {
             return x => call.GetMethodInfo() == x.GetRemoveMethod();
         }
 
-        private IEnumerable<EventInfo> GetEvents(ICall call, Func<ICall, Predicate<EventInfo>> createPredicate)
+        private static IEnumerable<EventInfo> GetEvents(ICall call, Func<ICall, Predicate<EventInfo>> createPredicate)
         {
             var predicate = createPredicate(call);
             return call.GetMethodInfo().DeclaringType.GetEvents().Where(x => predicate(x));


### PR DESCRIPTION
I've found a way to improve a few more places, making the call dispatch performance even better. According to the ECMA special methods have special names, so we could use that to omit expensive look ups for each call.

Benchmarking:
```
ENVIRONMENT:

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 2 [1703, Creators Update] (10.0.15063.786)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3320308 Hz, Resolution=301.1769 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2558.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2558.0

BEFORE:
                            Method |     Mean |     Error |    StdDev |
---------------------------------- |---------:|----------:|----------:|
 InvokeRegularMethodInterfaceProxy | 3.853 us | 0.0764 us | 0.1096 us |
     InvokeRegularMethodClassProxy | 6.190 us | 0.1182 us | 0.1362 us |

AFTER:
                            Method |     Mean |     Error |    StdDev |
---------------------------------- |---------:|----------:|----------:|
 InvokeRegularMethodInterfaceProxy | 3.015 us | 0.0495 us | 0.0439 us |
     InvokeRegularMethodClassProxy | 5.430 us | 0.0909 us | 0.0759 us |
```

As you can see, the performance boost is ~20% without making the significant changes to the code 😄 

@alexandrnikitin @dtchepak Please take a look.