### PR TITLE
Make next route configuration thread local

### DIFF
--- a/src/NSubstitute/Core/CallRouterResolver.cs
+++ b/src/NSubstitute/Core/CallRouterResolver.cs
@@ -9,14 +9,14 @@ namespace NSubstitute.Core
         {
             if (substitute == null) throw new NullSubstituteReferenceException();
 
-            if (substitute is ICallRouter callRouter)
+            if (substitute is ICallRouterProvider callRouterProvider)
             {
-                return callRouter;
+                return callRouterProvider.GetCallRouter();
             }
 
-            if (substitute is Delegate delegateProxy && delegateProxy.Target is ICallRouter delegateCallRouter)
+            if (substitute is Delegate delegateProxy && delegateProxy.Target is ICallRouterProvider delegateCallRouter)
             {
-                return delegateCallRouter;
+                return delegateCallRouter.GetCallRouter();
             }
 
             throw new NotASubstituteException();

--- a/src/NSubstitute/Core/Events/RaiseEventWrapper.cs
+++ b/src/NSubstitute/Core/Events/RaiseEventWrapper.cs
@@ -32,7 +32,7 @@ namespace NSubstitute.Core.Events
         protected static void RaiseEvent(RaiseEventWrapper wrapper)
         {
             var context = SubstitutionContext.Current;
-            context.ThreadContext.SetPendingRasingEventArgumentsFactory(call => wrapper.WorkOutRequiredArguments(call));
+            context.ThreadContext.SetPendingRaisingEventArgumentsFactory(call => wrapper.WorkOutRequiredArguments(call));
         }
     }
 }

--- a/src/NSubstitute/Core/ICallRouter.cs
+++ b/src/NSubstitute/Core/ICallRouter.cs
@@ -17,6 +17,8 @@ namespace NSubstitute.Core
         ConfiguredCall LastCallShouldReturn(IReturn returnValue, MatchArgs matchArgs, PendingSpecificationInfo pendingSpecInfo);
         object Route(ICall call);
         IEnumerable<ICall> ReceivedCalls();
+        [Obsolete("This method is deprecated and will be removed in future versions of the product. " +
+                  "Please use " + nameof(IThreadLocalContext) + "." + nameof(IThreadLocalContext.SetNextRoute) + " method instead.")]
         void SetRoute(Func<ISubstituteState, IRoute> getRoute);
         void SetReturnForType(Type type, IReturn returnValue);
         void RegisterCustomCallHandlerFactory(CallHandlerFactory factory);

--- a/src/NSubstitute/Core/ICallRouterProvider.cs
+++ b/src/NSubstitute/Core/ICallRouterProvider.cs
@@ -1,0 +1,7 @@
+namespace NSubstitute.Core
+{
+    public interface ICallRouterProvider
+    {
+        ICallRouter GetCallRouter();
+    }
+}

--- a/src/NSubstitute/Core/ISubstitutionContext.cs
+++ b/src/NSubstitute/Core/ISubstitutionContext.cs
@@ -43,7 +43,7 @@ namespace NSubstitute.Core
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.SetPendingRasingEventArgumentsFactory) + "() method instead.")]
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.SetPendingRaisingEventArgumentsFactory) + "() method instead.")]
         void RaiseEventForNextCall(Func<ICall, object[]> getArguments);
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +

--- a/src/NSubstitute/Core/IThreadLocalContext.cs
+++ b/src/NSubstitute/Core/IThreadLocalContext.cs
@@ -15,7 +15,7 @@ namespace NSubstitute.Core
         void EnqueueArgumentSpecification(IArgumentSpecification spec);
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();
 
-        void SetPendingRasingEventArgumentsFactory(Func<ICall, object[]> getArguments);
+        void SetPendingRaisingEventArgumentsFactory(Func<ICall, object[]> getArguments);
         /// <summary>
         /// Returns the previously set arguments factory and resets the stored value.
         /// </summary>

--- a/src/NSubstitute/Core/IThreadLocalContext.cs
+++ b/src/NSubstitute/Core/IThreadLocalContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NSubstitute.Core.Arguments;
+using NSubstitute.Routing;
 
 namespace NSubstitute.Core
 {
@@ -11,6 +12,16 @@ namespace NSubstitute.Core
         void SetLastCallRouter(ICallRouter callRouter);
         void ClearLastCallRouter();
         ConfiguredCall LastCallShouldReturn(IReturn value, MatchArgs matchArgs);
+
+        /// <summary>
+        /// Sets the route to use for the next call dispatch on the current thread for the specified <paramref name="callRouter"/>.
+        /// </summary>
+        void SetNextRoute(ICallRouter callRouter, Func<ISubstituteState, IRoute> nextRouteFactory);
+        /// <summary>
+        /// Returns the previously configured next route and resets the stored value.
+        /// If route was configured for the different router, returns <see langword="null"/> and persist the route info.
+        /// </summary>
+        Func<ISubstituteState, IRoute> UseNextRoute(ICallRouter callRouter);
 
         void EnqueueArgumentSpecification(IArgumentSpecification spec);
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -126,9 +126,9 @@ namespace NSubstitute.Core
             ThreadContext.DequeueAllArgumentSpecifications();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
-                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.SetPendingRasingEventArgumentsFactory) + "() method instead.")]
+                  "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.SetPendingRaisingEventArgumentsFactory) + "() method instead.")]
         public void RaiseEventForNextCall(Func<ICall, object[]> getArguments) =>
-            ThreadContext.SetPendingRasingEventArgumentsFactory(getArguments);
+            ThreadContext.SetPendingRaisingEventArgumentsFactory(getArguments);
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.UsePendingRaisingEventArgumentsFactory) + "() method instead.")]

--- a/src/NSubstitute/Core/ThreadLocalContext.cs
+++ b/src/NSubstitute/Core/ThreadLocalContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using NSubstitute.Core.Arguments;
 using NSubstitute.Exceptions;
+using NSubstitute.Routing;
 
 namespace NSubstitute.Core
 {
@@ -14,6 +15,7 @@ namespace NSubstitute.Core
         private readonly RobustThreadLocal<Func<ICall, object[]>> _getArgumentsForRaisingEvent;
         private readonly RobustThreadLocal<IQuery> _currentQuery;
         private readonly RobustThreadLocal<PendingSpecificationInfo> _pendingSpecificationInfo;
+        private readonly RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>> _nextRouteFactory;
         public IPendingSpecification PendingSpecification { get; }
 
         public ThreadLocalContext()
@@ -23,6 +25,7 @@ namespace NSubstitute.Core
             _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object[]>>();
             _currentQuery = new RobustThreadLocal<IQuery>();
             _pendingSpecificationInfo = new RobustThreadLocal<PendingSpecificationInfo>();
+            _nextRouteFactory = new RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>>();
 
             PendingSpecification = new PendingSpecificationWrapper(_pendingSpecificationInfo);
         }
@@ -52,6 +55,28 @@ namespace NSubstitute.Core
             var configuredCall = lastCallRouter.LastCallShouldReturn(value, matchArgs, pendingSpecInfo);
             ClearLastCallRouter();
             return configuredCall;
+        }
+
+        public void SetNextRoute(ICallRouter callRouter, Func<ISubstituteState, IRoute> nextRouteFactory)
+        {
+            if (callRouter == null) throw new ArgumentNullException(nameof(callRouter));
+            if (nextRouteFactory == null) throw new ArgumentNullException(nameof(nextRouteFactory));
+
+            _nextRouteFactory.Value = Tuple.Create(callRouter, nextRouteFactory);
+        }
+
+        public Func<ISubstituteState, IRoute> UseNextRoute(ICallRouter callRouter)
+        {
+            if (callRouter == null) throw new ArgumentNullException(nameof(callRouter));
+            
+            var value = _nextRouteFactory.Value;
+            if (value != null && ReferenceEquals(callRouter, value.Item1))
+            {
+                _nextRouteFactory.Value = null;
+                return value.Item2;
+            }
+
+            return null;
         }
 
         public void ClearLastCallRouter()

--- a/src/NSubstitute/Core/ThreadLocalContext.cs
+++ b/src/NSubstitute/Core/ThreadLocalContext.cs
@@ -78,7 +78,7 @@ namespace NSubstitute.Core
             return queue;
         }
 
-        public void SetPendingRasingEventArgumentsFactory(Func<ICall, object[]> getArguments)
+        public void SetPendingRaisingEventArgumentsFactory(Func<ICall, object[]> getArguments)
         {
             _getArgumentsForRaisingEvent.Value = getArguments;
         }

--- a/src/NSubstitute/Extensions/ConfigurationExtensions.cs
+++ b/src/NSubstitute/Extensions/ConfigurationExtensions.cs
@@ -22,10 +22,8 @@ namespace NSubstitute.Extensions
         public static T Configure<T>(this T substitute) where T : class
         {
             var context = SubstitutionContext.Current;
-            var router = context.GetCallRouterFor(substitute);
-            var routeFactory = context.RouteFactory;
-
-            router.SetRoute(state => routeFactory.RecordCallSpecification(state));
+            var callRouter = context.GetCallRouterFor(substitute);
+            context.ThreadContext.SetNextRoute(callRouter, context.RouteFactory.RecordCallSpecification);
 
             return substitute;
         }

--- a/src/NSubstitute/Extensions/ReceivedExtensions.cs
+++ b/src/NSubstitute/Extensions/ReceivedExtensions.cs
@@ -16,9 +16,9 @@ namespace NSubstitute.ReceivedExtensions
         public static T Received<T>(this T substitute, Quantity requiredQuantity)
         {
             var context = SubstitutionContext.Current;
-            var router = context.GetCallRouterFor(substitute);
-            var routeFactory = context.RouteFactory;
-            router.SetRoute(x => routeFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity));
+            var callRouter = context.GetCallRouterFor(substitute);
+
+            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity));
             return substitute;
         }
 
@@ -32,9 +32,9 @@ namespace NSubstitute.ReceivedExtensions
         public static T ReceivedWithAnyArgs<T>(this T substitute, Quantity requiredQuantity)
         {
             var context = SubstitutionContext.Current;
-            var router = context.GetCallRouterFor(substitute);
-            var routeFactory = context.RouteFactory;
-            router.SetRoute(x => routeFactory.CheckReceivedCalls(x, MatchArgs.Any, requiredQuantity));
+            var callRouter = context.GetCallRouterFor(substitute);
+
+            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.Any, requiredQuantity));
             return substitute;
         }
     }

--- a/src/NSubstitute/Routing/IRoute.cs
+++ b/src/NSubstitute/Routing/IRoute.cs
@@ -5,6 +5,5 @@ namespace NSubstitute.Routing
     public interface IRoute
     {
         object Handle(ICall call);
-        bool IsRecordReplayRoute { get; }
     }
 }

--- a/src/NSubstitute/Routing/Route.cs
+++ b/src/NSubstitute/Routing/Route.cs
@@ -1,23 +1,17 @@
+using System;
 using System.Collections.Generic;
 using NSubstitute.Core;
 
 namespace NSubstitute.Routing
 {
-    public enum RouteType { Other, RecordReplay }
-
     public class Route : IRoute
     {
         private readonly ICallHandler[] _handlers;
 
-        public Route(ICallHandler[] handlers) : this(RouteType.Other, handlers) { }
-
-        public Route(RouteType routeType, ICallHandler[] handlers)
+        public Route(ICallHandler[] handlers)
         {
-            IsRecordReplayRoute = routeType == RouteType.RecordReplay;
-            _handlers = handlers;
+            _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
         }
-
-        public bool IsRecordReplayRoute { get; }
 
         public IEnumerable<ICallHandler> Handlers => _handlers;
 

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -97,7 +97,7 @@ namespace NSubstitute.Routing
         }
         public IRoute RecordReplay(ISubstituteState state)
         {
-            return new Route(RouteType.RecordReplay, new ICallHandler[] {
+            return new Route(new ICallHandler[] {
                 new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
                 , new TrackLastCallHandler(_threadLocalContext.PendingSpecification)
                 , new RecordCallHandler(state.ReceivedCalls, _sequenceNumberGenerator)

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Exceptions;
+using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
 
 namespace NSubstitute.Acceptance.Specs
@@ -222,6 +223,20 @@ namespace NSubstitute.Acceptance.Specs
             var nonMatchingResult = _something.MethodWithOutParameter(0, out int _);
             Assert.That(matchingResult, Is.EqualTo(42));
             Assert.That(nonMatchingResult, Is.Not.EqualTo(42));
+        }
+
+        [Test]
+        public void Should_allow_to_check_received_using_properties_from_other_substitutes()
+        {
+            // Arrange
+            var otherSubs = Substitute.For<ISomething>();
+            otherSubs.SomeProperty.Returns(42);
+            
+            // Act
+            _something.Echo(42);
+            
+            // Assert
+            _something.Received().Echo(otherSubs.SomeProperty);
         }
 
         [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ConcurrencyTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ConcurrencyTests.cs
@@ -1,121 +1,278 @@
 ﻿using System;
 using System.Threading;
 using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.Exceptions;
+using NSubstitute.Extensions;
 using NUnit.Framework;
+using Task = System.Threading.Tasks.Task;
 
 namespace NSubstitute.Acceptance.Specs
 {
     public class ConcurrencyTests
     {
         [Test]
-        public void Call_between_invocation_and_received_doesnt_cause_issue()
+        public async Task Call_between_invocation_and_received_does_not_cause_issue()
         {
-            //arrange
+            // Arrange
             var subs = Substitute.For<ISomething>();
 
             var backgroundReady = new AutoResetEvent(false);
 
-            //act
+            // Act
+            // 1
             var dummy = subs.Say("ping");
 
-            RunInOtherThread(() =>
+            var bg = RunInOtherThread(() =>
             {
+                // 2
                 subs.Echo(42);
                 backgroundReady.Set();
             });
 
             backgroundReady.WaitOne();
 
+            // 3
             dummy.Returns("pong");
 
-            //assert
+            // Assert
             var actualResult = subs.Say("ping");
 
             Assert.That(actualResult, Is.EqualTo("pong"));
+            await bg;
         }
 
         [Test]
-        public void Background_invocation_doesnt_delete_specification()
+        public async Task Background_invocation_does_not_delete_specification()
         {
-            //arrange
+            // Arrange
             var subs = Substitute.For<ISomething>();
 
             var backgroundReady = new AutoResetEvent(false);
 
-            //act
+            // Act
+            // 1
             var dummy = subs.Say(Arg.Any<string>());
 
-            RunInOtherThread(() =>
+            var bg = RunInOtherThread(() =>
             {
+                // 2
                 subs.Say("hello");
                 backgroundReady.Set();
             });
 
             backgroundReady.WaitOne();
+
+            // 3
             dummy.Returns("42");
 
-            //assert
+            // Assert
             Assert.That(subs.Say("Alex"), Is.EqualTo("42"));
+            await bg;
         }
 
         [Test]
-        public void Both_threads_can_configure_returns_concurrently()
+        public async Task Both_threads_can_configure_returns_concurrently()
         {
-            //arrange
+            // Arrange
             var subs = Substitute.For<ISomething>();
 
             var foregroundReady = new AutoResetEvent(false);
             var backgroundReady = new AutoResetEvent(false);
 
-            //act
-            //1
+            // Act
+            // 1
             var dummy = subs.Say("ping");
 
-            RunInOtherThread(() =>
+            var bg = RunInOtherThread(() =>
             {
-                //2
+                // 2
                 var d = subs.Echo(42);
                 SignalAndWait(backgroundReady, foregroundReady);
 
-                //4
+                // 4
                 d.Returns("42");
                 backgroundReady.Set();
             });
 
             backgroundReady.WaitOne();
 
-            //3
+            // 3
             dummy.Returns("pong");
             SignalAndWait(foregroundReady, backgroundReady);
 
-            //assert
+            // Assert
             Assert.That(subs.Say("ping"), Is.EqualTo("pong"));
             Assert.That(subs.Echo(42), Is.EqualTo("42"));
+            await bg;
         }
 
         [Test]
-        public void Configuration_works_fine_for_async_methods()
+        public async Task Both_threads_can_verify_received_calls_concurrently()
         {
-            //arrange
+            // arrange
             var subs = Substitute.For<ISomething>();
 
-            //act
+            var foregroundReady = new AutoResetEvent(false);
+            var backgroundReady = new AutoResetEvent(false);
+
+            // act
+            // 1
+            subs.Add(1, 2);
+            subs.Echo(42);
+
+            subs.Received();
+
+            var bg = RunInOtherThread(() =>
+            {
+                // 2
+                subs.Received();
+                SignalAndWait(backgroundReady, foregroundReady);
+
+                // 4
+                // Make exceptional situation, as otherwise it isn't clear whether call is actually verified.
+                Assert.Throws<ReceivedCallsException>(() => subs.Echo(99)); // This call is checked for being received.
+            });
+
+            backgroundReady.WaitOne();
+
+            // 3
+            subs.Add(1, 2); // This call is checked for being received.
+            foregroundReady.Set();
+
+            await bg;
+        }
+
+        [Test]
+        public async Task Both_threads_can_verify_received_calls_with_any_args_concurrently()
+        {
+            // arrange
+            var subs = Substitute.For<ISomething>();
+
+            var foregroundReady = new AutoResetEvent(false);
+            var backgroundReady = new AutoResetEvent(false);
+
+            // act
+            // 1
+            subs.Add(1, 2);
+            subs.Echo(42);
+
+            subs.ReceivedWithAnyArgs();
+
+            var bg = RunInOtherThread(() =>
+            {
+                // 2
+                subs.DidNotReceiveWithAnyArgs();
+                SignalAndWait(backgroundReady, foregroundReady);
+
+                // 4
+                // Make exceptional situation, as otherwise it isn't clear whether call is actually verified.
+                Assert.Throws<ReceivedCallsException>(() => subs.Echo(default)); // This call is checked for being received.
+            });
+
+            backgroundReady.WaitOne();
+
+            // 3
+            subs.Add(default, default); // This call is checked for being received.
+            foregroundReady.Set();
+
+            await bg;
+        }
+
+        [Test]
+        public async Task Can_configure_using_Configure_method_concurrently()
+        {
+            // Arrange
+            var subs = Substitute.ForPartsOf<TypeWhichThrows>();
+
+            var foregroundReady = new AutoResetEvent(false);
+            var backgroundReady = new AutoResetEvent(false);
+
+            // Act
+            // 1
+            subs.Configure();
+
+            var bg = RunInOtherThread(() =>
+            {
+                // 2
+                subs.Configure();
+                SignalAndWait(backgroundReady, foregroundReady);
+
+                // 4
+                subs.EchoMethodB(42).Returns(42);
+                backgroundReady.Set();
+            });
+
+            backgroundReady.WaitOne();
+
+            // 3
+            subs.EchoMethodA(42).Returns(42);
+            SignalAndWait(foregroundReady, backgroundReady);
+
+            // Assert
+            // 5
+            var resultA = subs.EchoMethodA(42);
+            var resultB = subs.EchoMethodB(42);
+            Assert.That(resultA, Is.EqualTo(42));
+            Assert.That(resultB, Is.EqualTo(42));
+            await bg;
+        }
+
+        [Test]
+        public async Task Configure_in_one_thread_should_not_affect_substitute_in_other_thread()
+        {
+            // Arrange
+            var subs = Substitute.For<ISomething>();
+            var backgroundReady = new AutoResetEvent(false);
+
+            // Act
+            // 1
+            subs.Echo(42).Returns("42");
+
+            var bg = RunInOtherThread(() =>
+            {
+                // 2
+                subs.Configure();
+                backgroundReady.Set();
+            });
+
+            backgroundReady.WaitOne();
+            // 3
+            var result = subs.Echo(42);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("42"));
+            await bg;
+        }
+
+        [Test]
+        public async Task Configuration_works_fine_for_async_methods()
+        {
+            // Arrange
+            var subs = Substitute.For<ISomething>();
+
+            // Act
             subs.EchoAsync(42).Returns("42");
 
-            //assert
-            var result = subs.EchoAsync(42).Result;
+            // Assert
+            var result = await subs.EchoAsync(42);
             Assert.That(result, Is.EqualTo("42"));
         }
 
-        private static void RunInOtherThread(Action action)
+        private static Task RunInOtherThread(Action action)
         {
-            new Thread(action.Invoke) {IsBackground = true}.Start();
+            return Task.Factory.StartNew(action);
         }
 
         private static void SignalAndWait(EventWaitHandle toSignal, EventWaitHandle toWait)
         {
             toSignal.Set();
             toWait.WaitOne();
+        }
+
+        public class TypeWhichThrows
+        {
+            public virtual int EchoMethodA(int value) => throw new NotImplementedException();
+            public virtual int EchoMethodB(int value) => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Closes #453

I reviewed the issue 453 for a few times and while personally I don't want to support concurrency on setup/teardown phases, I feel that NSubstitute should be transparent on the behavior it has. The next route we are specifying for the call router should be thread-local, as our syntax in fact implies that.

After a couple of days of brainstorming, I came up with the current implementation. Now background calls don't affect the arrange/assertion phases of the test and temporary next route is local to the current thread only. I don't believe that someone will really utilize this feature, but I am happy that now we better comply with the [Principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) - when people see `subs.Received().Call()` they could barely imagine why background thread becomes crazy 😅 

Notice, I needed to apply a change to our internal architecture. Previously, the `CallRouter` instance was mixed in to the substitute directly (meaning that substitute implemented `ICallRouter` interface). I don't perform that anymore and now I mix in the `CallRouterProvider` wrapper holding a `CallRouter` reference. That's because when I resolve `callRouter` instance from substitute, I need it to point to the actual call router object, rather than to a proxy. See more detail in the code.

Just in case attaching the performance tests:

BEFORE
```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3914063 Hz, Resolution=255.4890 ns, Timer=TSC
.NET Core SDK=2.1.402
  [Host] : .NET Core 1.1.2 (CoreCLR 4.6.25211.01, CoreFX 4.6.24705.01), 64bit RyuJIT
  Clr    : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3190.0
  Core   : .NET Core 1.1.2 (CoreCLR 4.6.25211.01, CoreFX 4.6.24705.01), 64bit RyuJIT

                           Method |  Job | Runtime |      Mean |     Error |    StdDev |
--------------------------------- |----- |-------- |----------:|----------:|----------:|
        CreateInterfaceSubstitute |  Clr |     Clr |  5.333 us | 0.0170 us | 0.0159 us |
    CreateAbstractClassSubstitute |  Clr |     Clr |  4.792 us | 0.0152 us | 0.0135 us |
 CreateNonAbstractClassSubstitute |  Clr |     Clr |  4.830 us | 0.0143 us | 0.0127 us |
         CreateDelegateSubstitute |  Clr |     Clr | 10.941 us | 0.0444 us | 0.0416 us |
        CreateInterfaceSubstitute | Core |    Core |  5.581 us | 0.0204 us | 0.0181 us |
    CreateAbstractClassSubstitute | Core |    Core |  5.312 us | 0.0210 us | 0.0186 us |
 CreateNonAbstractClassSubstitute | Core |    Core |  5.221 us | 0.0207 us | 0.0162 us |
         CreateDelegateSubstitute | Core |    Core | 11.754 us | 0.0378 us | 0.0335 us |
```

AFTER:
```
                           Method |  Job | Runtime |      Mean |     Error |    StdDev |
--------------------------------- |----- |-------- |----------:|----------:|----------:|
        CreateInterfaceSubstitute |  Clr |     Clr |  4.552 us | 0.0567 us | 0.0530 us |
    CreateAbstractClassSubstitute |  Clr |     Clr |  4.557 us | 0.0620 us | 0.0518 us |
 CreateNonAbstractClassSubstitute |  Clr |     Clr |  4.377 us | 0.0518 us | 0.0484 us |
         CreateDelegateSubstitute |  Clr |     Clr |  9.769 us | 0.0870 us | 0.0814 us |
        CreateInterfaceSubstitute | Core |    Core |  5.585 us | 0.0655 us | 0.0612 us |
    CreateAbstractClassSubstitute | Core |    Core |  5.021 us | 0.0951 us | 0.0934 us |
 CreateNonAbstractClassSubstitute | Core |    Core |  5.330 us | 0.0690 us | 0.0646 us |
         CreateDelegateSubstitute | Core |    Core | 11.270 us | 0.1117 us | 0.1045 us |
```

It seems that it helped to activate substitute even a bit quicker 😉 

@dtchepak @alexandrnikitin Happy review!