### PR TITLE
Correctly format nested generic type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### unreleased
 
-* [FIX] Fix event handling for code created by non-ECMA compliant compilers. (#500, #525, @zvjira)
+* [FIX] Do not fail on nested generic type formatting. (#515, @zvirja)
+* [FIX] Fix event handling for code created by non-ECMA compliant compilers. (#500, #525, @zvirja)
 * [UPDATE] Thanks to Julian Verdurmen (@304NotModified) for updating our website and links
 to HTTPS! All links to the NSub website should now go through https://nsubstitute.github.io,
 and other web links in the project also go through to HTTPS where supported.

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace NSubstitute.Core
 {
@@ -17,11 +18,11 @@ namespace NSubstitute.Core
         }
 
         /// <summary>
-        /// Join the <paramref name="strings"/> using <paramref name="seperator"/>.
+        /// Join the <paramref name="strings"/> using <paramref name="separator"/>.
         /// </summary>
-        public static string Join(this IEnumerable<string> strings, string seperator)
+        public static string Join(this IEnumerable<string> strings, string separator)
         {
-            return string.Join(seperator, strings);
+            return string.Join(separator, strings);
         }
 
         private static bool TypeCanBeNull(Type type)
@@ -31,13 +32,59 @@ namespace NSubstitute.Core
 
         public static string GetNonMangledTypeName(this Type type)
         {
-            var typeName = type.Name;
-            if (!type.GetTypeInfo().IsGenericType)
-                return typeName;
+            // Handle simple case without invoking more complex logic.
+            if (!type.GetTypeInfo().IsGenericType && !type.IsNested)
+            {
+                return type.Name;
+            }
 
-            typeName = typeName.Substring(0, typeName.IndexOf('`'));
-            var genericArgTypes = type.GetGenericArguments().Select(GetNonMangledTypeName);
-            return string.Format("{0}<{1}>", typeName, string.Join(", ", genericArgTypes));
+            Type[] genericTypeArguments = type.GetGenericArguments();
+            int alreadyHandledGenericArgumentsCount = 0;
+            var resultTypeName = new StringBuilder();
+
+            void AppendTypeNameRecursively(Type currentType)
+            {
+                Type declaringType = currentType.DeclaringType;
+                if (declaringType != null)
+                {
+                    AppendTypeNameRecursively(declaringType);
+                    resultTypeName.Append("+");
+                }
+
+                resultTypeName.Append(GetTypeNameWithoutGenericArity(currentType));
+
+                // When you take the generic type arguments for a nested type, the type arguments from parent types
+                // are included as well. We don't want to include them again, so simply skip all the already
+                // handled arguments.
+                // Notice, we expect generic type arguments order to always be parent to child, left to right.
+                string[] ownGenericArguments = genericTypeArguments
+                    .Take(currentType.GetGenericArguments().Length)
+                    .Skip(alreadyHandledGenericArgumentsCount)
+                    .Select(t => t.GetNonMangledTypeName())
+                    .ToArray();
+
+                if (ownGenericArguments.Length == 0)
+                {
+                    return;
+                }
+
+                alreadyHandledGenericArgumentsCount += ownGenericArguments.Length;
+
+                resultTypeName.Append("<");
+                resultTypeName.Append(ownGenericArguments.Join(", "));
+                resultTypeName.Append(">");
+            }
+
+            AppendTypeNameRecursively(type);
+            return resultTypeName.ToString();
+
+            string GetTypeNameWithoutGenericArity(Type t)
+            {
+                var tn = t.Name;
+                var indexOfBacktick = tn.IndexOf('`');
+                // For nested generic types the back stick symbol might be missing.
+                return indexOfBacktick > -1 ? tn.Substring(0, indexOfBacktick) : tn;
+            }
         }
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue515_OutOfRangeExceptionForNestedGenericTypes.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue515_OutOfRangeExceptionForNestedGenericTypes.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using NSubstitute.Exceptions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    using NestedGeneric = Issue515_OutOfRangeExceptionForNestedGenericTypes.Foo<int, string>.Intermediate.Nested<List<byte>>;
+    using NestedNonGeneric = Issue515_OutOfRangeExceptionForNestedGenericTypes.Bar.Intermediate.Nested;
+
+    public class Issue515_OutOfRangeExceptionForNestedGenericTypes
+    {
+        [Test]
+        public void ShouldCorrectlyFormatNestedGenericTypeName()
+        {
+            var sub = Substitute.For<IConsumer>();
+            sub.ConsumeGeneric(new NestedGeneric());
+
+            var ex = Assert.Throws<ReceivedCallsException>(
+                () => sub.Received().ConsumeGeneric(null));
+            Assert.That(ex.Message, Contains.Substring(
+                "ConsumeGeneric(*Issue515_OutOfRangeExceptionForNestedGenericTypes+Foo<Int32, String>+Intermediate+Nested<List<Byte>>*)"));
+        }
+
+        [Test]
+        public void ShouldCorrectlyFormatNestedNonGenericTypeName()
+        {
+            var sub = Substitute.For<IConsumer>();
+            sub.ConsumeNonGeneric(new NestedNonGeneric());
+
+            var ex = Assert.Throws<ReceivedCallsException>(
+                () => sub.Received().ConsumeNonGeneric(null));
+            Assert.That(ex.Message, Contains.Substring(
+                "ConsumeNonGeneric(*Issue515_OutOfRangeExceptionForNestedGenericTypes+Bar+Intermediate+Nested*)"));
+        }
+
+        public interface IConsumer
+        {
+            void ConsumeGeneric(NestedGeneric arg);
+            void ConsumeNonGeneric(NestedNonGeneric arg);
+        }
+
+        public class Foo<T1, T2>
+        {
+            public class Intermediate
+            {
+                public class Nested<T3> where T3 : IEnumerable<byte>
+                {
+                    public int Baz { get; } = 42;
+                }
+            }
+        }
+
+        public class Bar
+        {
+            public class Intermediate
+            {
+                public class Nested
+                {
+                    public int Baz { get; } = 42;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes  #515.

Slightly complicate the type name formatting logic to handle the nested generic types correctly and to make our code maintenance a bit harder 😅 If you see how it could be written easier, please advise - I tried a few different approaches and the current one with local recursive function looks the best.