### PR TITLE
Improve return configuration

### DIFF
--- a/src/NSubstitute/Core/CallResults.cs
+++ b/src/NSubstitute/Core/CallResults.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Linq;
 
 namespace NSubstitute.Core
 {
@@ -36,7 +35,7 @@ namespace NSubstitute.Core
                 return false;
             }
 
-            result = resultWrapper.GetResult(_callInfoFactory.Create(call));
+            result = resultWrapper.GetResult(call, _callInfoFactory);
             return true;
         }
 
@@ -81,7 +80,16 @@ namespace NSubstitute.Core
             }
 
             public bool IsResultFor(ICall call) => _callSpecification.IsSatisfiedBy(call);
-            public object GetResult(CallInfo callInfo) => _resultToReturn.ReturnFor(callInfo);
+            public object GetResult(ICall call, ICallInfoFactory callInfoFactory)
+            {
+                if (_resultToReturn is ICallIndependentReturn callIndependentReturn)
+                {
+                    return callIndependentReturn.GetReturnValue();
+                }
+
+                var callInfo = callInfoFactory.Create(call);
+                return _resultToReturn.ReturnFor(callInfo);
+            }
         }
     }
 }

--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -8,56 +8,41 @@ namespace NSubstitute.ReturnsExtensions
         /// <summary>
         /// Set null as returned value for this call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsNull<T>(this T value) where T : class
         {
-            return value.Returns(i => null);
+            return value.Returns(default(T));
         }
 
         /// <summary>
         /// Set null as returned value for this call made with any arguments.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsNullForAnyArgs<T>(this T value) where T : class
         {
-            return value.ReturnsForAnyArgs(i => null);
+            return value.ReturnsForAnyArgs(default(T));
         }
 
         /// <summary>
         /// Set null as returned value for this call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsNull<T>(this Task<T> value) where T : class
         {
-            return value.Returns(i => SubstituteExtensions.CompletedTask<T>(null));
+            return value.Returns(default(T));
         }
 
         /// <summary>
         /// Set null as returned value for this call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsNull<T>(this ValueTask<T> value) where T : class
         {
-            return value.Returns(i => SubstituteExtensions.CompletedValueTask<T>(null));
+            return value.Returns(default(T));
         }
 
         /// <summary>
         /// Set null as returned value for this call made with any arguments.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsNullForAnyArgs<T>(this Task<T> value) where T : class
         {
-            return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedTask<T>(null));
+            return value.ReturnsForAnyArgs(default(T));
         }
 
         /// <summary>
@@ -68,7 +53,7 @@ namespace NSubstitute.ReturnsExtensions
         /// <returns></returns>
         public static ConfiguredCall ReturnsNullForAnyArgs<T>(this ValueTask<T> value) where T : class
         {
-            return value.ReturnsForAnyArgs(i => SubstituteExtensions.CompletedValueTask<T>(null));
+            return value.ReturnsForAnyArgs(default(T));
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
@@ -52,22 +52,22 @@ namespace NSubstitute.Routing.Handlers
         {
             public ConfiguredCall Returns<T>(T returnThis, params T[] returnThese)
             {
-                return SubstituteExtensions.Returns(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
+                return default(T).Returns(returnThis, returnThese);
             }
 
             public ConfiguredCall Returns<T>(Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
             {
-                return SubstituteExtensions.Returns(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
+                return default(T).Returns(returnThis, returnThese);
             }
 
             public ConfiguredCall ReturnsForAnyArgs<T>(T returnThis, params T[] returnThese)
             {
-                return SubstituteExtensions.Returns(MatchArgs.Any, returnThis, returnThese);
+                return default(T).ReturnsForAnyArgs(returnThis, returnThese);
             }
 
             public ConfiguredCall ReturnsForAnyArgs<T>(Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
             {
-                return SubstituteExtensions.Returns(MatchArgs.Any, returnThis, returnThese);
+                return default(T).ReturnsForAnyArgs(returnThis, returnThese);
             }
         }
     }

--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -13,172 +13,146 @@ namespace NSubstitute
         /// <summary>
         /// Set a return value for this call.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return</param>
         /// <param name="returnThese">Optionally return these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this T value, T returnThis, params T[] returnThese)
         {
-            return Returns(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
         }
 
         /// <summary>
         /// Set a return value for this call, calculated by the provided function.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Function to calculate the return value</param>
         /// <param name="returnThese">Optionally use these functions next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this T value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
-            return Returns(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
         }
 
         /// <summary>
         /// Set a return value for this call. The value(s) to be returned will be wrapped in Tasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return. Will be wrapped in a Task</param>
         /// <param name="returnThese">Optionally use these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this Task<T> value, T returnThis, params T[] returnThese)
         {
             var wrappedReturnValue = CompletedTask(returnThis);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedTask).ToArray() : null;
 
-            var wrappedParameters = returnThese.Select(CompletedTask);
-
-            return Returns(MatchArgs.AsSpecifiedInCall, wrappedReturnValue, wrappedParameters.ToArray());
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, wrappedReturnValue, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call, calculated by the provided function. The value(s) to be returned will be wrapped in Tasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Function to calculate the return value</param>
         /// <param name="returnThese">Optionally use these functions next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this Task<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
             var wrappedFunc = WrapFuncInTask(returnThis);
-            var wrappedFuncs = returnThese.Select(WrapFuncInTask);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInTask).ToArray() : null;
 
-            return Returns(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedFuncs.ToArray());
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return. Will be wrapped in a ValueTask</param>
         /// <param name="returnThese">Optionally use these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
         {
             var wrappedReturnValue = CompletedValueTask(returnThis);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedValueTask).ToArray() : null;
 
-            var wrappedParameters = returnThese.Select(CompletedValueTask);
-
-            return Returns(MatchArgs.AsSpecifiedInCall, wrappedReturnValue, wrappedParameters.ToArray());
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, wrappedReturnValue, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call, calculated by the provided function. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Function to calculate the return value</param>
         /// <param name="returnThese">Optionally use these functions next</param>
-        /// <returns></returns>
         public static ConfiguredCall Returns<T>(this ValueTask<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
             var wrappedFunc = WrapFuncInValueTask(returnThis);
-            var wrappedFuncs = returnThese.Select(WrapFuncInValueTask);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInValueTask).ToArray() : null;
 
-            return Returns(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedFuncs.ToArray());
+            return ConfigureReturn(MatchArgs.AsSpecifiedInCall, wrappedFunc, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in Tasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return</param>
         /// <param name="returnThese">Optionally return these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, T returnThis, params T[] returnThese)
         {
             var wrappedReturnValue = CompletedTask(returnThis);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedTask).ToArray() : null;
 
-            var wrappedParameters = returnThese.Select(CompletedTask);
-
-            return Returns(MatchArgs.Any, wrappedReturnValue, wrappedParameters.ToArray());
+            return ConfigureReturn(MatchArgs.Any, wrappedReturnValue, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call made with any arguments, calculated by the provided function. The value(s) to be returned will be wrapped in Tasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Function to calculate the return value</param>
         /// <param name="returnThese">Optionally use these functions next</param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
             var wrappedFunc = WrapFuncInTask(returnThis);
-            var wrappedFuncs = returnThese.Select(WrapFuncInTask);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInTask).ToArray() : null;
             
-            return Returns(MatchArgs.Any, wrappedFunc, wrappedFuncs.ToArray());
+            return ConfigureReturn(MatchArgs.Any, wrappedFunc, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return</param>
         /// <param name="returnThese">Optionally return these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
         {
             var wrappedReturnValue = CompletedValueTask(returnThis);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedValueTask).ToArray() : null;
 
-            var wrappedParameters = returnThese.Select(CompletedValueTask);
-
-            return Returns(MatchArgs.Any, wrappedReturnValue, wrappedParameters.ToArray());
+            return ConfigureReturn(MatchArgs.Any, wrappedReturnValue, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call made with any arguments, calculated by the provided function. The value(s) to be returned will be wrapped in ValueTasks.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Function to calculate the return value</param>
         /// <param name="returnThese">Optionally use these functions next</param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
             var wrappedFunc = WrapFuncInValueTask(returnThis);
-            var wrappedFuncs = returnThese.Select(WrapFuncInValueTask);
+            var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInValueTask).ToArray() : null;
 
-            return Returns(MatchArgs.Any, wrappedFunc, wrappedFuncs.ToArray());
+            return ConfigureReturn(MatchArgs.Any, wrappedFunc, wrappedReturnThese);
         }
 
         /// <summary>
         /// Set a return value for this call made with any arguments.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <param name="returnThis">Value to return</param>
         /// <param name="returnThese">Optionally return these values next</param>
-        /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this T value, T returnThis, params T[] returnThese)
         {
-            return Returns(MatchArgs.Any, returnThis, returnThese);
+            return ConfigureReturn(MatchArgs.Any, returnThis, returnThese);
         }
 
         /// <summary>
@@ -191,10 +165,10 @@ namespace NSubstitute
         /// <returns></returns>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this T value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
-            return Returns(MatchArgs.Any, returnThis, returnThese);
+            return ConfigureReturn(MatchArgs.Any, returnThis, returnThese);
         }
 
-        internal static ConfiguredCall Returns<T>(MatchArgs matchArgs, T returnThis, params T[] returnThese)
+        private static ConfiguredCall ConfigureReturn<T>(MatchArgs matchArgs, T returnThis, T[] returnThese)
         {
             IReturn returnValue;
             if (returnThese == null || returnThese.Length == 0)
@@ -211,7 +185,7 @@ namespace NSubstitute
                 .LastCallShouldReturn(returnValue, matchArgs);
         }
 
-        internal static ConfiguredCall Returns<T>(MatchArgs matchArgs, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
+        private static ConfiguredCall ConfigureReturn<T>(MatchArgs matchArgs, Func<CallInfo, T> returnThis, Func<CallInfo, T>[] returnThese)
         {
             IReturn returnValue;
             if (returnThese == null || returnThese.Length == 0)
@@ -371,12 +345,12 @@ namespace NSubstitute
             return x => CompletedValueTask(returnThis(x));
         }
 
-        internal static Task<T> CompletedTask<T>(T result) 
+        private static Task<T> CompletedTask<T>(T result) 
         {
             return Task.FromResult(result);
         }
 
-        internal static ValueTask<T> CompletedValueTask<T>(T result)
+        private static ValueTask<T> CompletedValueTask<T>(T result)
         {
             return new ValueTask<T>(result);
         }


### PR DESCRIPTION
Tiny performance and allocation improvement for the case when we want to return the already configured value. I found that  we don't need information about the arguments when we want return a static value. Again, it's a small improvement, but now we need less than 1 ns - isn't it wonderful (and, of course, fully useless in real life)? :sweat_smile:

Bechmark (tested only one case, as other would produce the same value):

```
BEFORE

                         Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
------------------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
 DispatchInterfaceProxyCall_Int | 1.044 us | 0.0205 us | 0.0300 us | 0.0801 | 0.0248 |     536 B |
 

AFTER:

 DispatchInterfaceProxyCall_Int | 958.0 ns | 15.60 ns | 13.03 ns | 0.0620 | 0.0181 |     408 B |

```

Additional, I slightly refactored out `Return` configuration extensions, so now they are more consistent.

@dtchepak Happy review, let me know if you have any objections.