### PR TITLE
Add feature to call base for the specified methods

### DIFF
--- a/src/NSubstitute/Core/ICallBaseConfiguration.cs
+++ b/src/NSubstitute/Core/ICallBaseConfiguration.cs
@@ -9,8 +9,15 @@
 
         /// <summary>
         /// Specifies whether base method should be always ignored for the matching call.
+        /// If method is both explicitly excluded and included, base method is _not_ called.
         /// </summary>
         void Exclude(ICallSpecification callSpecification);
+
+        /// <summary>
+        /// Specifies whether base method should be called for the matching call.
+        /// If method is both explicitly excluded and included, base method is _not_ called.
+        /// </summary>
+        void Include(ICallSpecification callSpecification);
 
         /// <summary>
         /// Tests whether base method should be called for the call given the existing configuration.

--- a/src/NSubstitute/Core/WhenCalled.cs
+++ b/src/NSubstitute/Core/WhenCalled.cs
@@ -51,6 +51,15 @@ namespace NSubstitute.Core
         }
 
         /// <summary>
+        /// Call the base implementation of future calls. For use with non-partial class substitutes.
+        /// </summary>
+        public void CallBase()
+        {
+            _callRouter.SetRoute(x => _routeFactory.CallBase(x, _matchArgs));
+            _call(_substitute);
+        }
+
+        /// <summary>
         /// Throw the specified exception when called.
         /// </summary>
         public void Throw(Exception exception)

--- a/src/NSubstitute/Routing/Handlers/CallBaseForCallHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/CallBaseForCallHandler.cs
@@ -1,0 +1,30 @@
+using System;
+using NSubstitute.Core;
+using NSubstitute.Exceptions;
+
+namespace NSubstitute.Routing.Handlers
+{
+    public class CallBaseForCallHandler : ICallHandler
+    {
+        private readonly ICallSpecificationFactory _callSpecificationFactory;
+        private readonly ICallBaseConfiguration _callBaseConfig;
+        private readonly MatchArgs _matchArgs;
+
+        public CallBaseForCallHandler(ICallSpecificationFactory callSpecificationFactory, ICallBaseConfiguration callBaseConfig, MatchArgs matchArgs)
+        {
+            _callSpecificationFactory = callSpecificationFactory ?? throw new ArgumentNullException(nameof(callSpecificationFactory));
+            _callBaseConfig = callBaseConfig ?? throw new ArgumentNullException(nameof(callBaseConfig));
+            _matchArgs = matchArgs ?? throw new ArgumentNullException(nameof(matchArgs));
+        }
+
+        public RouteAction Handle(ICall call)
+        {
+            if (!call.CanCallBase) throw CouldNotConfigureCallBaseException.ForSingleCall();
+
+            var callSpec = _callSpecificationFactory.CreateFrom(call, _matchArgs);
+            _callBaseConfig.Include(callSpec);
+
+            return RouteAction.Continue();
+        }
+    }
+}

--- a/src/NSubstitute/Routing/IRouteFactory.cs
+++ b/src/NSubstitute/Routing/IRouteFactory.cs
@@ -10,6 +10,7 @@ namespace NSubstitute.Routing
         IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity);
         IRoute DoWhenCalled(ISubstituteState state, Action<CallInfo> doAction, MatchArgs matchArgs);
         IRoute DoNotCallBase(ISubstituteState state, MatchArgs matchArgs);
+        IRoute CallBase(ISubstituteState state, MatchArgs matchArgs);
         IRoute RaiseEvent(ISubstituteState state, Func<ICall, object[]> getEventArguments);
         IRoute RecordCallSpecification(ISubstituteState state);
         IRoute RecordReplay(ISubstituteState state);

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -57,6 +57,15 @@ namespace NSubstitute.Routing
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
+        public IRoute CallBase(ISubstituteState state, MatchArgs matchArgs)
+        {
+            return new Route(new ICallHandler[] {
+                new ClearLastCallRouterHandler(_threadLocalContext)
+                , new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
+                , new CallBaseForCallHandler(_callSpecificationFactory, state.CallBaseConfiguration, matchArgs)
+                , ReturnDefaultForReturnTypeHandler()
+            });
+        }
         public IRoute RaiseEvent(ISubstituteState state, Func<ICall, object[]> getEventArguments)
         {
             return new Route(new ICallHandler[] {


### PR DESCRIPTION
Closes #405

This in PR I'm adding a feature to enable base call for the specific method. Usage:
```c#
var substitute = Subsitute.For<SomeClass>();
substitute.When(x => x.MethodWithImpl()).CallBase();

substitute.MethodWithImpl();
```

It's useful when you have non-partial proxy and want to make some methods/properties "live".

We also handle the special cases:
- If you both explicitly exclude and include call, ~the exclusion wins. It's a rare case (if it isn't unrealistic at all), but I think it's completely fine as if you disabled calls, you probably did that for purpose.~ the last rule wins. That's done to be compliant with other places of product (like `Received`).
- If you try to enable base method call when implementation is not available, we are failing with the meaningful exception.

I know that you have some doubts regarding the syntax, but to me it looks pretty natural giving the existing API. I needed that feature a lot when working with the legacy codebase with method made virtual only to enable the easier unit testing (and not pay for TypeMock 😊).

@dtchepak @alexandrnikitin Happy review!