### PR TITLE
Always generate delegate containers in unique scope

### DIFF
--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -18,11 +18,10 @@ namespace NSubstitute.Proxies.DelegateProxy
         private const string IsReadOnlyAttributeFullTypeName = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
         private readonly CastleDynamicProxyFactory _castleObjectProxyFactory;
         private readonly ConcurrentDictionary<Type, Type> _delegateContainerCache = new ConcurrentDictionary<Type, Type>();
-        private long _typeSuffixCounter;
 
         public DelegateProxyFactory(CastleDynamicProxyFactory objectProxyFactory)
         {
-            _castleObjectProxyFactory = objectProxyFactory;
+            _castleObjectProxyFactory = objectProxyFactory ?? throw new ArgumentNullException(nameof(objectProxyFactory));
         }
         
         public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
@@ -60,14 +59,7 @@ namespace NSubstitute.Proxies.DelegateProxy
             var delegateSignature = delegateType.GetMethod("Invoke");
             var delegateParameters = delegateSignature.GetParameters();
 
-            var typeSuffixCounter = Interlocked.Increment(ref _typeSuffixCounter);
-            var delegateTypeName = delegateType.GetTypeInfo().IsGenericType
-                ? delegateType.Name.Substring(0, delegateType.Name.IndexOf("`", StringComparison.Ordinal))
-                : delegateType.Name;
-            var typeName = string.Format(
-                "DelegateContainer_{0}_{1}",
-                delegateTypeName,
-                typeSuffixCounter.ToString(CultureInfo.InvariantCulture));
+            var typeName = $"NSubstituteDelegateProxy.DelegateContainer_{Guid.NewGuid():N}";
 
             var typeBuilder = _castleObjectProxyFactory.DefineDynamicType(
                 typeName,


### PR DESCRIPTION
If it appears that due to some reason the same `CastleDynamicProxyFactory` is shared for the different `DelegateProxyFactory` instances, code will fail at run time as types will be already defined. In this PR I ensure that delegate type names are always unique. Currently I don't have a clear scenario, but it's making the code more robust to any surprises (e.g. some user decides to play with `SubstitutionContext.Current`). 

Also I removed the delegate name - it's redundant and is never visible. Now container type name looks like:
`NSubstituteDelegateProxy.DelegateContainer_3944660c9c934082ba4b6c9553f73598`

Looks perfect 😊 

@dtchepak Please take a look.