### PR TITLE
Update CHANGELOG.md for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 4.0.0 (January 2019)
+
+_Promoted 4.0.0 Release Candidate 1 with no code changes. See the release candidate's notes
+for a full list of changes since 3.1.0._
+
 ### 4.0.0 Release Candidate 1 (November 2018)
 
 Thanks to core team member Alex Povar (@zvirja) for putting a huge amount of work into


### PR DESCRIPTION
Prep for 4.0.0 release.

Wasn't sure whether to update the changelog as per this PR, or to replace the previous release heading like this:

```
### 4.0.0 (January 2019)

_Initially released as 4.0.0 Release Candidate 1 (November 2018). Promoted to full release with no code changes (January 2019)._

Thanks to core team member ... 
```

@zvirja: Once this is merged feel free to [tag this and do the final release](https://github.com/nsubstitute/NSubstitute/wiki/Release-procedure), otherwise I'll do it as soon as I get a chance. We shouldn't need a new website release as it is already published with the latest doc updates.