### PR TITLE
Switch website and code references to https

### DIFF
--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -9,7 +9,7 @@ Reason: Previous NSubstitute versions had quite limited support for `out` and `r
 
 Workaround: If at all possible please update to a recent version of your .NET compiler (C# 7+, VB 2017, VB 15.3+, F# 4.1+). This should provide support for `ref` returns and make the code compile fine with the new `Arg` methods. These shipped with Visual Studio 2017. Visual Studio for Mac 2017 and JetBrains Rider 2017 also support C# 7+.
 
-If it is not possible for you to use a C# 7-compatible compiler, we have added an `Arg.Compat` class which has all the same members as `Arg`, just without the `ref` return type. If you replace `Arg.` references with `Arg.Compat.` in your project then you can continue to use older compilers with NSubstitute 4.x. Alternatively you can use a `NSubstitute.Compatibility.CompatArg` instance in your fixture which may make migration a bit easier. Both these approaches are described in the [Compatibility argument matchers](http://nsubstitute.github.io/help/compat-args) documentation.
+If it is not possible for you to use a C# 7-compatible compiler, we have added an `Arg.Compat` class which has all the same members as `Arg`, just without the `ref` return type. If you replace `Arg.` references with `Arg.Compat.` in your project then you can continue to use older compilers with NSubstitute 4.x. Alternatively you can use a `NSubstitute.Compatibility.CompatArg` instance in your fixture which may make migration a bit easier. Both these approaches are described in the [Compatibility argument matchers](https://nsubstitute.github.io/help/compat-args) documentation.
 
 ---------------
 
@@ -21,7 +21,7 @@ Reason: Previous NSubstitute releases had very limited support for matching `out
 
 Workaround:
 * Move the NSubstitute statement/assertion outside of the expression tree; or
-* Use an `Arg.Compat.` matcher as described above and in the [Compatibility argument matchers](http://nsubstitute.github.io/help/compat-args) documentation.
+* Use an `Arg.Compat.` matcher as described above and in the [Compatibility argument matchers](https://nsubstitute.github.io/help/compat-args) documentation.
 
 For example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### unreleased
+
+* [UPDATE] Thanks to Julian Verdurmen (@304NotModified) for updating our website and links
+to HTTPS! All links to the NSub website should now go through https://nsubstitute.github.io,
+and other web links in the project also go through to HTTPS where supported.
+
 ### 4.0.0 (January 2019)
 
 _Promoted 4.0.0 Release Candidate 1 with no code changes. See the release candidate's notes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ NSubstitute
 ========
 [![Build status](https://ci.appveyor.com/api/projects/status/ipe7ephhy6f9bbgp/branch/master?svg=true)](https://ci.appveyor.com/project/NSubstitute/nsubstitute/branch/master) [![Travis Build Status](https://travis-ci.com/nsubstitute/NSubstitute.svg?branch=master)](https://travis-ci.com/nsubstitute/NSubstitute)
 
-Visit the [NSubstitute website](https://nsubstitute.github.com) for more information.
+Visit the [NSubstitute website](https://nsubstitute.github.io) for more information.
 
 ### What is it?
 
@@ -47,7 +47,7 @@ We can ask NSubstitute to create a substitute instance for this type. We could a
     _calculator = Substitute.For<ICalculator>();
 <!-- {% endexamplecode %} -->
 
-⚠️ **Note**: NSubstitute will only work properly with interfaces or with `virtual` members of classes. Be careful substituting for classes with non-virtual members. See [Creating a substitute](/help/creating-a-substitute/#substituting_infrequently_and_carefully_for_classes) for more information.
+⚠️ **Note**: NSubstitute will only work properly with interfaces or with `virtual` members of classes. Be careful substituting for classes with non-virtual members. See [Creating a substitute](https://nsubstitute.github.io/help/creating-a-substitute/#substituting_infrequently_and_carefully_for_classes) for more information.
 
 Now we can tell our substitute to return a value for a call:
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,8 +18,8 @@
   <div id="nav">
     <a href="/help/getting-started">Get started</a> |
     <a href="/help.html">Docs</a> |
-    <a href="http://groups.google.com/group/nsubstitute">Discussion group</a> |
-    <a href="http://github.com/nsubstitute/NSubstitute">NSub on GitHub</a>  
+    <a href="https://groups.google.com/group/nsubstitute">Discussion group</a> |
+    <a href="https://github.com/nsubstitute/NSubstitute">NSub on GitHub</a>  
   </div>
 
   <div id="content">
@@ -27,14 +27,14 @@
   </div>
 
   <div id="footer">
-  NSubstitute is open source software, licensed under the <a href="http://www.opensource.org/licenses/bsd-license.php">BSD License</a>.<br />
+  NSubstitute is open source software, licensed under the <a href="https://www.opensource.org/licenses/bsd-license.php">BSD License</a>.<br />
 The NSubstitute project is possible <a href="https://github.com/nsubstitute/NSubstitute/blob/master/acknowledgements.md">thanks to a number of other software projects</a>. We acknowledge their awesomeness.<br />
-  NSubstitute logo donated by <a href="http://troyhunt.com">Troy Hunt</a>.
+  NSubstitute logo donated by <a href="https://troyhunt.com">Troy Hunt</a>.
   </div>
 
   <script type="text/javascript" src="/scripts/shCore.js"></script>
   <script type="text/javascript" src="/scripts/shBrushCSharp.js"></script>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
 
  <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/help.html
+++ b/docs/help.html
@@ -8,4 +8,4 @@ permalink: /help.html
 
 <p>For more in depth information start with <a href="/help/creating-a-substitute">Creating a substitute</a>.</p>
 
-<p>If you can't find the answer you're looking for, head on over to the <a href="http://groups.google.com/group/nsubstitute">NSubstitute discussion group</a>.</p>
+<p>If you can't find the answer you're looking for, of if you have feature requests or feedback on NSubstitute, please <a href="https://github.com/nsubstitute/NSubstitute/issues">raise an issue</a> on our project site. All questions are welcome via our project site, but for "how-to"-style questions you can also try <a href="https://stackoverflow.com/tags/nsubstitute">StackOverflow with the [nsubstitute] tag</a>, which often leads to very good answers from the larger programming community. StackOverflow is especially useful if your question also relates to other libraries that our team may not be as familiar with (e.g. NSubstitute with Entity Framework). You can also head on over to the <a href="https://groups.google.com/group/nsubstitute">NSubstitute discussion group</a> if you prefer.</p>

--- a/docs/help/_posts/2010-01-01-getting-started.markdown
+++ b/docs/help/_posts/2010-01-01-getting-started.markdown
@@ -5,7 +5,7 @@ layout: post
 
 ## Adding NSubstitute to your test project 
 
-First add the [NSubstitute NuGet package](http://nuget.org/List/Packages/NSubstitute) to your test project using [NuGet](https://docs.microsoft.com/en-us/nuget/quickstart/use-a-package) (either the command line executable, or via the package manager in your IDE).
+First add the [NSubstitute NuGet package](https://nuget.org/List/Packages/NSubstitute) to your test project using [NuGet](https://docs.microsoft.com/en-us/nuget/quickstart/use-a-package) (either the command line executable, or via the package manager in your IDE).
 
     > Install-Package NSubstitute
 

--- a/docs/help/_posts/2010-10-01-auto-and-recursive-mocks.markdown
+++ b/docs/help/_posts/2010-10-01-auto-and-recursive-mocks.markdown
@@ -92,7 +92,7 @@ Assert.AreEqual(
     
 Here `CurrentRequest` is automatically going to return a substitute for `IRequest`, and the `IRequest` substitute will automatically return a substitute for `IIdentity`.
 
-_Note:_ Setting up long chains of substitutes this way is a code smell: we are breaking the [Law of Demeter](http://en.wikipedia.org/wiki/Law_of_Demeter), which says objects should only talk to their immediate neighbours, not reach into their neighbours' neighbours. If you write your tests without recursive mocks this becomes quite obvious as the set up becomes quite complicated, so if you are going to use recursive mocking you'll need to be extra vigilant to avoid this type of coupling.
+_Note:_ Setting up long chains of substitutes this way is a code smell: we are breaking the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter), which says objects should only talk to their immediate neighbours, not reach into their neighbours' neighbours. If you write your tests without recursive mocks this becomes quite obvious as the set up becomes quite complicated, so if you are going to use recursive mocking you'll need to be extra vigilant to avoid this type of coupling.
 
 ## Auto values
 Properties and methods returning types of `String` or `Array` will automatically get empty, non-null defaults. This can help avoid null reference exceptions in cases where you just need a reference returned but don't care about its specific properties.

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,11 +57,11 @@ Received 2 non-matching calls (non-matching arguments indicated with '*' charact
   <div id="downloads" class="sidebar download">
       <ul>
           <li class="nuget">
-              <a href="http://nuget.org/List/Packages/NSubstitute">Install via NuGet:</a> <code>Install-Package NSubstitute</code>
+              <a href="https://nuget.org/List/Packages/NSubstitute">Install via NuGet:</a> <code>Install-Package NSubstitute</code>
           </li>
           <li class="nuget"><a href="/help/nsubstitute-analysers/">Optional analysers for C# and VB</a></li>
           <li class="github">
-              <a href="http://github.com/nsubstitute/nsubstitute">Source</a>
+              <a href="https://github.com/nsubstitute/nsubstitute">Source</a>
           </li>
       </ul>
   </div>

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -96,7 +96,7 @@ namespace NSubstitute
         /// Alternate version of <see cref="Arg"/> matchers for compatibility with pre-C#7 compilers
         /// which do not support <c>ref</c> return types. Do not use unless you are unable to use <see cref="Arg"/>.
         ///
-        /// For more information see <see href="http://nsubstitute.github.io/help/compat-args">Compatibility Argument
+        /// For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
         /// Matchers</see> in the NSubstitute documentation.
         /// </summary>
         public static class Compat

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -11,7 +11,7 @@ namespace NSubstitute.Compatibility
     /// to use from an abstract base class. You can get a reference to this instance using the static
     /// <see cref="Instance" /> field.
     ///
-    /// For more information see <see href="http://nsubstitute.github.io/help/compat-args">Compatibility Argument
+    /// For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
     /// Matchers</see> in the NSubstitute documentation.
     /// </summary>
     public class CompatArg

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -8,8 +8,8 @@
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>
-    <PackageIconUrl>http://nsubstitute.github.com/images/nsubstitute-100x100.png</PackageIconUrl>
-    <PackageProjectUrl>http://nsubstitute.github.com/</PackageProjectUrl>
+    <PackageIconUrl>https://nsubstitute.github.io/images/nsubstitute-100x100.png</PackageIconUrl>
+    <PackageProjectUrl>https://nsubstitute.github.io/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/nsubstitute/NSubstitute/raw/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
To implement #505 we need to link to nsubstitute.github.io instead of
nsubstitute.github.com, and to update our ancient jquery reference to
https.

While doing this I've updated as many links to https as I could
(some I couldn't, e.g. nunit.org doesn't support https), and updated
docs/help.html to include the latest info from README.md on how to get
help.

Also fixed a readme link to Creating a substitute that was broken.