### PR TITLE
Eliminate unnecessary allocations and improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### unreleased
 
+* [UPDATE] Various performance improvements. (#536, #542, #547, @zvirja)
+* [UPDATE] Use Castle.Proxy library to generate delegate proxies. (#537, @zvirja)
 * [FIX] Do not fail on nested generic type formatting. (#515, @zvirja)
 * [FIX] Fix event handling for code created by non-ECMA compliant compilers. (#500, #525, @zvirja)
 * [UPDATE] Thanks to Julian Verdurmen (@304NotModified) for updating our website and links

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
@@ -4,16 +4,18 @@ namespace NSubstitute.Core.Arguments
 {
     public class ArgumentSpecification : IArgumentSpecification
     {
-        static readonly Action<object> NoOpAction = x => { };
-        readonly Type _forType;
-        readonly IArgumentMatcher _matcher;
-        readonly Action<object> _action;
+        private static readonly Action<object> NoOpAction = x => { };
+ 
+        private readonly IArgumentMatcher _matcher;
+        private readonly Action<object> _action;
+        public Type ForType { get; }
+        public bool HasAction => _action != NoOpAction;
 
         public ArgumentSpecification(Type forType, IArgumentMatcher matcher) : this(forType, matcher, NoOpAction) { }
 
         public ArgumentSpecification(Type forType, IArgumentMatcher matcher, Action<object> action)
         {
-            _forType = forType;
+            ForType = forType;
             _matcher = matcher;
             _action = action;
         }
@@ -42,14 +44,12 @@ namespace NSubstitute.Core.Arguments
                 : matcherFormatter.Format(argument, isSatisfiedByArg);
         }
 
-        public Type ForType { get { return _forType; } }
-
-        public override string ToString() { return _matcher.ToString(); }
+        public override string ToString() => _matcher.ToString();
 
         public IArgumentSpecification CreateCopyMatchingAnyArgOfType(Type requiredType)
         {
-            //Don't pass RunActionIfTypeIsCompatible method if no action is present.
-            //Otherwise, unnecessary closure will keep reference to this and will keep it alive.
+            // Don't pass RunActionIfTypeIsCompatible method if no action is present.
+            // Otherwise, unnecessary closure will keep reference to this and will keep it alive.
             return new ArgumentSpecification(
                 requiredType,
                 new AnyArgumentMatcher(requiredType),

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecification.cs
@@ -7,6 +7,7 @@ namespace NSubstitute.Core.Arguments
         bool IsSatisfiedBy(object argument);
         Type ForType { get; }
         IArgumentSpecification CreateCopyMatchingAnyArgOfType(Type requiredType);
+        bool HasAction { get; }
         void RunAction(object argument);
         string DescribeNonMatch(object argument);
         string FormatArgument(object argument);

--- a/src/NSubstitute/Core/CallCollection.cs
+++ b/src/NSubstitute/Core/CallCollection.cs
@@ -8,58 +8,83 @@ namespace NSubstitute.Core
 {
     public class CallCollection : ICallCollection
     {
-        ConcurrentQueue<CallWrapper> _callWrappers = new ConcurrentQueue<CallWrapper>();
+        private ConcurrentQueue<IReceivedCallEntry> _callEntries = new ConcurrentQueue<IReceivedCallEntry>();
 
         public void Add(ICall call)
         {
             if (call == null) throw new ArgumentNullException(nameof(call));
-            _callWrappers.Enqueue(new CallWrapper(call));
+
+            IReceivedCallEntry callEntry;
+            if (call is IReceivedCallEntry callAsEntry && callAsEntry.TryTakeEntryOwnership())
+            {
+                callEntry = callAsEntry;
+            }
+            else
+            {
+                callEntry = new ReceivedCallEntry(call);
+            }
+ 
+            _callEntries.Enqueue(callEntry);
         }
 
         public void Delete(ICall call)
         {
             if (call == null) throw new ArgumentNullException(nameof(call));
 
-            var callWrapper = _callWrappers.FirstOrDefault(w => !w.IsDeleted && call.Equals(w.Call));
+            var callWrapper = _callEntries.FirstOrDefault(e => !e.IsSkipped && call.Equals(e.Call));
             if (callWrapper == null)
             {
                 throw new SubstituteInternalException("CallCollection.Delete - collection doesn't contain the call");
             }
 
-            callWrapper.Delete();
+            callWrapper.Skip();
         }
 
         public IEnumerable<ICall> AllCalls()
         {
-            return _callWrappers.ToArray()
-                .Where(w => !w.IsDeleted)
-                .Select(w => w.Call);
+            return _callEntries
+                .Where(e => !e.IsSkipped)
+                .Select(e => e.Call)
+                .ToArray();
         }
 
         public void Clear()
         {
-            //Queue doesn't have a Clear method.
-            _callWrappers = new ConcurrentQueue<CallWrapper>();
+            // Queue doesn't have a Clear method.
+            _callEntries = new ConcurrentQueue<IReceivedCallEntry>();
+        }
+ 
+        /// <summary>
+        /// Performance optimization. Allows to mark call as deleted without allocating extra wrapper.
+        /// To play safely, we track ownership, so object can be re-used only once.
+        /// </summary>
+        internal interface IReceivedCallEntry
+        {
+            ICall Call { get; }
+            bool IsSkipped { get; }
+            void Skip();
+            bool TryTakeEntryOwnership();
         }
 
         /// <summary>
         /// Wrapper to track that particular entry was deleted.
         /// That is needed because concurrent collections don't have a Delete method.
-        /// We null the hold value to not leak memory.
+        /// Notice, in most cases the original <see cref="Call"/> instance will be used as a wrapper itself.
         /// </summary>
-        private class CallWrapper
+        private class ReceivedCallEntry : IReceivedCallEntry
         {
             public ICall Call { get; private set; }
-            public bool IsDeleted => Call == null;
 
-            public CallWrapper(ICall call)
+            public bool IsSkipped => Call == null;
+
+            public void Skip() => Call = null; // Null the hold value to reclaim a bit of memory.
+
+            public bool TryTakeEntryOwnership() =>
+                throw new SubstituteInternalException("Ownership is never expected to be obtained for this entry.");
+
+            public ReceivedCallEntry(ICall call)
             {
                 Call = call;
-            }
-
-            public void Delete()
-            {
-                Call = null;
             }
         }
     }

--- a/src/NSubstitute/Core/CallResults.cs
+++ b/src/NSubstitute/Core/CallResults.cs
@@ -29,33 +29,35 @@ namespace NSubstitute.Core
                 return false;
             }
 
-            var resultWrapper = FindResultForCall(call);
-            if (resultWrapper == null)
+            if (!TryFindResultForCall(call, out var configuredResult))
             {
                 return false;
             }
 
-            result = resultWrapper.GetResult(call, _callInfoFactory);
+            result = configuredResult.GetResult(call, _callInfoFactory);
             return true;
         }
 
-        private ResultForCallSpec FindResultForCall(ICall call)
+        private bool TryFindResultForCall(ICall call, out ResultForCallSpec configuredResult)
         {
             // Optimization for performance - enumerator makes allocation.
             if (_results.IsEmpty)
             {
-                return null;
+                configuredResult = default;
+                return false;
             }
 
             foreach (var result in _results)
             {
                 if (result.IsResultFor(call))
                 {
-                    return result;
+                    configuredResult = result;
+                    return true;
                 }
             }
 
-            return null;
+            configuredResult = default;
+            return false;
         }
 
         public void Clear()
@@ -68,7 +70,7 @@ namespace NSubstitute.Core
             return call.GetReturnType() == typeof(void);
         }
 
-        private class ResultForCallSpec
+        private readonly struct ResultForCallSpec
         {
             private readonly ICallSpecification _callSpecification;
             private readonly IReturn _resultToReturn;

--- a/src/NSubstitute/Core/ReflectionExtensions.cs
+++ b/src/NSubstitute/Core/ReflectionExtensions.cs
@@ -8,10 +8,17 @@ namespace NSubstitute.Core
     {
         public static PropertyInfo GetPropertyFromSetterCallOrNull(this MethodInfo call)
         {
-            if(!CanBePropertySetterCall(call)) return null;
+            if (!CanBePropertySetterCall(call)) return null;
 
             var properties = call.DeclaringType.GetProperties();
-            return properties.FirstOrDefault(x => x.GetSetMethod() == call);
+
+            // Don't use .FirstOrDefault() lambda, as closure leads to allocation even if not reached.
+            foreach (var property in properties)
+            {
+                if (property.GetSetMethod() == call) return property;
+            }
+
+            return null;
         }
 
         public static PropertyInfo GetPropertyFromGetterCallOrNull(this MethodInfo call)

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
@@ -23,13 +23,21 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
                 !castleInvocation.MethodInvocationTarget.IsAbstract &&
                 !castleInvocation.MethodInvocationTarget.IsFinal)
             {
-                Func<object> baseResult = () => { castleInvocation.Proceed(); return castleInvocation.ReturnValue; };
-                var result = new Lazy<object>(baseResult);
-                baseMethod = () => result.Value;
+                baseMethod = CreateBaseResultInvocation(castleInvocation);
             }
 
             var queuedArgSpecifications = _argSpecificationDequeue.DequeueAllArgumentSpecificationsForMethod(castleInvocation.Arguments.Length);
             return _callFactory.Create(castleInvocation.Method, castleInvocation.Arguments, castleInvocation.Proxy, queuedArgSpecifications, baseMethod);
+        }
+
+        private static Func<object> CreateBaseResultInvocation(IInvocation invocation)
+        {
+            // Notice, it's important to keep this as a separate method, as methods with lambda closures
+            // always allocate, even if delegate is not actually constructed.
+            // This way we make allocation only if indeed required.
+            Func<object> baseResult = () => { invocation.Proceed(); return invocation.ReturnValue; };
+            var result = new Lazy<object>(baseResult);
+            return () => result.Value;
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/RecordCallSpecificationHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/RecordCallSpecificationHandler.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute.Core;
+﻿using System.Linq;
+using NSubstitute.Core;
 
 namespace NSubstitute.Routing.Handlers
 {
@@ -19,7 +20,14 @@ namespace NSubstitute.Routing.Handlers
         {
             var callSpec = _callSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall);
             _pendingCallSpecification.SetCallSpecification(callSpec);
-            _callActions.Add(callSpec);
+
+            // Performance optimization - don't register call actions if current argument matchers
+            // don't have any callbacks.
+            if (call.GetArgumentSpecifications().Any(x => x.HasAction))
+            {
+                _callActions.Add(callSpec);
+            }
+
             return RouteAction.Continue();
         }
     }


### PR DESCRIPTION
In this PR I decided to push it to the _reasonable_ limits and decrease allocations amount during call dispatch to the bare minimum (when it makes sense, of course). Additionally, added thread-safety to the `CallActions` collection - I think that was the only remaining non-thread safe place.

Considering the following scenario:

```c#
var substitute = Substitute.For<ISomething>();
substitute.Echo(42);

// MEASURE FROM HERE
substitute.Echo(42);
```

Allocations are following:
![image](https://user-images.githubusercontent.com/1074182/56443296-b6d1e380-62fc-11e9-82ca-2d9f19267d2b.png)

The allocations under cursor come from us. I also had a plan to eliminate the enumerator, but decided to not do it, as it complicates the code (we should use our custom stack implementation instead of built-in collections) and I think it doesn't worth it. We can also do nothing about `RouteAction`, as it would be a breaking change.

The same allocation graph happens for a dispatch of already configured call.

The performance measurement is following (measured only one case when it makes much difference):

```
BEFORE

                         Method |  Job | Runtime |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
------------------------------- |----- |-------- |---------:|---------:|---------:|-------:|-------:|----------:|
 DispatchInterfaceProxyCall_Int |  Clr |     Clr | 961.3 ns | 18.87 ns | 26.46 ns | 0.0629 | 0.0210 |     405 B |
 DispatchInterfaceProxyCall_Int | Core |    Core | 905.0 ns | 12.36 ns | 10.95 ns | 0.0620 | 0.0153 |     408 B |


AFTER

                         Method |  Job | Runtime |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
------------------------------- |----- |-------- |---------:|---------:|---------:|-------:|-------:|----------:|
 DispatchInterfaceProxyCall_Int |  Clr |     Clr | 928.1 ns | 18.07 ns | 14.11 ns | 0.0553 | 0.0134 |     349 B |
 DispatchInterfaceProxyCall_Int | Core |    Core | 866.1 ns | 12.57 ns | 11.14 ns | 0.0505 | 0.0153 |     336 B |
```

Slight, but win without significant code complications.

@dtchepak Please review the code and let me know your opinion. If you believe that some improvements make it very complicated (like one with `ICall`) - let me know.

As usual, it's easier to review commit by commit.

Thanks!