### PR TITLE
Reuse CallResults implementation for type results

### DIFF
--- a/src/NSubstitute/Core/IResultsForType.cs
+++ b/src/NSubstitute/Core/IResultsForType.cs
@@ -3,9 +3,8 @@
 namespace NSubstitute.Core
 {
     public interface IResultsForType {
-        bool HasResultFor(ICall call);
         void SetResult(Type type, IReturn resultToReturn);
-        object GetResult(ICall call);
+        bool TryGetResult(ICall call, out object result);
         void Clear();
     }
 }

--- a/src/NSubstitute/Routing/Handlers/ReturnResultForTypeHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnResultForTypeHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NSubstitute.Core;
+﻿using NSubstitute.Core;
 
 namespace NSubstitute.Routing.Handlers
 {
@@ -14,9 +13,9 @@ namespace NSubstitute.Routing.Handlers
 
         public RouteAction Handle(ICall call)
         {
-            return _resultsForType.HasResultFor(call)
-                       ? RouteAction.Return(_resultsForType.GetResult(call))
-                       : RouteAction.Continue();
+            return _resultsForType.TryGetResult(call, out var result)
+                ? RouteAction.Return(result)
+                : RouteAction.Continue();
         }
     }
 }


### PR DESCRIPTION
Found that `CallResults` can be actually re-used for the `ResultsForType`. Helps to de-duplicate the code.
I don't like an idea to implement `ICallSpecification` with `NotSupportedException` and likely it would be better to extract `ICallSpecificationMatch` interface with single `IsSatisfiedBy(call)` method (so `ICallSpecification` inherits it), but decided that it would be an overkill.

@dtchepak @alexandrnikitin Please share your feedback. Thanks 🍻 