### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+An example to help us reproduce the behaviour. (If you'd like some tips on the kind of information to include have a look at StackOverflow's [creating a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve).)
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen, compared to what actually happened.
+
+**Environment:**
+ - NSubstitute version: [e.g. 3.1.0]
+ - Platform: [e.g. dotnetcore2.0 project on Mac]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other-issues.md
+++ b/.github/ISSUE_TEMPLATE/other-issues.md
@@ -1,0 +1,7 @@
+---
+name: Other issues
+about: Anything that doesn't quite fit in the other catergories :)
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question
+about: Ask about how to do a specific task or how something works
+
+---
+
+**Question**
+Ask away! If you are trying to do a specific task (e.g. how do I mock this event?), please include a code example to help us understand the context and potentially provide a sample answer. (StackOverflow's guide to [creating a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) may help with the sort of information to include.)
+
+**Related links**
+If you've already asked or found related questions on [StackOverflow](https://stackoverflow.com/questions/tagged/nsubstitute) please include links here:
+* link 1
+* link 2


### PR DESCRIPTION
Initial attempt at adding some [issue templates](https://help.github.com/articles/about-issue-and-pull-request-templates/).

Aiming to help people get us the information we need to help them with their issue.

This is still fairly draft, please feel free to improve! The shorter they are the better I think, quickly covering the minimum info we need people to provide (without putting them off! I think an incomplete issue may still be more useful than no issue.) Also hopefully will avoid us needing to prompt for [MCVEs](https://stackoverflow.com/help/mcve). 😄  If you've seen other projects with great issue templates would be good to get these more inline with them.

Not sure if questions template should encourage people to try SO first? There are lots more eyeballs on SO so that may be the fastest way for people to get an answer to their questions, but they are also welcome to also ask here to get a semi-"official" response.