### PR TITLE
Add dependency injection to easily customize NSubstitute

### DIFF
--- a/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
+++ b/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
@@ -1,47 +1,16 @@
-﻿using NSubstitute.Core.Arguments;
+﻿using System;
+using NSubstitute.Core.DependencyInjection;
 
 namespace NSubstitute.Core
 {
-    public class CallSpecificationFactoryFactoryYesThatsRight
+    public static class CallSpecificationFactoryFactoryYesThatsRight
     {
-        public static ICallSpecificationFactory CreateCallSpecFactory()
-        {
-            return
-                new CallSpecificationFactory(
-                    new ArgumentSpecificationsFactory(
-                        new MixedArgumentSpecificationsFactory(
-                            new ArgumentSpecificationFactory(
-                                NewParamsArgumentSpecificationFactory(),
-                                NewNonParamsArgumentSpecificationFactory()
-                                ),
-                            new SuppliedArgumentSpecificationsFactory(
-                                new ArgumentSpecificationCompatibilityTester(
-                                    new DefaultChecker(new DefaultForType())
-                                    )
-                                )
-                            )
-                        )
-                    );
-        }
-
-        private static IParamsArgumentSpecificationFactory NewParamsArgumentSpecificationFactory()
-        {
-            return
-                new ParamsArgumentSpecificationFactory(
-                    new ArgumentEqualsSpecificationFactory(),
-                    new ArrayArgumentSpecificationsFactory(
-                        new NonParamsArgumentSpecificationFactory(new ArgumentEqualsSpecificationFactory())
-                    ),
-                    new ParameterInfosFromParamsArrayFactory(),
-                    new ArrayContentsArgumentSpecificationFactory()
-                );
-        }
-
-        private static INonParamsArgumentSpecificationFactory NewNonParamsArgumentSpecificationFactory()
-        {
-            return
-                new NonParamsArgumentSpecificationFactory(new ArgumentEqualsSpecificationFactory()
-                );
-        }
+        [Obsolete("This factory is deprecated and will be removed in future versions of the product. " +
+                  "Please use '" + nameof(SubstitutionContext) + "." + nameof(SubstitutionContext.Current) + "." +
+                  nameof(SubstitutionContext.Current.CallSpecificationFactory) + "' instead. " +
+                  "Use " + nameof(NSubstituteDefaultFactory) + " services if you need to activate a new instance.")]
+        // ReSharper disable once UnusedMember.Global - is left for API compatibility from other libraries.
+        public static ICallSpecificationFactory CreateCallSpecFactory() =>
+            NSubstituteDefaultFactory.DefaultContainer.Resolve<ICallSpecificationFactory>();
     }
 }

--- a/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
+++ b/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace NSubstitute.Core.DependencyInjection
+{
+    public interface INSubResolver
+    {
+        T Resolve<T>();
+    }
+
+    public interface INSubContainer : INSubResolver
+    {
+        /// <summary>
+        /// Creates a new container based on the current one,
+        /// which can be configured to override the existing registrations without affecting the existing container.
+        /// </summary>
+        IConfigurableNSubContainer Customize();
+
+        /// <summary>
+        /// Create an explicit scope, so all dependencies with the <see cref="NSubLifetime.PerScope"/> lifetime
+        /// are preserved for multiple resolve requests.
+        /// </summary>
+        INSubResolver CreateScope();
+    }
+
+    public interface IConfigurableNSubContainer : INSubContainer
+    {
+        IConfigurableNSubContainer Register<TKey, TImpl>(NSubLifetime lifetime) where TImpl : TKey;
+
+        IConfigurableNSubContainer Register<TKey>(Func<INSubResolver, TKey> factory, NSubLifetime lifetime);
+    }
+
+    public static class ConfigurableNSubContainerExtensions
+    {
+        public static IConfigurableNSubContainer RegisterPerScope<TKey, TImpl>(this IConfigurableNSubContainer container)
+            where TImpl : TKey
+        {
+            return container.Register<TKey, TImpl>(NSubLifetime.PerScope);
+        }
+
+        public static IConfigurableNSubContainer RegisterPerScope<TKey>(this IConfigurableNSubContainer container, Func<INSubResolver, TKey> factory)
+        {
+            return container.Register(factory, NSubLifetime.PerScope);
+        }
+
+        public static IConfigurableNSubContainer RegisterSingleton<TKey, TImpl>(this IConfigurableNSubContainer container)
+            where TImpl : TKey
+        {
+            return container.Register<TKey, TImpl>(NSubLifetime.Singleton);
+        }
+    }
+}

--- a/src/NSubstitute/Core/DependencyInjection/NSubContainer.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubContainer.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace NSubstitute.Core.DependencyInjection
+{
+    /// <summary>
+    /// Tiny and very limited implementation of the DI services.
+    /// Container supports the following features required by NSubstitute:
+    ///     - Registration by type with automatic constructor injection
+    ///     - Registration of factory methods for the complex objects
+    ///     - Support of the most required lifetimes:
+    ///         - <see cref="NSubLifetime.Transient"/>
+    ///         - <see cref="NSubLifetime.PerScope"/>
+    ///         - <see cref="NSubLifetime.Singleton"/>
+    ///     - Immutability (via interfaces) and customization by creating a nested container
+    /// </summary>
+    public class NSubContainer : IConfigurableNSubContainer
+    {
+        private readonly NSubContainer _parentContainer;
+        private readonly object _syncRoot;
+
+        private Dictionary<Type, Registration> Registrations { get; } = new Dictionary<Type, Registration>();
+
+        public NSubContainer()
+        {
+            _syncRoot = new object();
+        }
+
+        private NSubContainer(NSubContainer parentContainer)
+        {
+            _parentContainer = parentContainer;
+
+            // Use the same synchronization object in descendant containers.
+            // It's required to e.g. ensure that singleton dependencies are resolved only once.
+            _syncRoot = parentContainer._syncRoot;
+        }
+
+        public T Resolve<T>()
+        {
+            return (T) ResolveImpl(typeof(T), new ScopeCache());
+        }
+
+        public IConfigurableNSubContainer Register<TKey, TImpl>(NSubLifetime lifetime) where TImpl : TKey
+        {
+            var constructors = typeof(TImpl).GetConstructors();
+            if (constructors.Length != 1)
+            {
+                throw new ArgumentException(
+                    $"Type '{typeof(TImpl).FullName}' should contain only single public constructor. " +
+                    $"Please register type using factory method to avoid ambiguity.");
+            }
+
+            var ctor = constructors[0];
+
+            object Factory(ScopeCache scopeCache)
+            {
+                var args = ctor.GetParameters()
+                    .Select(p => ResolveImpl(p.ParameterType, scopeCache))
+                    .ToArray();
+                return ctor.Invoke(args);
+            }
+
+            AddRegistration(typeof(TKey), new Registration(Factory, lifetime));
+
+            return this;
+        }
+
+        public IConfigurableNSubContainer Register<TKey>(Func<INSubResolver, TKey> factory, NSubLifetime lifetime)
+        {
+            object Factory(ScopeCache scopeCache)
+            {
+                return factory.Invoke(new ScopeCacheBoundResolver(this, scopeCache));
+            }
+            
+            AddRegistration(typeof(TKey), new Registration(Factory, lifetime));
+
+            return this;
+        }
+
+        public IConfigurableNSubContainer Customize()
+        {
+            return new NSubContainer(this);
+        }
+
+        public INSubResolver CreateScope()
+        {
+            return new ScopeCacheBoundResolver(this, new ScopeCache());
+        }
+
+        private void AddRegistration(Type type, Registration registration)
+        {
+            lock (_syncRoot)
+            {
+                Registrations[type] = registration;
+            }
+        }
+        
+        private object ResolveImpl(Type type, ScopeCache scopeCache)
+        {
+            lock (_syncRoot)
+            {
+                if (Registrations.TryGetValue(type, out var registration))
+                {
+                    return registration.Resolve(scopeCache);
+                }
+
+                if (_parentContainer != null)
+                {
+                    return _parentContainer.ResolveImpl(type, scopeCache);
+                }
+
+                throw new InvalidOperationException($"Type is not registered: {type.FullName}");
+            }
+        }
+
+        private class Registration
+        {
+            private readonly NSubLifetime _lifetime;
+            private readonly Func<ScopeCache, object> _factory;
+            private object _singletonValue;
+
+            public Registration(Func<ScopeCache, object> factory, NSubLifetime lifetime)
+            {
+                _factory = factory;
+                _lifetime = lifetime;
+            }
+
+            public object Resolve(ScopeCache scopeCache)
+            {
+                switch (_lifetime)
+                {
+                    case NSubLifetime.Transient:
+                        return _factory.Invoke(scopeCache);
+
+                    case NSubLifetime.Singleton:
+                        return _singletonValue ?? (_singletonValue = _factory.Invoke(scopeCache));
+
+                    case NSubLifetime.PerScope:
+                        if (scopeCache.TryGetValue(this, out var result))
+                        {
+                            return result;
+                        }
+
+                        result = _factory.Invoke(scopeCache);
+                        scopeCache.Set(this, result);
+                        return result;
+
+                    default:
+                        throw new InvalidOperationException("Unknown lifetime.");
+                }
+            }
+        }
+
+        private class ScopeCache
+        {
+            private readonly Dictionary<Registration, object> _cache = new Dictionary<Registration, object>();
+
+            public bool TryGetValue(Registration registration, out object result) =>
+                _cache.TryGetValue(registration, out result);
+
+            public void Set(Registration registration, object value) =>
+                _cache[registration] = value;
+        }
+
+        private class ScopeCacheBoundResolver : INSubResolver
+        {
+            private readonly NSubContainer _container;
+            private readonly ScopeCache _scopeCache;
+
+            public ScopeCacheBoundResolver(NSubContainer container, ScopeCache scopeCache)
+            {
+                _container = container;
+                _scopeCache = scopeCache;
+            }
+
+            public T Resolve<T>() =>
+                (T) _container.ResolveImpl(typeof(T), _scopeCache);
+        }
+    }
+}

--- a/src/NSubstitute/Core/DependencyInjection/NSubLifetime.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubLifetime.cs
@@ -1,0 +1,19 @@
+namespace NSubstitute.Core.DependencyInjection
+{
+    public enum NSubLifetime
+    {
+        /// <summary>
+        /// Value is created only once.
+        /// </summary>
+        Singleton,
+        /// <summary>
+        /// Value is created only once per scope. Allows to share the same instance across the objects in the same graph.
+        /// If no explicit scope is created, an implicit scope is created per single resolve request.
+        /// </summary>
+        PerScope,
+        /// <summary>
+        /// New value is created for each time.
+        /// </summary>
+        Transient
+    }
+}

--- a/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
@@ -1,0 +1,55 @@
+using NSubstitute.Core.Arguments;
+using NSubstitute.Proxies;
+using NSubstitute.Proxies.CastleDynamicProxy;
+using NSubstitute.Proxies.DelegateProxy;
+using NSubstitute.Routing;
+using NSubstitute.Routing.AutoValues;
+
+namespace NSubstitute.Core.DependencyInjection
+{
+    public static class NSubstituteDefaultFactory
+    {
+        /// <summary>
+        /// The default NSubstitute registrations. Feel free to configure the existing container to customize
+        /// and override NSubstitute parts.
+        /// </summary>
+        public static INSubContainer DefaultContainer { get; } = CreateDefaultContainer();
+
+        public static ISubstitutionContext CreateSubstitutionContext() => DefaultContainer.Resolve<ISubstitutionContext>();
+
+        private static INSubContainer CreateDefaultContainer()
+        {
+            return new NSubContainer()
+                .RegisterSingleton<SequenceNumberGenerator, SequenceNumberGenerator>()
+                .RegisterPerScope<IThreadLocalContext, ThreadLocalContext>()
+                .RegisterPerScope<IArgumentSpecificationDequeue>(r =>
+                    new ArgumentSpecificationDequeue(r.Resolve<IThreadLocalContext>().DequeueAllArgumentSpecifications))
+                .RegisterPerScope<ICallSpecificationFactory, CallSpecificationFactory>()
+                .RegisterPerScope<IArgumentSpecificationFactory, ArgumentSpecificationFactory>()
+                .RegisterPerScope<IArgumentSpecificationsFactory, ArgumentSpecificationsFactory>()
+                .RegisterPerScope<IMixedArgumentSpecificationsFactory, MixedArgumentSpecificationsFactory>()
+                .RegisterPerScope<IParamsArgumentSpecificationFactory, ParamsArgumentSpecificationFactory>()
+                .RegisterPerScope<INonParamsArgumentSpecificationFactory, NonParamsArgumentSpecificationFactory>()
+                .RegisterPerScope<IArgumentEqualsSpecificationFactory, ArgumentEqualsSpecificationFactory>()
+                .RegisterPerScope<IArrayArgumentSpecificationsFactory, ArrayArgumentSpecificationsFactory>()
+                .RegisterPerScope<IParameterInfosFromParamsArrayFactory, ParameterInfosFromParamsArrayFactory>()
+                .RegisterPerScope<IArrayContentsArgumentSpecificationFactory, ArrayContentsArgumentSpecificationFactory>()
+                .RegisterPerScope<ISuppliedArgumentSpecificationsFactory, SuppliedArgumentSpecificationsFactory>()
+                .RegisterPerScope<IArgumentSpecificationCompatibilityTester, ArgumentSpecificationCompatibilityTester>()
+                .RegisterPerScope<IDefaultChecker, DefaultChecker>()
+                .RegisterPerScope<IDefaultForType, DefaultForType>()
+                .RegisterPerScope<IRouteFactory, RouteFactory>()
+                .RegisterPerScope<ICallInfoFactory, CallInfoFactory>()
+                .RegisterPerScope<IAutoValueProvidersFactory, AutoValueProvidersFactory>()
+                .RegisterPerScope<ISubstituteStateFactory, SubstituteStateFactory>()
+                .RegisterPerScope<ICallRouterFactory, CallRouterFactory>()
+                .RegisterPerScope<ISubstituteFactory, SubstituteFactory>()
+                .RegisterPerScope<ICallRouterResolver, CallRouterResolver>()
+                .RegisterPerScope<ISubstitutionContext, SubstitutionContext>()
+                .RegisterPerScope<CastleDynamicProxyFactory, CastleDynamicProxyFactory>()
+                .RegisterPerScope<DelegateProxyFactory, DelegateProxyFactory>()
+                .RegisterPerScope<IProxyFactory>(r =>
+                    new ProxyFactory(r.Resolve<DelegateProxyFactory>(), r.Resolve<CastleDynamicProxyFactory>()));
+        }
+    }
+}

--- a/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
@@ -49,7 +49,10 @@ namespace NSubstitute.Core.DependencyInjection
                 .RegisterPerScope<CastleDynamicProxyFactory, CastleDynamicProxyFactory>()
                 .RegisterPerScope<DelegateProxyFactory, DelegateProxyFactory>()
                 .RegisterPerScope<IProxyFactory>(r =>
-                    new ProxyFactory(r.Resolve<DelegateProxyFactory>(), r.Resolve<CastleDynamicProxyFactory>()));
+                    new ProxyFactory(r.Resolve<DelegateProxyFactory>(), r.Resolve<CastleDynamicProxyFactory>()))
+                .RegisterPerScope<ICallFactory, CallFactory>()
+                .RegisterPerScope<IPropertyHelper, PropertyHelper>()
+                .RegisterSingleton<IReceivedCallsExceptionThrower, ReceivedCallsExceptionThrower>();
         }
     }
 }

--- a/src/NSubstitute/Core/ISubstitutionContext.cs
+++ b/src/NSubstitute/Core/ISubstitutionContext.cs
@@ -9,6 +9,7 @@ namespace NSubstitute.Core
     {
         ISubstituteFactory SubstituteFactory { get; }
         IRouteFactory RouteFactory { get; }
+        ICallSpecificationFactory CallSpecificationFactory { get; }
 
         /// <summary>
         /// A thread bound state of the NSubstitute context. Usually this API is used to provide the fluent

--- a/src/NSubstitute/Core/Query.cs
+++ b/src/NSubstitute/Core/Query.cs
@@ -10,9 +10,9 @@ namespace NSubstitute.Core
         private readonly HashSet<ICall> _matchingCalls = new HashSet<ICall>(new CallSequenceNumberComparer());
         private readonly ICallSpecificationFactory _callSpecificationFactory;
 
-        public Query()
+        public Query(ICallSpecificationFactory callSpecificationFactory)
         {
-            _callSpecificationFactory = CallSpecificationFactoryFactoryYesThatsRight.CreateCallSpecFactory();
+            _callSpecificationFactory = callSpecificationFactory ?? throw new ArgumentNullException(nameof(callSpecificationFactory));
         }
         
         public void RegisterCall(ICall call)

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -25,7 +25,8 @@ namespace NSubstitute.Core
             IRouteFactory routeFactory,
             ICallSpecificationFactory callSpecificationFactory,
             IThreadLocalContext threadLocalContext,
-            ICallRouterResolver callRouterResolver)
+            ICallRouterResolver callRouterResolver,
+            SequenceNumberGenerator sequenceNumberGenerator)
         {
             SubstituteFactory = substituteFactory ?? throw new ArgumentNullException(nameof(substituteFactory));
             RouteFactory = routeFactory ?? throw new ArgumentNullException(nameof(routeFactory));
@@ -34,7 +35,7 @@ namespace NSubstitute.Core
             _callRouterResolver = callRouterResolver ?? throw new ArgumentNullException(nameof(callRouterResolver));
 
 #pragma warning disable 618 // Obsolete
-            SequenceNumberGenerator = NSubstituteDefaultFactory.DefaultContainer.Resolve<SequenceNumberGenerator>();
+            SequenceNumberGenerator = sequenceNumberGenerator;
 #pragma warning restore 618 // Obsolete
         }
 

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -10,13 +10,15 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 {
     public class CastleDynamicProxyFactory : IProxyFactory
     {
+        private readonly ICallFactory _callFactory;
         private readonly IArgumentSpecificationDequeue _argSpecificationDequeue;
         private readonly ProxyGenerator _proxyGenerator;
         private readonly AllMethodsExceptCallRouterCallsHook _allMethodsExceptCallRouterCallsHook;
 
-        public CastleDynamicProxyFactory(IArgumentSpecificationDequeue argSpecificationDequeue)
+        public CastleDynamicProxyFactory(ICallFactory callFactory, IArgumentSpecificationDequeue argSpecificationDequeue)
         {
-            _argSpecificationDequeue = argSpecificationDequeue;
+            _callFactory = callFactory ?? throw new ArgumentNullException(nameof(callFactory));
+            _argSpecificationDequeue = argSpecificationDequeue ?? throw new ArgumentNullException(nameof(argSpecificationDequeue));
             _proxyGenerator = new ProxyGenerator();
             _allMethodsExceptCallRouterCallsHook = new AllMethodsExceptCallRouterCallsHook();
         }
@@ -28,7 +30,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             var proxyIdInterceptor = new ProxyIdInterceptor(typeToProxy);
             var forwardingInterceptor = new CastleForwardingInterceptor(
                 new CastleInvocationMapper(
-                    new CallFactory(),
+                    _callFactory,
                     _argSpecificationDequeue),
                 callRouter);
 

--- a/src/NSubstitute/Received.cs
+++ b/src/NSubstitute/Received.cs
@@ -14,7 +14,7 @@ namespace NSubstitute
         /// <param name="calls">Action containing calls to substitutes in the expected order</param>
         public static void InOrder(Action calls)
         {
-            var query = new Query();
+            var query = new Query(SubstitutionContext.Current.CallSpecificationFactory);
             SubstitutionContext.Current.ThreadContext.RunInQueryContext(calls, query);
             new SequenceInOrderAssertion().Assert(query.Result());
         }

--- a/tests/NSubstitute.Acceptance.Specs/NSubContainerTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/NSubContainerTests.cs
@@ -1,0 +1,291 @@
+using System;
+using NSubstitute.Core.DependencyInjection;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs
+{
+    public class NSubContainerTests
+    {
+        [Test]
+        public void ShouldActivateRegisteredType()
+        {
+            var sut = new NSubContainer().Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            var result = sut.Resolve<ITestInterface>();
+
+            Assert.That(result, Is.Not.Null);
+        }
+
+        [Test]
+        public void ShouldThrowIfTryToRegisterTypeWithoutPublicCtors()
+        {
+            var sut = new NSubContainer();
+
+            var ex = Assert.Throws<ArgumentException>(() => sut.Register<ITestInterface, TestImplNoPublicCtors>(NSubLifetime.Transient));
+            Assert.That(ex.Message, Contains.Substring("single public constructor"));
+        }
+
+        [Test]
+        public void ShouldThrowIfTryToRegisterTypeWithMultipleCtors()
+        {
+            var sut = new NSubContainer();
+
+            var ex = Assert.Throws<ArgumentException>(() => sut.Register<ITestInterface, TestImplMultipleCtors>(NSubLifetime.Transient));
+            Assert.That(ex.Message, Contains.Substring("single public constructor"));
+        }
+
+        [Test]
+        public void ShouldAllowToRegisterTypeWithMultipleCtorsUsingFactoryMethod()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register(_ => new TestImplMultipleCtors("42"), NSubLifetime.Transient);
+
+            var result = sut.Resolve<TestImplMultipleCtors>();
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void ShouldResolveDependencies()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            var result = sut.Resolve<ClassWithDependency>();
+            Assert.That(result.Dep, Is.AssignableTo<TestImplSingleCtor>());
+        }
+
+        [Test]
+        public void ShouldAllowToResolveDependencyInFactoryMethod()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            sut.Register<ClassWithDependency>(r => new ClassWithDependency(r.Resolve<ITestInterface>()), NSubLifetime.Transient);
+
+            var result = sut.Resolve<ClassWithDependency>();
+            Assert.That(result, Is.Not.Null);
+        }
+
+        [Test]
+        public void ShouldReturnNewInstanceForEachRequestForTransientLifetime()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            var result1 = sut.Resolve<ITestInterface>();
+            var result2 = sut.Resolve<ITestInterface>();
+            Assert.That(result2, Is.Not.SameAs(result1));
+        }
+
+        [Test]
+        public void ShouldReturnNewInstanceForSameRequestForTransientLifetime()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ClassWithMultipleDependencies, ClassWithMultipleDependencies>(NSubLifetime.Transient);
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            var result = sut.Resolve<ClassWithMultipleDependencies>();
+            Assert.That(result.TestInterfaceDep, Is.Not.SameAs(result.ClassWithDependencyDep.Dep));
+        }
+
+        [Test]
+        public void ShouldReturnSameInstanceForNewRequestForSingletonLifetime()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Singleton);
+
+            var result1 = sut.Resolve<ITestInterface>();
+            var result2 = sut.Resolve<ITestInterface>();
+            Assert.That(result2, Is.SameAs(result1));
+        }
+
+        [Test]
+        public void ShouldReturnSameInstanceForSameRequestForSingletonLifetime()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ClassWithMultipleDependencies, ClassWithMultipleDependencies>(NSubLifetime.Transient);
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Singleton);
+
+            var result = sut.Resolve<ClassWithMultipleDependencies>();
+            Assert.That(result.TestInterfaceDep, Is.SameAs(result.ClassWithDependencyDep.Dep));
+        }
+
+        [Test]
+        public void ShouldReturnNewInstanceForNewRequestForPerScopeLifetime()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+
+            var result1 = sut.Resolve<ITestInterface>();
+            var result2 = sut.Resolve<ITestInterface>();
+            Assert.That(result2, Is.Not.SameAs(result1));
+        }
+
+        [Test]
+        public void ShouldReturnSameInstanceForSameRequestForPerScopeLifetime()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ClassWithMultipleDependencies, ClassWithMultipleDependencies>(NSubLifetime.Transient);
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+
+            var result = sut.Resolve<ClassWithMultipleDependencies>();
+            Assert.That(result.TestInterfaceDep, Is.SameAs(result.ClassWithDependencyDep.Dep));
+        }
+
+        [Test]
+        public void ShouldReturnSameInstanceWhenResolvingDependencyInFactoryMethodForPerScopeLifetime()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+            sut.Register<ClassWithMultipleDependencies>(
+                r => new ClassWithMultipleDependencies(r.Resolve<ITestInterface>(), r.Resolve<ClassWithDependency>()),
+                NSubLifetime.Transient);
+
+            var result = sut.Resolve<ClassWithMultipleDependencies>();
+            Assert.That(result.TestInterfaceDep, Is.SameAs(result.ClassWithDependencyDep.Dep));
+        }
+
+        [Test]
+        public void ShouldUseNewRegistrationOnRepeatedRegister()
+        {
+            var sut = new NSubContainer();
+
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+            sut.Register<ITestInterface, TestImplSingleCtor2>(NSubLifetime.Transient);
+
+            var result = sut.Resolve<ITestInterface>();
+            Assert.That(result, Is.AssignableTo<TestImplSingleCtor2>());
+        }
+
+        [Test]
+        public void ShouldCreateNewContainerInstanceOnCustomize()
+        {
+            var sut = new NSubContainer();
+
+            var sutFork = sut.Customize();
+
+            Assert.That(sutFork, Is.Not.SameAs(sut));
+        }
+
+        [Test]
+        public void ShouldNotModifyOriginalContainerOnCustomize()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            var sutFork = sut.Customize().Register<ITestInterface, TestImplSingleCtor2>(NSubLifetime.Transient);
+
+            var sutResult = sut.Resolve<ITestInterface>();
+            var sutForkResult = sutFork.Resolve<ITestInterface>();
+            Assert.That(sutResult, Is.AssignableTo<TestImplSingleCtor>());
+            Assert.That(sutForkResult, Is.AssignableTo<TestImplSingleCtor2>());
+        }
+
+        [Test]
+        public void ShouldReturnFromParentContainerIfNoForkCustomizations()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            var sutFork = sut.Customize().Customize().Customize();
+
+            var result = sutFork.Resolve<ITestInterface>();
+            Assert.That(result, Is.AssignableTo<TestImplSingleCtor>());
+        }
+
+        [Test]
+        public void ShouldFailWithMeaningfulExceptionIfUnableToResolveType()
+        {
+            var sut = new NSubContainer();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => sut.Resolve<ITestInterface>());
+            Assert.That(ex.Message, Contains.Substring("not registered"));
+            Assert.That(ex.Message, Contains.Substring(typeof(ITestInterface).FullName));
+        }
+
+        [Test]
+        public void ShouldReturnSameValueWithinSameExplicitScope()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+            sut.Register<ClassWithDependency, ClassWithDependency>(NSubLifetime.Transient);
+
+            var scope = sut.CreateScope();
+            var result1 = scope.Resolve<ClassWithDependency>();
+            var result2 = scope.Resolve<ClassWithDependency>();
+
+            Assert.That(result1, Is.Not.SameAs(result2));
+            Assert.That(result1.Dep, Is.SameAs(result2.Dep));
+        }
+
+        public interface ITestInterface
+        {
+        }
+
+        public class TestImplSingleCtor : ITestInterface
+        {
+        }
+
+        public class TestImplSingleCtor2 : ITestInterface
+        {
+        }
+
+        public class TestImplMultipleCtors : ITestInterface
+        {
+            public string Value { get; }
+
+            public TestImplMultipleCtors()
+            {
+            }
+
+            public TestImplMultipleCtors(string value)
+            {
+                Value = value;
+            }
+        }
+
+        public class TestImplNoPublicCtors : ITestInterface
+        {
+            private TestImplNoPublicCtors()
+            {
+            }
+        }
+
+        public class ClassWithDependency
+        {
+            public ITestInterface Dep { get; }
+
+            public ClassWithDependency(ITestInterface dep)
+            {
+                Dep = dep;
+            }
+        }
+
+        public class ClassWithMultipleDependencies
+        {
+            public ITestInterface TestInterfaceDep { get; }
+            public ClassWithDependency ClassWithDependencyDep { get; }
+
+            public ClassWithMultipleDependencies(ITestInterface testInterfaceDep, ClassWithDependency classWithDependencyDep)
+            {
+                TestInterfaceDep = testInterfaceDep;
+                ClassWithDependencyDep = classWithDependencyDep;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #439

In this PR I decided to revisit the NSubstitute customization story and bring it to a brand new level 😊 Previously the graph was statically created and if you really want to customize some part (e.g. `AutoValueProviders`) you needed to copy-paste the whole graph activation to your project. With this PR I've introduced a pure dependency injection container, so we use it now to wire up all the dependency graph.

I know that it isn't perfect to invent a wheel for the million and one time, but decided to approach with the own container as:
- our usage is really limited and we don't require much functionality
- didn't want to use the existing container to avoid new dependencies. It could also happen that such container is already used by the client, but it's of different version - and here we have the compatibility issues.

Given that I ended up with only about 150 LOC, it should not make a significant maintenance pressure.

Now if somebody wants to customize the NSubstitute, it can do that using the syntax like:
```c#
SubstitutionContext.Current = NSubstituteDefaultFactory.DefaultContainer.Customize()
   .RegisterScoped<IAutoValueProvidersFactory, CoolAndFancyAutoValueProvidersFactory>()
   .Resolve<ISubstitutionContext>();
```

Pretty neat, isn't it? 😃 

As for the activation performance, it degraded a bit of course, however numbers are much better than I expected:

```
               Method |  Job | Runtime |      Mean |     Error |    StdDev |    Median |
-------------------- |----- |-------- |----------:|----------:|----------:|----------:|
 ActivateUsingOldWay |  Clr |     Clr |  2.309 us | 0.0451 us | 0.0675 us |  2.300 us |
 ActivateUsingNewWay |  Clr |     Clr | 15.050 us | 0.0464 us | 0.0411 us | 15.036 us |
 ActivateUsingOldWay | Core |    Core |  2.321 us | 0.0462 us | 0.1152 us |  2.312 us |
 ActivateUsingNewWay | Core |    Core | 14.675 us | 0.2917 us | 0.5407 us | 14.419 us |
```

However given that we activate graph only once, it shouldn't be an issue at all.

@dtchepak @alexandrnikitin Please take a look. I know that it's a significant change, however looks like a small (but significant) step forward.