### PR TITLE
Add When() extensions for async methods

### DIFF
--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -232,9 +232,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has received the following call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <returns></returns>
         public static T Received<T>(this T substitute) where T : class
         {
             return substitute.Received(Quantity.AtLeastOne());
@@ -243,10 +240,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has received the following call the required number of times.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <param name="requiredNumberOfCalls"></param>
-        /// <returns></returns>
         public static T Received<T>(this T substitute, int requiredNumberOfCalls) where T : class
         {
             return substitute.Received(Quantity.Exactly(requiredNumberOfCalls));
@@ -255,9 +248,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has not received the following call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <returns></returns>
         public static T DidNotReceive<T>(this T substitute) where T : class
         {
             return substitute.Received(Quantity.None());
@@ -266,9 +256,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has received the following call with any arguments.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <returns></returns>
         public static T ReceivedWithAnyArgs<T>(this T substitute) where T : class
         {
             return substitute.ReceivedWithAnyArgs(Quantity.AtLeastOne());
@@ -277,10 +264,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has received the following call with any arguments the required number of times.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <param name="requiredNumberOfCalls"></param>
-        /// <returns></returns>
         public static T ReceivedWithAnyArgs<T>(this T substitute, int requiredNumberOfCalls) where T : class
         {
             return substitute.ReceivedWithAnyArgs(Quantity.Exactly(requiredNumberOfCalls));
@@ -289,9 +272,6 @@ namespace NSubstitute
         /// <summary>
         /// Checks this substitute has not received the following call with any arguments.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <returns></returns>
         public static T DidNotReceiveWithAnyArgs<T>(this T substitute) where T : class
         {
             return substitute.ReceivedWithAnyArgs(Quantity.None());
@@ -300,8 +280,6 @@ namespace NSubstitute
         /// <summary>
         /// Forget all the calls this substitute has received.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
         /// <remarks>
         /// Note that this will not clear any results set up for the substitute using Returns().
         /// See <see cref="NSubstitute.ClearExtensions.ClearExtensions.ClearSubstitute{T}"/> for more options with resetting 
@@ -316,10 +294,6 @@ namespace NSubstitute
         /// Perform an action when this member is called. 
         /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <param name="substituteCall"></param>
-        /// <returns></returns>
         public static WhenCalled<T> When<T>(this T substitute, Action<T> substituteCall) where T : class
         {
             var context = SubstitutionContext.Current;
@@ -327,13 +301,29 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Perform an action when this member is called. 
+        /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
+        /// </summary>
+        public static WhenCalled<T> When<T>(this T substitute, Func<T, Task> substituteCall) where T : class
+        {
+            var context = SubstitutionContext.Current;
+            return new WhenCalled<T>(context, substitute, x => substituteCall(x), MatchArgs.AsSpecifiedInCall);
+        }
+
+        /// <summary>
+        /// Perform an action when this member is called. 
+        /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
+        /// </summary>
+        public static WhenCalled<TSubstitute> When<TSubstitute, TResult>(this TSubstitute substitute, Func<TSubstitute, ValueTask<TResult>> substituteCall) where TSubstitute : class
+        {
+            var context = SubstitutionContext.Current;
+            return new WhenCalled<TSubstitute>(context, substitute, x => substituteCall(x), MatchArgs.AsSpecifiedInCall);
+        }
+
+        /// <summary>
         /// Perform an action when this member is called with any arguments. 
         /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <param name="substituteCall"></param>
-        /// <returns></returns>
         public static WhenCalled<T> WhenForAnyArgs<T>(this T substitute, Action<T> substituteCall) where T : class
         {
             var context = SubstitutionContext.Current;
@@ -341,11 +331,28 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Perform an action when this member is called with any arguments. 
+        /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
+        /// </summary>
+        public static WhenCalled<T> WhenForAnyArgs<T>(this T substitute, Func<T, Task> substituteCall) where T : class
+        {
+            var context = SubstitutionContext.Current;
+            return new WhenCalled<T>(context, substitute, x => substituteCall(x), MatchArgs.Any);
+        }
+
+        /// <summary>
+        /// Perform an action when this member is called with any arguments. 
+        /// Must be followed by <see cref="WhenCalled{T}.Do(Action{CallInfo})"/> to provide the callback.
+        /// </summary>
+        public static WhenCalled<TSubstitute> WhenForAnyArgs<TSubstitute, TResult>(this TSubstitute substitute, Func<TSubstitute, ValueTask<TResult>> substituteCall) where TSubstitute : class
+        {
+            var context = SubstitutionContext.Current;
+            return new WhenCalled<TSubstitute>(context, substitute, x => substituteCall(x), MatchArgs.Any);
+        }
+
+        /// <summary>
         /// Returns the calls received by this substitute.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="substitute"></param>
-        /// <returns></returns>
         public static IEnumerable<ICall> ReceivedCalls<T>(this T substitute) where T : class
         {
             return SubstitutionContext

--- a/tests/NSubstitute.Acceptance.Specs/ConcurrencyTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ConcurrencyTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Exceptions;
 using NSubstitute.Extensions;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace NSubstitute.Acceptance.Specs
 {

--- a/tests/NSubstitute.Acceptance.Specs/Infrastructure/BackgroundTask.cs
+++ b/tests/NSubstitute.Acceptance.Specs/Infrastructure/BackgroundTask.cs
@@ -3,12 +3,12 @@ using System.Threading;
 
 namespace NSubstitute.Acceptance.Specs.Infrastructure
 {
-    public class Task
+    public class BackgroundTask
     {
         readonly Action _start;
         readonly Action _await;
         private Exception _exception;
-        public Task(Action action)
+        public BackgroundTask(Action action)
         {
             var thread = new Thread(() =>
                                         {
@@ -20,7 +20,7 @@ namespace NSubstitute.Acceptance.Specs.Infrastructure
         }
         void ThrowIfError() { if (_exception != null) throw new Exception("Thread threw", _exception); }
 
-        public static void StartAll(Task[] tasks) { foreach (var task in tasks) { task._start(); } }
-        public static void AwaitAll(Task[] tasks) { foreach (var task in tasks) { task._await(); } }
+        public static void StartAll(BackgroundTask[] tasks) { foreach (var task in tasks) { task._start(); } }
+        public static void AwaitAll(BackgroundTask[] tasks) { foreach (var task in tasks) { task._await(); } }
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
+++ b/tests/NSubstitute.Acceptance.Specs/MultipleThreads.cs
@@ -47,9 +47,9 @@ namespace NSubstitute.Acceptance.Specs
             for (var i = 0; i < 1000; i++)
             {
                 var sub = Substitute.For<IFoo>();
-                var tasks = Enumerable.Range(0, 20).Select(x => new Task(() => sub.Bar())).ToArray();
-                Task.StartAll(tasks);
-                Task.AwaitAll(tasks);
+                var tasks = Enumerable.Range(0, 20).Select(x => new BackgroundTask(() => sub.Bar())).ToArray();
+                BackgroundTask.StartAll(tasks);
+                BackgroundTask.AwaitAll(tasks);
             }
         }
 
@@ -60,9 +60,9 @@ namespace NSubstitute.Acceptance.Specs
             for (var i = 0; i < 100000; i++)
             {
                 var sub = Substitute.For<IFoo>();
-                var tasks = Enumerable.Range(0, 20).Select(x => new Task(() => sub.VoidMethod())).ToArray();
-                Task.StartAll(tasks);
-                Task.AwaitAll(tasks);
+                var tasks = Enumerable.Range(0, 20).Select(x => new BackgroundTask(() => sub.VoidMethod())).ToArray();
+                BackgroundTask.StartAll(tasks);
+                BackgroundTask.AwaitAll(tasks);
             }
         }
 
@@ -74,11 +74,11 @@ namespace NSubstitute.Acceptance.Specs
             for (var i = 0; i < 1000; i++)
             {
                 var foo = Substitute.For<IFoo>();
-                var checkThread = new Task(() => foo.Received(expected).VoidMethod());
-                var callThreads = Enumerable.Range(1, expected).Select(x => new Task(() => { Thread.Sleep(0); foo.VoidMethod(); }));
+                var checkThread = new BackgroundTask(() => foo.Received(expected).VoidMethod());
+                var callThreads = Enumerable.Range(1, expected).Select(x => new BackgroundTask(() => { Thread.Sleep(0); foo.VoidMethod(); }));
                 var tasks = callThreads.Concat(new[] { checkThread }).ToArray();
-                Task.StartAll(tasks);
-                try { Task.AwaitAll(tasks); }
+                BackgroundTask.StartAll(tasks);
+                try { BackgroundTask.AwaitAll(tasks); }
                 catch (Exception ex)
                 {
                     if (ex.InnerException == null) throw;
@@ -100,7 +100,7 @@ namespace NSubstitute.Acceptance.Specs
         {
             var tasks =
                 Enumerable.Range(0, 20).Select( _ => 
-                    new Task(() =>
+                    new BackgroundTask(() =>
                         {
                             for (var i = 0; i < 1000; ++i)
                             {
@@ -108,8 +108,8 @@ namespace NSubstitute.Acceptance.Specs
                             }
                         })).ToArray();
 
-            Task.StartAll(tasks);
-            Task.AwaitAll(tasks);
+            BackgroundTask.StartAll(tasks);
+            BackgroundTask.AwaitAll(tasks);
         }
 
         [Test]

--- a/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
+++ b/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
@@ -2,6 +2,7 @@ using System;
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NUnit.Framework;
+using Task = System.Threading.Tasks.Task;
 
 namespace NSubstitute.Acceptance.Specs
 {
@@ -106,6 +107,50 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(called, Is.EqualTo(0), "Should not have been called yet");
             ArgumentException thrownException = Assert.Throws<ArgumentException>(() => _something.Echo(1234));
             Assert.That(thrownException.Message, Is.EqualTo("Argument: 1234"));
+            Assert.That(called, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Can_configure_async_methods_nicely()
+        {
+            int called = 0;
+            _something.When(x => x.SayAsync(Arg.Any<string>())).Do(c => called++);
+
+            await _something.SayAsync("Boo");
+
+            Assert.That(called, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Can_configure_async_valueTask_methods_nicely()
+        {
+            int called = 0;
+            _something.When(x => x.SayValueTaskAsync(Arg.Any<string>())).Do(c => called++);
+
+            await _something.SayValueTaskAsync("Boo");
+
+            Assert.That(called, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Can_configure_async_methods_for_any_args_nicely()
+        {
+            int called = 0;
+            _something.WhenForAnyArgs(x => x.SayAsync(default)).Do(c => called++);
+
+            await _something.SayAsync("Boo");
+
+            Assert.That(called, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Can_configure_async_valueTask_methods_for_any_args_nicely()
+        {
+            int called = 0;
+            _something.WhenForAnyArgs(x => x.SayValueTaskAsync(default)).Do(c => called++);
+
+            await _something.SayValueTaskAsync("Boo");
+
             Assert.That(called, Is.EqualTo(1));
         }
 

--- a/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
+++ b/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace NSubstitute.Acceptance.Specs
 {


### PR DESCRIPTION
Fixes #467

We should not await inside the `When()` callback, as the routes we switch to might return null. To allow users avoid compilation warnings, I've added a set of helper `When()` overloads consuming the returned `Task`. Currently we follow the same approach for `Returns()` extensions.

Additionally, did a small rename in test project to not conflict with `Task` type name.

@dtchepak Are you fine with the change? 😉 