### PR TITLE
Improve ambiguous exception diagnostics capabilities

### DIFF
--- a/src/NSubstitute/Core/Arguments/AnyArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/AnyArgumentMatcher.cs
@@ -11,11 +11,8 @@ namespace NSubstitute.Core.Arguments
             _typeArgMustBeCompatibleWith = typeArgMustBeCompatibleWith;
         }
 
-        public override string ToString() { return "any " + _typeArgMustBeCompatibleWith.Name; }
+        public override string ToString() => "any " + _typeArgMustBeCompatibleWith.GetNonMangledTypeName();
 
-        public bool IsSatisfiedBy(object argument)
-        {
-            return argument.IsCompatibleWith(_typeArgMustBeCompatibleWith);
-        }
+        public bool IsSatisfiedBy(object argument) => argument.IsCompatibleWith(_typeArgMustBeCompatibleWith);
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
@@ -1,7 +1,13 @@
-﻿namespace NSubstitute.Core.Arguments
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace NSubstitute.Core.Arguments
 {
     public class ArgumentFormatter : IArgumentFormatter
     {
+        internal static IArgumentFormatter Default { get; } = new ArgumentFormatter();
+
         public string Format(object argument, bool highlight)
         {
             var formatted = Format(argument);
@@ -10,11 +16,20 @@
 
         private string Format(object arg)
         {
-            if (arg == null) return "<null>";
-            if (arg is string) return string.Format("\"{0}\"", arg);
-            var standardToString = arg.ToString();
-            if (standardToString == arg.GetType().ToString()) return arg.GetType().GetNonMangledTypeName();
-            return standardToString;
+            switch (arg)
+            {
+                case null:
+                    return "<null>";
+
+                case string str:
+                    return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", str);
+
+                case object obj when obj.GetType().GetMethod(nameof(ToString), Type.EmptyTypes).DeclaringType == typeof(object):
+                    return arg.GetType().GetNonMangledTypeName();
+
+                default:
+                    return arg.ToString();
+            }
        }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
@@ -4,7 +4,6 @@ namespace NSubstitute.Core.Arguments
 {
     public class ArgumentSpecification : IArgumentSpecification
     {
-        static readonly ArgumentFormatter Formatter = new ArgumentFormatter();
         static readonly Action<object> NoOpAction = x => { };
         readonly Type _forType;
         readonly IArgumentMatcher _matcher;
@@ -38,7 +37,9 @@ namespace NSubstitute.Core.Arguments
         {
             var isSatisfiedByArg = IsSatisfiedBy(argument);
             var matcherFormatter = _matcher as IArgumentFormatter;
-            return (matcherFormatter == null) ? Formatter.Format(argument, !isSatisfiedByArg) : matcherFormatter.Format(argument, isSatisfiedByArg);
+            return matcherFormatter == null
+                ? ArgumentFormatter.Default.Format(argument, !isSatisfiedByArg)
+                : matcherFormatter.Format(argument, isSatisfiedByArg);
         }
 
         public Type ForType { get { return _forType; } }

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationsFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace NSubstitute.Core.Arguments
 {
@@ -12,9 +13,10 @@ namespace NSubstitute.Core.Arguments
             _mixedArgumentSpecificationsFactory = mixedArgumentSpecificationsFactory;
         }
 
-        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MatchArgs matchArgs)
+        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs,
+            object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs)
         {
-            var argumentSpecifications = _mixedArgumentSpecificationsFactory.Create(argumentSpecs, arguments, parameterInfos);
+            var argumentSpecifications = _mixedArgumentSpecificationsFactory.Create(argumentSpecs, arguments, parameterInfos, methodInfo);
 
             return (matchArgs == MatchArgs.Any) 
                 ? argumentSpecifications.Select(x => x.CreateCopyMatchingAnyArgOfType(x.ForType))

--- a/src/NSubstitute/Core/Arguments/ArrayArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ArrayArgumentSpecificationsFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core.Arguments
 {
@@ -21,7 +22,15 @@ namespace NSubstitute.Core.Arguments
             var result = new List<IArgumentSpecification>();
             foreach (var member in arrayMembers)
             {
-                result.Add(_nonParamsArgumentSpecificationFactory.Create(member, parameterInfos.ElementAt(index), suppliedArgumentSpecifications)); 
+                try
+                {
+                    result.Add(_nonParamsArgumentSpecificationFactory.Create(member, parameterInfos.ElementAt(index), suppliedArgumentSpecifications));
+                }
+                catch (AmbiguousArgumentsException ex)
+                {
+                    ex.Data[AmbiguousArgumentsException.NonReportedResolvedSpecificationsKey] = result;
+                    throw;
+                }
                 index++;
             }
             return result;

--- a/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
@@ -6,7 +6,6 @@ namespace NSubstitute.Core.Arguments
 {
     public class ArrayContentsArgumentMatcher : IArgumentMatcher, IArgumentFormatter
     {
-        private static readonly IArgumentFormatter DefaultArgumentFormatter = new ArgumentFormatter();
         private readonly IEnumerable<IArgumentSpecification> _argumentSpecifications;
 
         public ArrayContentsArgumentMatcher(IEnumerable<IArgumentSpecification> argumentSpecifications)
@@ -50,7 +49,7 @@ namespace NSubstitute.Core.Arguments
             }
             return args.Select((arg, index) => {
                 var hasSpecForThisArg = index < specs.Length;
-                return hasSpecForThisArg ? specs[index].FormatArgument(arg) : DefaultArgumentFormatter.Format(arg, true);
+                return hasSpecForThisArg ? specs[index].FormatArgument(arg) : ArgumentFormatter.Default.Format(arg, true);
             });
         }
     }

--- a/src/NSubstitute/Core/Arguments/EqualsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/EqualsArgumentMatcher.cs
@@ -4,13 +4,15 @@ namespace NSubstitute.Core.Arguments
 {
     public class EqualsArgumentMatcher : IArgumentMatcher
     {
-        readonly static ArgumentFormatter DefaultArgumentFormatter = new ArgumentFormatter();
         private readonly object _value;
-        public EqualsArgumentMatcher(object value) { _value = value; }
-        public override string ToString() { return DefaultArgumentFormatter.Format(_value, false); }
-        public bool IsSatisfiedBy(object argument)
+
+        public EqualsArgumentMatcher(object value)
         {
-            return EqualityComparer<object>.Default.Equals(_value, argument);
+            _value = value;
         }
+
+        public override string ToString() => ArgumentFormatter.Default.Format(_value, false);
+
+        public bool IsSatisfiedBy(object argument) => EqualityComparer<object>.Default.Equals(_value, argument);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecificationsFactory.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentSpecificationsFactory
     {
-        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MatchArgs matchArgs);
+        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IMixedArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/IMixedArgumentSpecificationsFactory.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace NSubstitute.Core.Arguments
 {
     public interface IMixedArgumentSpecificationsFactory
     {
-        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos);
+        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo);
     }
 }

--- a/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
@@ -5,7 +5,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface ISuppliedArgumentSpecifications
     {
-        IEnumerable<IArgumentSpecification> AllSpecifications { get; }
         bool AnyFor(object argument, Type argumentType);
         bool IsNextFor(object argument, Type argumentType);
         IArgumentSpecification Dequeue();

--- a/src/NSubstitute/Core/Arguments/MixedArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/MixedArgumentSpecificationsFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core.Arguments
@@ -15,18 +16,36 @@ namespace NSubstitute.Core.Arguments
             _suppliedArgumentSpecificationsFactory = suppliedArgumentSpecificationsFactory;
         }
 
-        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos)
+        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo)
         {
             var suppliedArgumentSpecifications = _suppliedArgumentSpecificationsFactory.Create(argumentSpecs);
 
-            var result = arguments
-                .Select((arg, i) => _argumentSpecificationFactory.Create(arg, parameterInfos[i], suppliedArgumentSpecifications))
-                .ToArray();
+            var result = new List<IArgumentSpecification>();
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                var arg = arguments[i];
+                var paramInfo = parameterInfos[i];
+
+                try
+                {
+                    result.Add(_argumentSpecificationFactory.Create(arg, paramInfo, suppliedArgumentSpecifications));
+                }
+                catch (AmbiguousArgumentsException ex) when (ex.ContainsDefaultMessage)
+                {
+                    IEnumerable<IArgumentSpecification> alreadyResolvedSpecs = result;
+                    if (ex.Data[AmbiguousArgumentsException.NonReportedResolvedSpecificationsKey] is IEnumerable<IArgumentSpecification> additional)
+                    {
+                        alreadyResolvedSpecs = alreadyResolvedSpecs.Concat(additional);
+                    }
+
+                    throw new AmbiguousArgumentsException(methodInfo, arguments, alreadyResolvedSpecs, argumentSpecs);
+                }
+            }
 
             var remainingArgumentSpecifications = suppliedArgumentSpecifications.DequeueRemaining();
             if (remainingArgumentSpecifications.Any())
             {
-                throw new RedundantArgumentMatcherException(remainingArgumentSpecifications, suppliedArgumentSpecifications.AllSpecifications);
+                throw new RedundantArgumentMatcherException(remainingArgumentSpecifications, argumentSpecs);
             }
 
             return result;

--- a/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
@@ -24,7 +24,7 @@ namespace NSubstitute.Core.Arguments
                 return _argumentEqualsSpecificationFactory.Create(argument, parameterInfo.ParameterType);
             }
 
-            throw new AmbiguousArgumentsException(suppliedArgumentSpecifications.AllSpecifications);
+            throw new AmbiguousArgumentsException();
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
@@ -35,7 +35,7 @@ namespace NSubstitute.Core.Arguments
             bool isAmbiguousSpecificationPresent = suppliedArgumentSpecifications.AnyFor(argument, parameterInfo.ParameterType);
             if (isAmbiguousSpecificationPresent)
             {
-                throw new AmbiguousArgumentsException(suppliedArgumentSpecifications.AllSpecifications);
+                throw new AmbiguousArgumentsException();
             }
 
             // User passed "null" as the params array value.

--- a/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
@@ -8,7 +8,7 @@ namespace NSubstitute.Core.Arguments
     {
         private readonly IArgumentSpecificationCompatibilityTester _argSpecCompatibilityTester;
         private readonly Queue<IArgumentSpecification> _queue;
-        public IEnumerable<IArgumentSpecification> AllSpecifications { get; }
+        private IReadOnlyCollection<IArgumentSpecification> AllSpecifications { get; }
 
         public SuppliedArgumentSpecifications(IArgumentSpecificationCompatibilityTester argSpecCompatibilityTester, IEnumerable<IArgumentSpecification> argumentSpecifications)
         {

--- a/src/NSubstitute/Core/CallFormatter.cs
+++ b/src/NSubstitute/Core/CallFormatter.cs
@@ -6,6 +6,8 @@ namespace NSubstitute.Core
 {
     public class CallFormatter : IMethodInfoFormatter
     {
+        internal static IMethodInfoFormatter Default { get; } = new CallFormatter();
+
         private readonly IEnumerable<IMethodInfoFormatter> _methodInfoFormatters;
 
         public CallFormatter()

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -8,9 +8,6 @@ namespace NSubstitute.Core
 {
     public class CallSpecification : ICallSpecification
     {
-        static readonly IMethodInfoFormatter DefaultFormatter = new CallFormatter();
-        public IMethodInfoFormatter CallFormatter = DefaultFormatter;
-
         private readonly MethodInfo _methodInfo;
         readonly IArgumentSpecification[] _argumentSpecifications;
 
@@ -84,12 +81,12 @@ namespace NSubstitute.Core
         public override string ToString()
         {
             var argSpecsAsStrings = _argumentSpecifications.Select(x => x.ToString()).ToArray();
-            return CallFormatter.Format(GetMethodInfo(), argSpecsAsStrings);
+            return CallFormatter.Default.Format(GetMethodInfo(), argSpecsAsStrings);
         }
 
         public string Format(ICall call)
         {
-            return CallFormatter.Format(call.GetMethodInfo(), FormatArguments(call.GetOriginalArguments()));
+            return CallFormatter.Default.Format(call.GetMethodInfo(), FormatArguments(call.GetOriginalArguments()));
         }
 
         private IEnumerable<string> FormatArguments(IEnumerable<object> arguments)

--- a/src/NSubstitute/Core/CallSpecificationFactory.cs
+++ b/src/NSubstitute/Core/CallSpecificationFactory.cs
@@ -17,7 +17,7 @@ namespace NSubstitute.Core
             var argumentSpecs = call.GetArgumentSpecifications();
             var arguments = call.GetOriginalArguments();
             var parameterInfos = call.GetParameterInfos();
-            var argumentSpecificationsForCall = _argumentSpecificationsFactory.Create(argumentSpecs, arguments, parameterInfos, matchArgs);
+            var argumentSpecificationsForCall = _argumentSpecificationsFactory.Create(argumentSpecs, arguments, parameterInfos, methodInfo, matchArgs);
             return new CallSpecification(methodInfo, argumentSpecificationsForCall);
         }
     }

--- a/src/NSubstitute/Core/MethodFormatter.cs
+++ b/src/NSubstitute/Core/MethodFormatter.cs
@@ -25,7 +25,7 @@ namespace NSubstitute.Core
         {
             if (!methodInfoOfCall.IsGenericMethod) return string.Empty;
             var genericArgs = methodInfoOfCall.GetGenericArguments();
-            return "<" + string.Join(", ", genericArgs.Select(x => x.Name).ToArray()) + ">";
+            return "<" + string.Join(", ", genericArgs.Select(x => x.GetNonMangledTypeName()).ToArray()) + ">";
         }
 
         private static bool IsDelegateProxy(MethodInfo methodInfo)

--- a/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
+++ b/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
@@ -63,7 +63,6 @@ namespace NSubstitute.Core.SequenceChecking
             private readonly int _instanceNumber;
             private readonly ICall _call;
             private readonly CallSpecAndTarget _specAndTarget;
-            private readonly CallFormatter _callFormatter = new CallFormatter();
 
             public CallData(int instanceNumber, CallSpecAndTarget specAndTarget)
             {
@@ -119,7 +118,7 @@ namespace NSubstitute.Core.SequenceChecking
                 var args = methodInfo.GetParameters()
                             .Zip(call.GetOriginalArguments(), (p, a) => new ArgAndParamInfo(p, a))
                             .ToArray();
-                return _callFormatter.Format(methodInfo, FormatArgs(args));
+                return CallFormatter.Default.Format(methodInfo, FormatArgs(args));
             }
 
             private IEnumerable<string> FormatArgs(ArgAndParamInfo[] arguments)

--- a/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
+++ b/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
@@ -64,7 +64,6 @@ namespace NSubstitute.Core.SequenceChecking
             private readonly ICall _call;
             private readonly CallSpecAndTarget _specAndTarget;
             private readonly CallFormatter _callFormatter = new CallFormatter();
-            private readonly ArgumentFormatter _argFormatter = new ArgumentFormatter();
 
             public CallData(int instanceNumber, CallSpecAndTarget specAndTarget)
             {
@@ -130,7 +129,7 @@ namespace NSubstitute.Core.SequenceChecking
                         .SelectMany(a => a.ParamInfo.IsParams()
                                           ? ((IEnumerable) a.Argument).Cast<object>()
                                           : ToEnumerable(a.Argument))
-                        .Select(x => _argFormatter.Format(x, false))
+                        .Select(x => ArgumentFormatter.Default.Format(x, false))
                         .ToArray();
 
                 return argsWithParamsExpanded;

--- a/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -1,5 +1,9 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text;
+using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
 using static System.Environment;
 
@@ -7,26 +11,138 @@ namespace NSubstitute.Exceptions
 {
     public class AmbiguousArgumentsException : SubstituteException
     {
-        public AmbiguousArgumentsException(IEnumerable<IArgumentSpecification> queuedSpecifications)
-            : this(BuildExceptionMessage(queuedSpecifications))
+        internal const string NonReportedResolvedSpecificationsKey = "NON_REPORTED_RESOLVED_SPECIFICATIONS";
+        private const string DefaultErrorMessage =
+            "Cannot determine argument specifications to use. Please use specifications for all arguments of the same type.";
+
+        private const string TabPadding = "    ";
+
+        internal bool ContainsDefaultMessage { get; }
+
+        public AmbiguousArgumentsException() : base(DefaultErrorMessage)
         {
+            ContainsDefaultMessage = true;
         }
 
         public AmbiguousArgumentsException(string message) : base(message)
         {
         }
 
-        private static string BuildExceptionMessage(IEnumerable<IArgumentSpecification> queuedSpecifications)
+        public AmbiguousArgumentsException(MethodInfo method,
+            IEnumerable<object> invocationArguments,
+            IEnumerable<IArgumentSpecification> matchedSpecifications,
+            IEnumerable<IArgumentSpecification> allSpecifications)
+            : this(BuildExceptionMessage(method, invocationArguments, matchedSpecifications, allSpecifications))
         {
-            return
-                $"Cannot determine argument specifications to use. Please use specifications for all arguments of the same type.{NewLine}" +
-                $"All queued specifications:{NewLine}" +
-                $"{FormatSpecifications(queuedSpecifications)}{NewLine}";
+        }
+
+        private static string BuildExceptionMessage(MethodInfo method,
+            IEnumerable<object> invocationArguments,
+            IEnumerable<IArgumentSpecification> matchedSpecifications,
+            IEnumerable<IArgumentSpecification> allSpecifications)
+        {
+            string methodSignature = null;
+            string methodArgsWithHighlightedPossibleArgSpecs = null;
+            string matchedSpecificationsInfo = null;
+            if (CallFormatter.Default.CanFormat(method))
+            {
+                var argsWithInlinedParamsArray = invocationArguments.ToArray();
+                // If last argument is `params`, we inline the value.
+                if (method.GetParameters().Last().IsParams()
+                    && argsWithInlinedParamsArray.Last() is IEnumerable paramsArray)
+                {
+                    argsWithInlinedParamsArray = argsWithInlinedParamsArray
+                        .Take(argsWithInlinedParamsArray.Length - 1)
+                        .Concat(paramsArray.Cast<object>())
+                        .ToArray();
+                }
+
+                methodSignature = CallFormatter.Default.Format(
+                    method,
+                    FormatMethodParameterTypes(method.GetParameters()));
+
+                methodArgsWithHighlightedPossibleArgSpecs = CallFormatter.Default.Format(
+                    method,
+                    FormatMethodArguments(argsWithInlinedParamsArray));
+
+                matchedSpecificationsInfo = CallFormatter.Default.Format(
+                    method,
+                    PadNonMatchedSpecifications(matchedSpecifications, argsWithInlinedParamsArray));
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine(DefaultErrorMessage);
+
+            if (methodSignature != null)
+            {
+                message.AppendLine("Method signature:");
+                message.Append(TabPadding);
+                message.AppendLine(methodSignature);
+            }
+
+            if (methodArgsWithHighlightedPossibleArgSpecs != null)
+            {
+                message.AppendLine("Method arguments (possible arg matchers are indicated with '*'):");
+                message.Append(TabPadding);
+                message.AppendLine(methodArgsWithHighlightedPossibleArgSpecs);
+            }
+
+            message.AppendLine("All queued specifications:");
+            message.AppendLine(FormatSpecifications(allSpecifications));
+
+            if (matchedSpecificationsInfo != null)
+            {
+                message.AppendLine("Matched argument specifications:");
+                message.Append(TabPadding);
+                message.AppendLine(matchedSpecificationsInfo);
+            }
+
+            return message.ToString();
+        }
+
+        private static IEnumerable<string> FormatMethodParameterTypes(IEnumerable<ParameterInfo> parameters)
+        {
+            return parameters.Select(p =>
+            {
+                var type = p.ParameterType;
+
+                if (p.IsOut)
+                    return "out " + type.GetElementType().GetNonMangledTypeName();
+
+                if (type.IsByRef)
+                    return "ref " + type.GetElementType().GetNonMangledTypeName();
+
+                if (p.IsParams())
+                    return "params " + type.GetNonMangledTypeName();
+
+                return type.GetNonMangledTypeName();
+            });
+        }
+
+        private static IEnumerable<string> FormatMethodArguments(IEnumerable<object> arguments)
+        {
+            var defaultChecker = new DefaultChecker(new DefaultForType());
+
+            return arguments.Select(arg =>
+            {
+                var isPotentialArgSpec = arg == null || defaultChecker.IsDefault(arg, arg.GetType());
+                return ArgumentFormatter.Default.Format(arg, highlight: isPotentialArgSpec);
+            });
+        }
+
+        private static IEnumerable<string> PadNonMatchedSpecifications(IEnumerable<IArgumentSpecification> matchedSpecifications, IEnumerable<object> allArguments)
+        {
+            var allMatchedSpecs = matchedSpecifications.Select(x => x.ToString()).ToArray();
+
+            int nonResolvedArgumentsCount = allArguments.Count() - allMatchedSpecs.Length;
+            var nonResolvedArgsPlaceholders = Enumerable.Repeat("???", nonResolvedArgumentsCount);
+
+            return allMatchedSpecs.Concat(nonResolvedArgsPlaceholders);
         }
 
         private static string FormatSpecifications(IEnumerable<IArgumentSpecification> specifications)
         {
-            return string.Join(NewLine, specifications.Select(spec => "    " + spec.ToString()));
+            return string.Join(NewLine, specifications.Select(spec => TabPadding + spec.ToString()));
         }
     }
 }


### PR DESCRIPTION
Closes #400 

Improved the `AmbiguousArgumentException` to show more useful info to detect the problem.

Code:

```c#
interface IFoo
{
    int ParamsArgs(int arg1, int arg2, params int[] rest);
}
......
foo.ParamsArgs(0, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), 0, Arg.Any<int>()).Returns(42);

```

Here is how the exception looks now:
```
Cannot determine argument specifications to use. Please use specifications for all arguments of the same type.
Method signature:
    ParamsArgs(Int32, Int32, params Int32[])
Method invocation arguments:
    ParamsArgs(0 OR ARG_MATCHER, 0 OR ARG_MATCHER, 0 OR ARG_MATCHER, 0 OR ARG_MATCHER, 0 OR ARG_MATCHER, 0 OR ARG_MATCHER)
All queued specifications:
    any Int32
    any Int32
    any Int32
    any Int32
Matched argument specifications:
    ParamsArgs(any Int32, any Int32, any Int32, any Int32, ???, ???)
```

For all the `default` arguments I show that it might be potentially an argument matcher, so it's better to pay attention there. There is a false positive for the `out` parameters - value is equal default and I show e.g. `<null> OR ARG_MATCHER`. That's to keep the logic simple and it shouldn't be a big issue.

For the rest cases I tried to cover most of them.

@dtchepak Please take a look and share your feedback. If you see how to improve things (especially the `OR ARG_MATCHER` part), let me know 😉 