### PR TITLE
Update readme to include other libs of interest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# VS Code directory
+.vscode/
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ There are also build scripts in the `./build` directory for command line builds,
 
 To do [full builds](https://github.com/nsubstitute/NSubstitute/wiki/Release-procedure) you'll also need Ruby, as the jekyll gem is used to generate the website.
 
-### Other languages
+### Other libraries you may be interested in
 
-NSubstitute has been ported to other languages as well. These ports are not maintained by the NSubstitute team.
+* [Moq](https://github.com/Moq/moq4/wiki/Quickstart): the original Arrange-Act-Assert mocking library for .NET, and a big source of inspiration for NSubstitute.
+* [FakeItEasy](https://fakeiteasy.github.io/): another modern mocking library for .NET. If you're not sold on NSubstitute's syntax, try FIE!
+* [substitute.js](https://github.com/ffMathy/FluffySpoon.JavaScript.Testing): a mocking library for TypeScript inspired by NSubstitute's syntax (`@fluffy-spoon/substitute` on NPM)
 
-- *TypeScript*
-	- [substitute.js](https://github.com/ffMathy/FluffySpoon.JavaScript.Testing) (`@fluffy-spoon/substitute` on NPM)

--- a/README.md
+++ b/README.md
@@ -125,3 +125,10 @@ NSubstitute and its tests can be compiled and run using Visual Studio and Visual
 There are also build scripts in the `./build` directory for command line builds, and CI configurations in the project root.
 
 To do [full builds](https://github.com/nsubstitute/NSubstitute/wiki/Release-procedure) you'll also need Ruby, as the jekyll gem is used to generate the website.
+
+### Other languages
+
+NSubstitute has been ported to other languages as well. These ports are not maintained by the NSubstitute team.
+
+- *TypeScript*
+	- [substitute.js](https://github.com/ffMathy/FluffySpoon.JavaScript.Testing) (`@fluffy-spoon/substitute` on NPM)

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,12 +52,6 @@ Received 2 non-matching calls (non-matching arguments indicated with '*' charact
         <p>NSubstitute is designed for Arrange-Act-Assert (AAA) testing, so you just need to arrange how it should work, then assert it received the calls you expected once you're done. Because you've got more important code to write than whether you need a mock or a stub.</p>
       </div>
 
-      <div class="feature">
-        <h2>Ported to TypeScript too</h2>
-        <p>The NSubstitute community has ported the same mocking syntax you know to TypeScript as well!</p>
-        <p>Go to the <a href="https://github.com/ffMathy/FluffySpoon.Testing.JavaScript">substitute.js GitHub repository</a> for more information.</p>
-      </div>
-
   </div>
 
   <div id="downloads" class="sidebar download">

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,12 @@ Received 2 non-matching calls (non-matching arguments indicated with '*' charact
         <p>NSubstitute is designed for Arrange-Act-Assert (AAA) testing, so you just need to arrange how it should work, then assert it received the calls you expected once you're done. Because you've got more important code to write than whether you need a mock or a stub.</p>
       </div>
 
+      <div class="feature">
+        <h2>Ported to TypeScript too</h2>
+        <p>The NSubstitute community has ported the same mocking syntax you know to TypeScript as well!</p>
+        <p>Go to the <a href="https://github.com/ffMathy/FluffySpoon.Testing.JavaScript">substitute.js GitHub repository</a> for more information.</p>
+      </div>
+
   </div>
 
   <div id="downloads" class="sidebar download">


### PR DESCRIPTION
Based on #428 and on the changes in #433, have added links to libraries of interest, including substitute.js, as well as to some of the other wonderful .net mocking libs available. 
