### PR TITLE
Rephrase to avoid potential confusion

### DIFF
--- a/docs/help/_posts/2010-04-01-argument-matchers.markdown
+++ b/docs/help/_posts/2010-04-01-argument-matchers.markdown
@@ -179,10 +179,10 @@ Similarly, we should not use an arg matcher as a real value to return from a cal
 var widgetFactory = Substitute.For<IWidgetFactory>();
 
 // NOT OK: using an arg matcher as a value, not to specify a call:
-//    widgetFactory.Make(new WidgetInfo { Name = "Test" }).Returns(Arg.Any<string>());
+//    widgetFactory.Make(Arg.Any<WidgetInfo>()).Returns(Arg.Any<string>());
 
 // Instead use something like:
-widgetFactory.Make(new WidgetInfo { Name = "Test" }).Returns("any widget");
+widgetFactory.Make(Arg.Any<WidgetInfo>()).Returns("any widget");
 ```
 
 Another legal use of argument matchers is specifying calls when configuring callbacks:

--- a/docs/help/_posts/2010-04-01-argument-matchers.markdown
+++ b/docs/help/_posts/2010-04-01-argument-matchers.markdown
@@ -22,6 +22,7 @@ public interface IFormatter {
 }
 public interface IWidgetFactory {
   string Make(WidgetInfo info);
+  string MakeDefaultWidget();
 }
 public class WidgetInfo {
   public string Name { get; set; }
@@ -179,10 +180,10 @@ Similarly, we should not use an arg matcher as a real value to return from a cal
 var widgetFactory = Substitute.For<IWidgetFactory>();
 
 // NOT OK: using an arg matcher as a value, not to specify a call:
-//    widgetFactory.Make(Arg.Any<WidgetInfo>()).Returns(Arg.Any<string>());
+//    widgetFactory.MakeDefaultWidget().Returns(Arg.Any<string>());
 
 // Instead use something like:
-widgetFactory.Make(Arg.Any<WidgetInfo>()).Returns("any widget");
+widgetFactory.MakeDefaultWidget().Returns("any widget");
 ```
 
 Another legal use of argument matchers is specifying calls when configuring callbacks:


### PR DESCRIPTION
It's a common problem when people assume that NSubstitute does deep arguments inspection instead of just using reference comparison. Updated sample, as it looks veery much like we do structural inspection.

@dtchepak Sorry for nitpicking, I know I'm doing that, but I'm just tired of people coming over and over again and asking why we don't do structural inspection 😫 I want our documentation to never even drop a shadow in that direction; don't even raise that "what if" in heads of readers.