### PR TITLE
Docs: out/ref arg matchers, CompatArg, non-virtuals warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     syntax (1.0.0)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ We can ask NSubstitute to create a substitute instance for this type. We could a
     _calculator = Substitute.For<ICalculator>();
 <!-- {% endexamplecode %} -->
 
+⚠️ **Note**: NSubstitute will only work properly with interfaces or with `virtual` members of classes. Be careful substituting for classes with non-virtual members. See [Creating a substitute](/help/creating-a-substitute/#substituting_infrequently_and_carefully_for_classes) for more information.
+
 Now we can tell our substitute to return a value for a call:
 
 <!-- {% examplecode csharp %} -->

--- a/build/ExtractDocs.fsx
+++ b/build/ExtractDocs.fsx
@@ -36,6 +36,7 @@ module ExtractDocs =
     using System.Collections.Generic;
     using System.ComponentModel;
     using NSubstitute.Extensions;
+    using NSubstitute.Compatibility;
 
     namespace NSubstitute.Samples {
         public class Tests_%s {

--- a/docs/help/_posts/2010-01-01-getting-started.markdown
+++ b/docs/help/_posts/2010-01-01-getting-started.markdown
@@ -44,6 +44,8 @@ We can ask NSubstitute to create a substitute instance for this type. We could a
 calculator = Substitute.For<ICalculator>();
 {% endexamplecode %}
 
+⚠️ **Note**: NSubstitute will only work properly with interfaces or with `virtual` members of classes. Be careful substituting for classes with non-virtual members. See [Creating a substitute](/help/creating-a-substitute/#substituting_infrequently_and_carefully_for_classes) for more information.
+
 Now we can tell our substitute to return a value for a call:
 
 {% examplecode csharp %}

--- a/docs/help/_posts/2010-01-02-creating-a-substitute.markdown
+++ b/docs/help/_posts/2010-01-02-creating-a-substitute.markdown
@@ -13,7 +13,7 @@ This is how you'll normally create substitutes for types. Generally this type wi
 
 ## Substituting (infrequently and carefully) for classes
 
-**Warning:** Substituting for classes can have some nasty side-effects!
+⚠️ **Warning:** Substituting for classes can have some nasty side-effects!
 
 For starters, **NSubstitute can only work with *virtual* members of the class**, so any non-virtual code in the class will actually execute! If you try to substitute for a class that formats your hard drive in the constructor or in a non-virtual property setter then you're asking for trouble.
 

--- a/docs/help/_posts/2010-04-01-argument-matchers.markdown
+++ b/docs/help/_posts/2010-04-01-argument-matchers.markdown
@@ -7,7 +7,7 @@ Argument matchers can be used when [setting return values](/help/return-for-args
 
 The argument matchers syntax shown here depends on having C# 7.0 or later. If you are stuck on an earlier version (getting an error such as `CS7085: By-reference return type 'ref T' is not supported` while trying to use them) please use [compatibility argument matchers](/help/compat-args) instead. 
 
-⚠️ **Note:** Argument matchers should only be used when setting return values or checking received calls. Using `Arg.Is` or `Arg.Any` without a call to `.Returns` or `Received()` can cause your tests to behave in unexpected ways. See [How NOT to use argument matchers](#how_not_to_use_argument_matchers) for more information.
+⚠️ **Note:** Argument matchers should only be used when setting return values or checking received calls. Using `Arg.Is` or `Arg.Any` without a call to `Returns(...)` or `Received()` can cause your tests to behave in unexpected ways. See [How NOT to use argument matchers](#how_not_to_use_argument_matchers) for more information.
 
 {% requiredcode %}
 public interface ICalculator {

--- a/docs/help/_posts/2010-04-01-argument-matchers.markdown
+++ b/docs/help/_posts/2010-04-01-argument-matchers.markdown
@@ -114,8 +114,7 @@ calculator
         return true;
     });
 
-int memoryValue;
-var hasEntry = calculator.LoadMemory(1, out memoryValue);
+var hasEntry = calculator.LoadMemory(1, out var memoryValue);
 Assert.AreEqual(true, hasEntry);
 Assert.AreEqual(42, memoryValue);
 {% endexamplecode %}
@@ -128,7 +127,7 @@ Occasionally argument matchers get used in ways that cause unexpected results fo
 
 ### Using matchers outside of stubbing or checking received calls
 
-Argument matchers should only be used when setting return values or checking received calls. Using `Arg.Is` or `Arg.Any` without a call to `.Returns` or `Received()` can cause your tests to behave in unexpected ways.
+Argument matchers should only be used when setting return values or checking received calls. Using `Arg.Is` or `Arg.Any` without a call to `Returns(...)` or `Received()` can cause your tests to behave in unexpected ways.
 
 For example:
 

--- a/docs/help/_posts/2010-11-01-setting-out-and-ref-arguments.markdown
+++ b/docs/help/_posts/2010-11-01-setting-out-and-ref-arguments.markdown
@@ -15,16 +15,16 @@ For the interface above we can configure the return value and set the output of 
 
 {% examplecode csharp %}
 //Arrange
-var value = "";
 var lookup = Substitute.For<ILookup>();
 lookup
-    .TryLookup("hello", out value)
+    .TryLookup("hello", out Arg.Is(""))
     .Returns(x => { 
         x[1] = "world!";
         return true;
     });
 
 //Act
+var value = "";
 var result = lookup.TryLookup("hello", out value);
 
 //Assert
@@ -32,5 +32,30 @@ Assert.True(result);
 Assert.AreEqual(value, "world!");
 {% endexamplecode %}
 
+## Matching after assignments
 
+Be careful when using an argument matcher with a reference we also assign to. The assignment can cause previously matching arguments to stop matching.
+
+{% examplecode csharp %}
+var counter = 0;
+var value = "";
+var lookup = Substitute.For<ILookup>();
+lookup
+    .TryLookup("hello", out Arg.Is(value)) // value is "", matcher will check for ""
+    .Returns(x => { 
+        x[1] = "assigned"; // Assign to 2nd arg
+        counter++;         // Count this matching call
+        return true;
+    });
+
+// value is "", this will match!
+lookup.TryLookup("hello", out value);
+// Call matches, counter is now 1:
+Assert.AreEqual(1, counter);
+
+// value is now "assigned" but arg matcher is still looking for "", will NOT match anymore!
+lookup.TryLookup("hello", out value);
+// Call does NOT match anymore, counter is still 1:
+Assert.AreEqual(1, counter);
+{% endexamplecode %}
 

--- a/docs/help/_posts/2013-04-15-compat-args.markdown
+++ b/docs/help/_posts/2013-04-15-compat-args.markdown
@@ -1,0 +1,49 @@
+---
+title: Compatibility argument matchers
+layout: post
+---
+
+NSubstitute [argument matchers](/help/argument-matchers) depend on having C# 7.0 or later (as of NSubstitute 4.0). If you are stuck on an earlier version of C# you may get an error like the following when trying to use a matcher like `Arg.Is(123)`:
+
+> `CS7085: By-reference return type 'ref T' is not supported.`
+
+If you have C# 7.0-compatible tooling installed you can [set `<LangVersion />` in your test csproj file](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version) to `7` or higher, or to `latest` or `default`.
+
+Stuck with pre-7.0 tooling? Then use `CompatArg` from the `NSubstitute.Compatibility` namespace instead of `Arg`. `CompatArg` will work everywhere `Arg` does, with the exception of matching `out` and `ref` args (which require C# 7.0 features). For example, if the documentation mentions `Arg.Is(42)`, you can instead use `CompatArg.Is(42)`. 
+
+## Using `CompatArg`
+
+First, add `NSubstitute.Compatibility` to the list of imports:
+
+    using NSubstitute;
+    using NSubstitute.Compatibility;
+
+Then use `CompatArg` in place of `Arg`:
+
+{% requiredcode %}
+public interface ICalculator {
+    int Add(int a, int b);
+}
+ICalculator calculator;
+[SetUp] public void SetUp() { 
+    calculator = Substitute.For<ICalculator>(); 
+}
+{% endrequiredcode %}
+
+{% examplecode csharp %}
+calculator.Add(1, -10);
+
+// Instead of `Arg.Is<int>(x => x < 0)`, use:
+calculator.Received().Add(1, CompatArg.Is<int>(x => x < 0));
+
+// Instead of `Arg.Any<int>()`, use:
+calculator
+    .Received()
+    .Add(1, CompatArg.Any<int>());
+
+// Same for Returns and DidNotReceive:
+calculator.Add(CompatArg.Any<int>(), CompatArg.Is(42)).Returns(123);
+calculator.DidNotReceive().Add(CompatArg.Is<int>(x => x > 10), -10);
+{% endexamplecode %}
+
+To make this a bit less verbose you may want to create a wrapper within the root of your test project with a shorter name (e.g. `ArgC`) that delegates to `CompatArg`. This will also avoid needing the extra using import, and make it easier to switch to the standard `Arg` class once you're able to update to C# 7.0 and beyond.


### PR DESCRIPTION
Update docs for 4.0 release.

- Document out/ref matcher use. Closes #399.
- Add CompatArg documentation from #401.
- Add non-virtuals warning to getting started and readme. Closes #437.