### PR TITLE
Add support for custom IArgumentMatcher<T>

### DIFF
--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq.Expressions;
-using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
 
 namespace NSubstitute
@@ -15,7 +14,7 @@ namespace NSubstitute
         /// </summary>
         public static ref T Any<T>()
         {
-            return ref EnqueueSpecFor<T>(new AnyArgumentMatcher(typeof(T)));
+            return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(T)));
         }
 
         /// <summary>
@@ -23,7 +22,7 @@ namespace NSubstitute
         /// </summary>
         public static ref T Is<T>(T value)
         {
-            return ref EnqueueSpecFor<T>(new EqualsArgumentMatcher(value));
+            return ref ArgumentMatcher.Enqueue<T>(new EqualsArgumentMatcher(value));
         }
 
         /// <summary>
@@ -32,7 +31,7 @@ namespace NSubstitute
         /// </summary>
         public static ref T Is<T>(Expression<Predicate<T>> predicate)
         {
-            return ref EnqueueSpecFor<T>(new ExpressionArgumentMatcher<T>(predicate));
+            return ref ArgumentMatcher.Enqueue<T>(new ExpressionArgumentMatcher<T>(predicate));
         }
 
         /// <summary>
@@ -40,7 +39,7 @@ namespace NSubstitute
         /// </summary>
         public static ref Action Invoke()
         {
-            return ref EnqueueSpecFor<Action>(new AnyArgumentMatcher(typeof(Action)), InvokeDelegateAction());
+            return ref ArgumentMatcher.Enqueue<Action>(new AnyArgumentMatcher(typeof(Action)), InvokeDelegateAction());
         }
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace NSubstitute
         /// </summary>
         public static ref Action<T> Invoke<T>(T arg)
         {
-            return ref EnqueueSpecFor<Action<T>>(new AnyArgumentMatcher(typeof(Action<T>)), InvokeDelegateAction(arg));
+            return ref ArgumentMatcher.Enqueue<Action<T>>(new AnyArgumentMatcher(typeof(Action<T>)), InvokeDelegateAction(arg));
         }
 
         /// <summary>
@@ -56,7 +55,7 @@ namespace NSubstitute
         /// </summary>
         public static ref Action<T1, T2> Invoke<T1, T2>(T1 arg1, T2 arg2)
         {
-            return ref EnqueueSpecFor<Action<T1, T2>>(new AnyArgumentMatcher(typeof(Action<T1, T2>)), InvokeDelegateAction(arg1, arg2));
+            return ref ArgumentMatcher.Enqueue<Action<T1, T2>>(new AnyArgumentMatcher(typeof(Action<T1, T2>)), InvokeDelegateAction(arg1, arg2));
         }
 
         /// <summary>
@@ -64,7 +63,7 @@ namespace NSubstitute
         /// </summary>
         public static ref Action<T1, T2, T3> Invoke<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
         {
-            return ref EnqueueSpecFor<Action<T1, T2, T3>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3>)), InvokeDelegateAction(arg1, arg2, arg3));
+            return ref ArgumentMatcher.Enqueue<Action<T1, T2, T3>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3>)), InvokeDelegateAction(arg1, arg2, arg3));
         }
 
         /// <summary>
@@ -72,7 +71,7 @@ namespace NSubstitute
         /// </summary>
         public static ref Action<T1, T2, T3, T4> Invoke<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
-            return ref EnqueueSpecFor<Action<T1, T2, T3, T4>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3, T4>)), InvokeDelegateAction(arg1, arg2, arg3, arg4));
+            return ref ArgumentMatcher.Enqueue<Action<T1, T2, T3, T4>>(new AnyArgumentMatcher(typeof(Action<T1, T2, T3, T4>)), InvokeDelegateAction(arg1, arg2, arg3, arg4));
         }
 
         /// <summary>
@@ -81,7 +80,7 @@ namespace NSubstitute
         /// <param name="arguments">Arguments to pass to delegate.</param>
         public static ref TDelegate InvokeDelegate<TDelegate>(params object[] arguments)
         {
-            return ref EnqueueSpecFor<TDelegate>(new AnyArgumentMatcher(typeof(TDelegate)), InvokeDelegateAction(arguments));
+            return ref ArgumentMatcher.Enqueue<TDelegate>(new AnyArgumentMatcher(typeof(TDelegate)), InvokeDelegateAction(arguments));
         }
 
         /// <summary>
@@ -90,35 +89,12 @@ namespace NSubstitute
         /// </summary>
         public static ref T Do<T>(Action<T> useArgument)
         {
-            return ref EnqueueSpecFor<T>(new AnyArgumentMatcher(typeof(T)), x => useArgument((T)x));
-        }
-
-        private static ref T EnqueueSpecFor<T>(IArgumentMatcher argumentMatcher)
-        {
-            var argumentSpecification = new ArgumentSpecification(typeof(T), argumentMatcher);
-            return ref EnqueueArgSpecification<T>(argumentSpecification);
-        }
-
-        private static ref T EnqueueSpecFor<T>(IArgumentMatcher argumentMatcher, Action<object> action)
-        {
-            var argumentSpecification = new ArgumentSpecification(typeof(T), argumentMatcher, action);
-            return ref EnqueueArgSpecification<T>(argumentSpecification);
-        }
-
-        private static ref T EnqueueArgSpecification<T>(IArgumentSpecification specification)
-        {
-            SubstitutionContext.Current.ThreadContext.EnqueueArgumentSpecification(specification);
-            return ref new DefaultValueContainer<T>().Value;
+            return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(T)), x => useArgument((T) x));
         }
 
         private static Action<object> InvokeDelegateAction(params object[] arguments)
         {
-            return x => ((Delegate)x).DynamicInvoke(arguments);
-        }
-
-        private class DefaultValueContainer<T>
-        {
-            public T Value;
+            return x => ((Delegate) x).DynamicInvoke(arguments);
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace NSubstitute.Core.Arguments
+{
+    public static class ArgumentMatcher
+    {
+        /// <summary>
+        /// Enqueues a matcher for the method argument in current position and returns the value which should be
+        /// passed back to the method you invoke.
+        /// </summary>
+        public static ref T Enqueue<T>(IArgumentMatcher<T> argumentMatcher)
+        {
+            if (argumentMatcher == null) throw new ArgumentNullException(nameof(argumentMatcher));
+
+            IArgumentMatcher nonGenericMatcher;
+            if (argumentMatcher is IDescribeNonMatches)
+            {
+                nonGenericMatcher = new GenericToNonGenericMatcherProxyWithDescribe<T>(argumentMatcher);
+            }
+            else
+            {
+                nonGenericMatcher = new GenericToNonGenericMatcherProxy<T>(argumentMatcher);
+            }
+
+            return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), nonGenericMatcher));
+        }
+
+        internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher)
+        {
+            return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher));
+        }
+
+        internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher, Action<object> action)
+        {
+            return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher, action));
+        }
+
+        private static ref T EnqueueArgSpecification<T>(IArgumentSpecification specification)
+        {
+            SubstitutionContext.Current.ThreadContext.EnqueueArgumentSpecification(specification);
+            return ref new DefaultValueContainer<T>().Value;
+        }
+
+        private class GenericToNonGenericMatcherProxy<T> : IArgumentMatcher
+        {
+            protected readonly IArgumentMatcher<T> _matcher;
+
+            public GenericToNonGenericMatcherProxy(IArgumentMatcher<T> matcher)
+            {
+                _matcher = matcher;
+            }
+
+            public bool IsSatisfiedBy(object argument) => _matcher.IsSatisfiedBy((T) argument);
+        }
+
+        private class GenericToNonGenericMatcherProxyWithDescribe<T> : GenericToNonGenericMatcherProxy<T>, IDescribeNonMatches
+        {
+            public GenericToNonGenericMatcherProxyWithDescribe(IArgumentMatcher<T> matcher) : base(matcher)
+            {
+                if (matcher as IDescribeNonMatches == null) throw new ArgumentException("Should implement IDescribeNonMatches type.");
+            }
+
+            public string DescribeFor(object argument) => ((IDescribeNonMatches) _matcher).DescribeFor(argument);
+        }
+
+        private class DefaultValueContainer<T>
+        {
+            public T Value;
+        }
+    }
+}

--- a/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
@@ -12,4 +12,18 @@ namespace NSubstitute.Core.Arguments
         /// </summary>
         bool IsSatisfiedBy(object argument);
     }
+
+    /// <summary>
+    /// Provides a specification for arguments for use with <see ctype="Arg.Matches &lt; T &gt;(IArgumentMatcher)" />.
+    /// Can additionally implement <see ctype="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+    /// </summary>
+    /// <typeparam name="T">Matches arguments of type <typeparamref name="T"/> or compatible type.</typeparam>
+    public interface IArgumentMatcher<T>
+    {
+        /// <summary>
+        /// Checks whether the <paramref name="argument"/> satisfies the condition of the matcher.
+        /// If this throws an exception the argument will be treated as non-matching.
+        /// </summary>
+        bool IsSatisfiedBy(T argument);
+    }
 }


### PR DESCRIPTION
Closes #438.

Implementing helper API for enqueueing custom `ArgumentMatchers<T>`. Hope one day somebody finds it useful 😊 