### PR TITLE
Make property and event call detection more robust

### DIFF
--- a/src/NSubstitute/Core/ReflectionExtensions.cs
+++ b/src/NSubstitute/Core/ReflectionExtensions.cs
@@ -30,7 +30,10 @@ namespace NSubstitute.Core
             // It's safe to verify method prefix and signature as according to the ECMA-335 II.22.28:
             // 10. Any setter method for a property whose Name is xxx shall be called set_xxx [CLS]
             // 13. Any getter and setter methods shall have Method.Flags.SpecialName = 1 [CLS] 
-            return call.IsSpecialName && call.Name.StartsWith("set_", StringComparison.Ordinal);
+            // Notice, even though it's correct to check the SpecialName flag, we don't do that deliberately.
+            // The reason is that some compilers (e.g. F#) might not emit this attribute and our library
+            // misbehaves in those cases. We use slightly slower, but robust check.
+            return call.Name.StartsWith("set_", StringComparison.Ordinal);
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
@@ -29,15 +29,16 @@ namespace NSubstitute.Routing.Handlers
         private static bool CanBeSubscribeUnsubscribeCall(ICall call)
         {
             var methodInfo = call.GetMethodInfo();
-            var methodName = methodInfo.Name;
             
             // It's safe to verify method prefix and signature as according to the ECMA-335 II.22.28:
             // 18. Any AddOn method for an event whose Name is xxx shall have the signature: void add_xxx (<DelegateType> handler) (§I.10.4) [CLS] 
             // 19. Any RemoveOn method for an event whose Name is xxx shall have the signature: void remove_xxx(<DelegateType> handler) (§I.10.4) [CLS]
-            return methodInfo.IsSpecialName && 
-                   methodInfo.ReturnType == typeof(void) &&
-                   ( methodName.StartsWith("add_", StringComparison.Ordinal) ||
-                     methodName.StartsWith("remove_", StringComparison.Ordinal));
+            // Notice, even though it's correct to check the SpecialName flag, we don't do that deliberately.
+            // The reason is that some compilers (e.g. F#) might not emit this attribute and our library
+            // misbehaves in those cases. We use slightly slower, but robust check.
+            return methodInfo.ReturnType == typeof(void) &&
+                   (methodInfo.Name.StartsWith("add_", StringComparison.Ordinal) ||
+                    methodInfo.Name.StartsWith("remove_", StringComparison.Ordinal));
         }
 
         private static void If(ICall call, Func<ICall, Predicate<EventInfo>> meetsThisSpecification, Action<string, object> takeThisAction)

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue500_SpecialMethodsWithoutAttribute.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue500_SpecialMethodsWithoutAttribute.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue500_SpecialMethodsWithoutAttribute
+    {
+        private const string EventName = "MyEvent";
+        private const string PropertyName = "MyProperty";
+        private static readonly Type TypeWithMissingSpecialNameMethodAttributes;
+
+        static Issue500_SpecialMethodsWithoutAttribute()
+        {
+            TypeWithMissingSpecialNameMethodAttributes = GenerateTypeWithMissingSpecialNameAttributes();
+        }
+
+        [Test]
+        public void ShouldCorrectlyConfigureProperty()
+        {
+            var substitute = Substitute.For(new[] {TypeWithMissingSpecialNameMethodAttributes}, new object[0]);
+            var fixture = new GeneratedTypeFixture(substitute);
+
+            fixture.MyProperty = "42";
+
+            var result = fixture.MyProperty;
+            Assert.That(result, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void ShouldCorrectlyConfigureEvent()
+        {
+            object substitute = Substitute.For(new[] {TypeWithMissingSpecialNameMethodAttributes}, new object[0]);
+            var fixture = new GeneratedTypeFixture(substitute);
+
+            bool wasCalled = false;
+            fixture.MyEvent += (sender, args) => wasCalled = true;
+            fixture.MyEvent += Raise.Event();
+
+            Assert.That(wasCalled, Is.EqualTo(true));
+        }
+
+        private static Type GenerateTypeWithMissingSpecialNameAttributes()
+        {
+            const string assemblyName = "Issue500_SpecialMethodsWithoutAttribute";
+
+            var assembly = AssemblyBuilder
+                .DefineDynamicAssembly(
+                    new AssemblyName(assemblyName),
+                    AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule(assemblyName);
+            var typeBuilder = module.DefineType("TypeWithMissingSpecialAttributes",
+                TypeAttributes.Public | TypeAttributes.Abstract);
+ 
+            var evBuilder = typeBuilder.DefineEvent(EventName, EventAttributes.None, typeof(EventHandler));
+            var evAdder = typeBuilder.DefineMethod(
+                $"add_{EventName}",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract |
+                MethodAttributes.HideBySig | MethodAttributes.NewSlot /* | MethodAttributes.SpecialName */,
+                typeof(void),
+                new[] {typeof(EventHandler)});
+            var evRemover = typeBuilder.DefineMethod(
+                $"remove_{EventName}",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract |
+                MethodAttributes.HideBySig | MethodAttributes.NewSlot /* | MethodAttributes.SpecialName */,
+                typeof(void),
+                new[] {typeof(EventHandler)});
+            evBuilder.SetAddOnMethod(evAdder);
+            evBuilder.SetRemoveOnMethod(evRemover);
+
+            var propBuilder =
+                typeBuilder.DefineProperty(PropertyName, PropertyAttributes.None, typeof(string), Type.EmptyTypes);
+            var propGetter = typeBuilder.DefineMethod(
+                $"get_{PropertyName}",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract |
+                MethodAttributes.HideBySig | MethodAttributes.NewSlot /* | MethodAttributes.SpecialName */,
+                typeof(object),
+                Type.EmptyTypes);
+            var propSetter = typeBuilder.DefineMethod(
+                $"set_{PropertyName}",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract |
+                MethodAttributes.HideBySig | MethodAttributes.NewSlot /* | MethodAttributes.SpecialName */,
+                typeof(void),
+                new[] {typeof(object)});
+            propBuilder.SetGetMethod(propGetter);
+            propBuilder.SetSetMethod(propSetter);
+
+            return typeBuilder.CreateTypeInfo().AsType();
+        }
+
+        private class GeneratedTypeFixture
+        {
+            private readonly object _substitute;
+
+            public GeneratedTypeFixture(object substitute)
+            {
+                _substitute = substitute;
+            }
+
+            public object MyProperty
+            {
+                get => _substitute.GetType().GetProperty(PropertyName).GetValue(_substitute);
+                set => _substitute.GetType().GetProperty(PropertyName).SetValue(_substitute, value);
+            }
+
+            public event EventHandler MyEvent
+            {
+                add => _substitute.GetType().GetEvent(EventName).AddEventHandler(_substitute, value);
+                remove => _substitute.GetType().GetEvent(EventName).RemoveEventHandler(_substitute, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #500

As we live in the real world, apparently not all the compilers are compliant with ECMA so our checks should be more robust. The end user never worries whether it's NSubstitute or other compiler fault - it just want things to work 😓 

I removed the extra checks for the `special name` attribute, so now we compare only method name (hope all the compilers/code generators enforce at least this rule).

P.S. Spent 10 minutes to fix the issue and 1 day to write the unit tests 😅 Hope it worth it.