### PR TITLE
Only instantiate relatedCalls if required

### DIFF
--- a/src/NSubstitute/Routing/Handlers/CheckReceivedCallsHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/CheckReceivedCallsHandler.cs
@@ -28,10 +28,10 @@ namespace NSubstitute.Routing.Handlers
 
             var allCalls = _receivedCalls.AllCalls().ToList();
             var matchingCalls = allCalls.Where(callSpecification.IsSatisfiedBy).ToList();
-            var relatedCalls = allCalls.Where(allCallsToMethodSpec.IsSatisfiedBy).Except(matchingCalls);
 
             if (!_requiredQuantity.Matches(matchingCalls))
             {
+                var relatedCalls = allCalls.Where(allCallsToMethodSpec.IsSatisfiedBy).Except(matchingCalls);
                 _exceptionThrower.Throw(callSpecification, matchingCalls, relatedCalls, _requiredQuantity);
             }
             return RouteAction.Continue();


### PR DESCRIPTION
Noticed this when answering a question about arg matcher evaluation.

Pretty useless as I don't think it will make any real difference, but I think makes the
inputs required to _requiredQuantity.Matches(matchingCalls) a little
clearer. 🤷‍♂️ 

(Feel free to close without merging)