### PR TITLE
Use statically defined IsReadOnlyAttribute type

### DIFF
--- a/src/NSubstitute/AssemblyProperties.cs
+++ b/src/NSubstitute/AssemblyProperties.cs
@@ -1,0 +1,6 @@
+﻿using System.Runtime.CompilerServices;
+using Castle.Core.Internal;
+
+// Make internal types visible to Castle's dynamic assembly as we might want
+// to dynamically define internal IsReadOnlyAttribute attribute.
+[assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)]

--- a/src/NSubstitute/IsReadOnlyAttribute.cs
+++ b/src/NSubstitute/IsReadOnlyAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Attribute used by the compiler to mark the readonly by-ref arguments (`in` parameters).
+    /// The reason this attribute is defined explicitly is that we need to access it's type it in our code.
+    /// </summary>
+    internal class IsReadOnlyAttribute: Attribute
+    {
+    }
+}

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -20,6 +20,9 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>nsubstitute.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
+
+    <!-- Enable the latest C# features -->
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -46,19 +46,12 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
         }
 
         /// <summary>
-        /// Allows to dynamically create a type in runtime.
-        /// Use the <paramref name="typeBuildCallback"/> callback to define and build the type.
+        /// Dynamically define the type with specified <paramref name="typeName"/>.
         /// </summary>
-        /// <param name="typeBuildCallback">Callback used to construct the type.</param>
-        /// <returns>The result returned by <paramref name="typeBuildCallback"/> callback.</returns>
-        public Type DefineDynamicType(Func<ModuleBuilder, Type> typeBuildCallback)
+        public TypeBuilder DefineDynamicType(string typeName, TypeAttributes flags)
         {
-            var moduleBuilder = _proxyGenerator.ProxyBuilder.ModuleScope.ObtainDynamicModuleWithStrongName();
-
-            using (_proxyGenerator.ProxyBuilder.ModuleScope.Lock.ForWriting())
-            {
-                return typeBuildCallback.Invoke(moduleBuilder);
-            }
+            // It's important to use the signed module, as we exposed internals type to the signed module.
+            return _proxyGenerator.ProxyBuilder.ModuleScope.DefineType(inSignedModulePreferably: true, typeName, flags);
         }
 
         private object CreateProxyUsingCastleProxyGenerator(Type typeToProxy, Type[] additionalInterfaces,

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45</TargetFrameworks>
+
+    <!-- Enable the latest C# features -->
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -10,10 +13,6 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <OutputPath>..\..\bin\Release\NSubstitute.Acceptance.Specs\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously we generated the `IsReadOnlyAttribute` at run time. The problem is that currenlty Castle.Core doesn't expose a way to synchronize type creation. As result it could happen that type is defined twice and creation fails with exception.

Given that we don't have a reliable way to ensure that type is defined once only, we defined our own internal `IsReadOnlyAttribute` type and made it visible to the dynamic assembly. Looks line a nice elegant solution to the problem.

The reason this type is internal rather than public is that it might exist in the target platform, so we don't want our attribute to interfere with the system one.

@dtchepak @alexandrnikitin Please take a look 😉