### PR TITLE
Remove SequenceNumberGenerator from SubstituteState

### DIFF
--- a/src/NSubstitute/Core/ISubstituteState.cs
+++ b/src/NSubstitute/Core/ISubstituteState.cs
@@ -9,7 +9,6 @@ namespace NSubstitute.Core
         ICallCollection ReceivedCalls { get; }
         ICallResults CallResults { get; }
         ICallActions CallActions { get; }
-        SequenceNumberGenerator SequenceNumberGenerator { get; }
         IConfigureCall ConfigureCall { get; }
         IEventHandlerRegistry EventHandlerRegistry { get; }
         IReadOnlyCollection<IAutoValueProvider> AutoValueProviders { get; }

--- a/src/NSubstitute/Core/SubstituteState.cs
+++ b/src/NSubstitute/Core/SubstituteState.cs
@@ -9,7 +9,6 @@ namespace NSubstitute.Core
         public ICallCollection ReceivedCalls { get; }
         public ICallResults CallResults { get; }
         public ICallActions CallActions { get; }
-        public SequenceNumberGenerator SequenceNumberGenerator { get; }
         public IConfigureCall ConfigureCall { get; }
         public IEventHandlerRegistry EventHandlerRegistry { get; }
         public IReadOnlyCollection<IAutoValueProvider> AutoValueProviders { get; }
@@ -17,12 +16,10 @@ namespace NSubstitute.Core
         public IResultsForType ResultsForType { get; }
         public ICustomHandlers CustomHandlers { get; }
 
-        public SubstituteState(SequenceNumberGenerator sequenceNumberGenerator,
-            ICallSpecificationFactory callSpecificationFactory,
+        public SubstituteState(ICallSpecificationFactory callSpecificationFactory,
             ICallInfoFactory callInfoFactory,
             IReadOnlyCollection<IAutoValueProvider> autoValueProviders)
         {
-            SequenceNumberGenerator = sequenceNumberGenerator;
             AutoValueProviders = autoValueProviders;
 
             var callCollection = new CallCollection();
@@ -37,7 +34,6 @@ namespace NSubstitute.Core
             var getCallSpec = new GetCallSpec(callCollection, callSpecificationFactory, CallActions);
             ConfigureCall = new ConfigureCall(CallResults, CallActions, getCallSpec);
             EventHandlerRegistry = new EventHandlerRegistry();
-
         }
     }
 }

--- a/src/NSubstitute/Core/SubstituteStateFactory.cs
+++ b/src/NSubstitute/Core/SubstituteStateFactory.cs
@@ -1,33 +1,27 @@
-﻿using NSubstitute.Routing.AutoValues;
+﻿using System;
+using NSubstitute.Routing.AutoValues;
 
 namespace NSubstitute.Core
 {
     public class SubstituteStateFactory : ISubstituteStateFactory
     {
-        private readonly SequenceNumberGenerator _sequenceNumberGenerator;
         private readonly ICallSpecificationFactory _callSpecificationFactory;
         private readonly ICallInfoFactory _callInfoFactory;
         private readonly IAutoValueProvidersFactory _autoValueProvidersFactory;
 
-        public SubstituteStateFactory(SequenceNumberGenerator sequenceNumberGenerator,
-            ICallSpecificationFactory callSpecificationFactory,
+        public SubstituteStateFactory(ICallSpecificationFactory callSpecificationFactory,
             ICallInfoFactory callInfoFactory,
             IAutoValueProvidersFactory autoValueProvidersFactory)
         {
-            _sequenceNumberGenerator = sequenceNumberGenerator;
-            _callSpecificationFactory = callSpecificationFactory;
-            _callInfoFactory = callInfoFactory;
-            _autoValueProvidersFactory = autoValueProvidersFactory;
+            _callSpecificationFactory = callSpecificationFactory ?? throw new ArgumentNullException(nameof(callSpecificationFactory));
+            _callInfoFactory = callInfoFactory ?? throw new ArgumentNullException(nameof(callInfoFactory));
+            _autoValueProvidersFactory = autoValueProvidersFactory ?? throw new ArgumentNullException(nameof(autoValueProvidersFactory));
         }
 
         public ISubstituteState Create(ISubstituteFactory substituteFactory)
         {
             var autoValueProviders = _autoValueProvidersFactory.CreateProviders(substituteFactory);
-
-            return new SubstituteState(_sequenceNumberGenerator,
-                _callSpecificationFactory,
-                _callInfoFactory,
-                autoValueProviders);
+            return new SubstituteState(_callSpecificationFactory, _callInfoFactory, autoValueProviders);
         }
     }
 }

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -31,21 +31,22 @@ namespace NSubstitute.Core
             var callSpecificationFactory = CallSpecificationFactoryFactoryYesThatsRight.CreateCallSpecFactory();
             _callRouterResolver = new CallRouterResolver();
 
-            RouteFactory = new RouteFactory(ThreadContext, callSpecificationFactory);
-
             var sequenceNumberGenerator = new SequenceNumberGenerator();
+#pragma warning disable 618 // Obsolete
+            SequenceNumberGenerator = sequenceNumberGenerator;
+#pragma warning restore 618 // Obsolete
+
+            RouteFactory = new RouteFactory(sequenceNumberGenerator, ThreadContext, callSpecificationFactory);
+
             var callInfoFactory = new CallInfoFactory();
             var autoValueProvidersFactory = new AutoValueProvidersFactory();
-            var substituteStateFactory = new SubstituteStateFactory(sequenceNumberGenerator, callSpecificationFactory, callInfoFactory, autoValueProvidersFactory);
+            var substituteStateFactory = new SubstituteStateFactory(callSpecificationFactory, callInfoFactory, autoValueProvidersFactory);
             var callRouterFactory = new CallRouterFactory(ThreadContext, RouteFactory);
             var argSpecificationQueue = new ArgumentSpecificationDequeue(ThreadContext.DequeueAllArgumentSpecifications);
             var dynamicProxyFactory = new CastleDynamicProxyFactory(argSpecificationQueue);
             var delegateFactory = new DelegateProxyFactory(dynamicProxyFactory);
             var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
             SubstituteFactory = new SubstituteFactory(substituteStateFactory, callRouterFactory, proxyFactory);
-#pragma warning disable 618 // Obsolete
-            SequenceNumberGenerator = sequenceNumberGenerator;
-#pragma warning restore 618 // Obsolete
         }
 
         public SubstitutionContext(ISubstituteFactory substituteFactory,

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -8,11 +8,13 @@ namespace NSubstitute.Routing
 {
     public class RouteFactory : IRouteFactory
     {
+        private readonly SequenceNumberGenerator _sequenceNumberGenerator;
         private readonly IThreadLocalContext _threadLocalContext;
         private readonly ICallSpecificationFactory _callSpecificationFactory;
 
-        public RouteFactory(IThreadLocalContext threadLocalContext, ICallSpecificationFactory callSpecificationFactory)
+        public RouteFactory(SequenceNumberGenerator sequenceNumberGenerator, IThreadLocalContext threadLocalContext, ICallSpecificationFactory callSpecificationFactory)
         {
+            _sequenceNumberGenerator = sequenceNumberGenerator ?? throw new ArgumentNullException(nameof(sequenceNumberGenerator));
             _threadLocalContext = threadLocalContext ?? throw new ArgumentNullException(nameof(threadLocalContext));
             _callSpecificationFactory = callSpecificationFactory ?? throw new ArgumentNullException(nameof(callSpecificationFactory));
         }
@@ -79,7 +81,7 @@ namespace NSubstitute.Routing
             return new Route(RouteType.RecordReplay, new ICallHandler[] {
                 new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
                 , new TrackLastCallHandler(_threadLocalContext.PendingSpecification)
-                , new RecordCallHandler(state.ReceivedCalls, state.SequenceNumberGenerator)
+                , new RecordCallHandler(state.ReceivedCalls, _sequenceNumberGenerator)
                 , new EventSubscriptionHandler(state.EventHandlerRegistry)
                 , new PropertySetterHandler(new PropertyHelper(new CallFactory(), new ArgumentSpecificationCompatibilityTester(new DefaultChecker(new DefaultForType()))), state.ConfigureCall)
                 , new DoActionsCallHandler(state.CallActions)


### PR DESCRIPTION
Currently `SequenceNumberGenerator` is a global thing, therefore it should be a part of `SubstituteState`, which contains only specific info.
It should make `ISubstituteState` data to hold only data specific for substitute.

@dtchepak Please take a look 😉 