### PR TITLE
Replace nsubstitute.github urls to https (nsubstitute.github.io)

### DIFF
--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -9,7 +9,7 @@ Reason: Previous NSubstitute versions had quite limited support for `out` and `r
 
 Workaround: If at all possible please update to a recent version of your .NET compiler (C# 7+, VB 2017, VB 15.3+, F# 4.1+). This should provide support for `ref` returns and make the code compile fine with the new `Arg` methods. These shipped with Visual Studio 2017. Visual Studio for Mac 2017 and JetBrains Rider 2017 also support C# 7+.
 
-If it is not possible for you to use a C# 7-compatible compiler, we have added an `Arg.Compat` class which has all the same members as `Arg`, just without the `ref` return type. If you replace `Arg.` references with `Arg.Compat.` in your project then you can continue to use older compilers with NSubstitute 4.x. Alternatively you can use a `NSubstitute.Compatibility.CompatArg` instance in your fixture which may make migration a bit easier. Both these approaches are described in the [Compatibility argument matchers](http://nsubstitute.github.io/help/compat-args) documentation.
+If it is not possible for you to use a C# 7-compatible compiler, we have added an `Arg.Compat` class which has all the same members as `Arg`, just without the `ref` return type. If you replace `Arg.` references with `Arg.Compat.` in your project then you can continue to use older compilers with NSubstitute 4.x. Alternatively you can use a `NSubstitute.Compatibility.CompatArg` instance in your fixture which may make migration a bit easier. Both these approaches are described in the [Compatibility argument matchers](https://nsubstitute.github.io/help/compat-args) documentation.
 
 ---------------
 
@@ -21,7 +21,7 @@ Reason: Previous NSubstitute releases had very limited support for matching `out
 
 Workaround:
 * Move the NSubstitute statement/assertion outside of the expression tree; or
-* Use an `Arg.Compat.` matcher as described above and in the [Compatibility argument matchers](http://nsubstitute.github.io/help/compat-args) documentation.
+* Use an `Arg.Compat.` matcher as described above and in the [Compatibility argument matchers](https://nsubstitute.github.io/help/compat-args) documentation.
 
 For example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@ released.
 * [BREAKING] Raise.Action() methods removed. Use Raise.Event<THandler>() (e.g. Raise.Event<Action>>()).
 * [BREAKING] Renamed Raise.Event<TEventArgs>() methods to Raise.EventWith<TEventArgs>().
 * [UPDATE] Arg matchers can be specified using more specific, compatible type (Arg.Is<string>(..) for arg of type object).
-* [NEW] NSubstitute website and documentation http://nsubstitute.github.com
+* [NEW] NSubstitute website and documentation https://nsubstitute.github.io
 * [FIX] Formating for argument matchers that take predicate functions.
 * [FIX] Match single argument matcher passed to params arg (#34)
 * [FIX] Detect ambiguous arg matchers in additional case (#31)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ NSubstitute
 ========
 [![Build status](https://ci.appveyor.com/api/projects/status/ipe7ephhy6f9bbgp/branch/master?svg=true)](https://ci.appveyor.com/project/NSubstitute/nsubstitute/branch/master) [![Travis Build Status](https://travis-ci.com/nsubstitute/NSubstitute.svg?branch=master)](https://travis-ci.com/nsubstitute/NSubstitute)
 
-Visit the [NSubstitute website](https://nsubstitute.github.com) for more information.
+Visit the [NSubstitute website](https://nsubstitute.github.io) for more information.
 
 ### What is it?
 

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -181,7 +181,7 @@ Target "Documentation" <| fun _ ->
                             | None   -> log ("count not find exe"); "bundle"
 
     let workingDir = root </> "docs/"
-    let docOutputRelativeToWorkingDir = ".." </> output </> "nsubstitute.github.com"
+    let docOutputRelativeToWorkingDir = ".." </> output </> "nsubstitute.github.io"
     let result = 
         ExecProcess (fun info -> 
                         info.UseShellExecute <- false

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -96,7 +96,7 @@ namespace NSubstitute
         /// Alternate version of <see cref="Arg"/> matchers for compatibility with pre-C#7 compilers
         /// which do not support <c>ref</c> return types. Do not use unless you are unable to use <see cref="Arg"/>.
         ///
-        /// For more information see <see href="http://nsubstitute.github.io/help/compat-args">Compatibility Argument
+        /// For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
         /// Matchers</see> in the NSubstitute documentation.
         /// </summary>
         public static class Compat

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 
 namespace NSubstitute.Compatibility
@@ -11,7 +11,7 @@ namespace NSubstitute.Compatibility
     /// to use from an abstract base class. You can get a reference to this instance using the static
     /// <see cref="Instance" /> field.
     ///
-    /// For more information see <see href="http://nsubstitute.github.io/help/compat-args">Compatibility Argument
+    /// For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
     /// Matchers</see> in the NSubstitute documentation.
     /// </summary>
     public class CompatArg

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>NSubstitute is a friendly substitute for .NET mocking frameworks. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
@@ -8,8 +8,8 @@
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>
-    <PackageIconUrl>http://nsubstitute.github.com/images/nsubstitute-100x100.png</PackageIconUrl>
-    <PackageProjectUrl>http://nsubstitute.github.com/</PackageProjectUrl>
+    <PackageIconUrl>https://nsubstitute.github.io/images/nsubstitute-100x100.png</PackageIconUrl>
+    <PackageProjectUrl>https://nsubstitute.github.io/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/nsubstitute/NSubstitute/raw/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
note: https://nsubstitute.github.com will redirect to http://nsubstitute.github.io ;)

So it should be https://nsubstitute.github.io