### PR TITLE
Allow the use of a custom ArgumentMatcher

### DIFF
--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -93,6 +93,14 @@ namespace NSubstitute
             return ref EnqueueSpecFor<T>(new AnyArgumentMatcher(typeof(T)), x => useArgument((T)x));
         }
 
+        /// <summary>
+        /// Match the argument using the specified <paramref name="argumentMatcher"/>.
+        /// </summary>
+        public static ref T Matches<T>(IArgumentMatcher argumentMatcher)
+        {
+            return ref EnqueueSpecFor<T>(argumentMatcher);
+        }
+
         private static ref T EnqueueSpecFor<T>(IArgumentMatcher argumentMatcher)
         {
             var argumentSpecification = new ArgumentSpecification(typeof(T), argumentMatcher);

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.Core.Arguments;
 using NSubstitute.Exceptions;
 using NUnit.Framework;
 
@@ -631,6 +632,35 @@ namespace NSubstitute.Acceptance.Specs
 
             var result = subs("foo", out string _);
             Assert.That(result, Is.EqualTo("42"));
+        }
+
+        private class CustomMatcher
+            : IArgumentMatcher
+        {
+            public bool wasMatch;
+
+            public bool IsSatisfiedBy(object argument)
+            {
+                if (argument.Equals(42))
+                {
+                    wasMatch = true;
+                    return true;
+                }
+                wasMatch = false;
+                return false;
+            }
+        }
+
+        [Test]
+        public void Matches_uses_custom_matcher()
+        {
+            var matcher = new CustomMatcher();
+            _something.Echo(Arg.Matches<int>(matcher)).Returns("42");
+
+            Assert.That(_something.Echo(42), Is.EqualTo("42"));
+            Assert.That(matcher.wasMatch, Is.True);
+            Assert.That(_something.Echo(43), Is.EqualTo(string.Empty));
+            Assert.That(matcher.wasMatch, Is.False);
         }
 
         [SetUp]


### PR DESCRIPTION
In an effort to address several open issues, and to get human friendly error messages for parameters that are not matched using the available IDescribeNonMatches infrastructure. I added a method to the Arg class which was suggested in the comments. 

Related issues:

- https://github.com/nsubstitute/NSubstitute/issues/276
- https://github.com/nsubstitute/NSubstitute/issues/239
- https://github.com/nsubstitute/NSubstitute/issues/160