### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dist: xenial
 dotnet: 2.1.502
 mono: none
 env: CONFIGURATION=Release FRAMEWORK=netcoreapp2.1


### PR DESCRIPTION
From [1].

Travis build started breaking: https://travis-ci.com/nsubstitute/NSubstitute/builds/109138042

> Installing .NET Core
> $ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
> $ export DOTNET_CLI_TELEMETRY_OPTOUT=1
> 7.55s0.38sE: Unable to locate package dotnet-sdk-2.1
> E: Couldn't find any package by glob 'dotnet-sdk-2.1'
> E: Couldn't find any package by regex 'dotnet-sdk-2.1'
> The command "sudo apt-get install -qq dotnet-sdk-2.1=2.1.502*" failed and exited with 100 during .

[1]: https://travis-ci.community/t/c-builds-are-failing-net-core-installation-error/3063