### PR TITLE
Optimize array allocation to boost the proxy activation performance

### DIFF
--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -63,14 +63,19 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             {
                 VerifyNoConstructorArgumentsGivenForInterface(constructorArguments);
 
-                var interfaces = new List<Type> {typeToProxy};
+                var interfacesArrayLength = additionalInterfaces != null ? additionalInterfaces.Length + 1 : 1;
+                var interfaces = new Type[interfacesArrayLength];
+
+                interfaces[0] = typeToProxy;
                 if (additionalInterfaces != null)
-                    interfaces.AddRange(additionalInterfaces);
+                {
+                    Array.Copy(additionalInterfaces, 0, interfaces, 1, additionalInterfaces.Length);
+                }
 
                 // We need to create a proxy for the object type, so we can intercept the ToString() method.
                 // Therefore, we put the desired primary interface to the secondary list.
                 typeToProxy = typeof(object);
-                additionalInterfaces = interfaces.ToArray();
+                additionalInterfaces = interfaces;
             }
 
             return _proxyGenerator.CreateClassProxy(typeToProxy,


### PR DESCRIPTION
Before:
```
                           Method |  Job | Runtime |     Mean |     Error |    StdDev |
--------------------------------- |----- |-------- |---------:|----------:|----------:|
        CreateInterfaceSubstitute |  Clr |     Clr | 5.470 us | 0.1092 us | 0.2327 us |
    CreateAbstractClassSubstitute |  Clr |     Clr | 4.750 us | 0.0927 us | 0.1104 us |
 CreateNonAbstractClassSubstitute |  Clr |     Clr | 5.132 us | 0.1020 us | 0.2152 us |
        CreateInterfaceSubstitute | Core |    Core | 6.364 us | 0.1405 us | 0.1504 us |
    CreateAbstractClassSubstitute | Core |    Core | 5.797 us | 0.0478 us | 0.0373 us |
 CreateNonAbstractClassSubstitute | Core |    Core | 5.924 us | 0.0578 us | 0.0482 us |
```

After:
```
                           Method |  Job | Runtime |      Mean |     Error |    StdDev |
--------------------------------- |----- |-------- |----------:|----------:|----------:|
        CreateInterfaceSubstitute |  Clr |     Clr |  5.265 us | 0.0632 us | 0.0591 us |
    CreateAbstractClassSubstitute |  Clr |     Clr |  4.928 us | 0.1326 us | 0.1944 us |
 CreateNonAbstractClassSubstitute |  Clr |     Clr |  4.991 us | 0.0493 us | 0.0412 us |
        CreateInterfaceSubstitute | Core |    Core |  6.382 us | 0.1283 us | 0.1920 us |
    CreateAbstractClassSubstitute | Core |    Core |  5.886 us | 0.0483 us | 0.0428 us |
 CreateNonAbstractClassSubstitute | Core |    Core |  5.825 us | 0.0399 us | 0.0373 us |

```

A very tiny, but still a win 😅 

@alexandrnikitin @dtchepak Please take a look 😉 