### PR TITLE
Publish NuGet package as build artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,7 @@ before_test:
 
 test_script:
   - build/build.cmd All
+
+artifacts:
+- path: bin\Release\NSubstitute\*.nupkg
+  name: NuGet


### PR DESCRIPTION
Sometimes during diagnostics it would be useful to provide people with NuGet package for the latest `master`. Now we can take the NuGet package from the build artifacts.