### PR TITLE
Add ability to decorate existing registrations

### DIFF
--- a/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
+++ b/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
@@ -27,6 +27,13 @@ namespace NSubstitute.Core.DependencyInjection
         IConfigurableNSubContainer Register<TKey, TImpl>(NSubLifetime lifetime) where TImpl : TKey;
 
         IConfigurableNSubContainer Register<TKey>(Func<INSubResolver, TKey> factory, NSubLifetime lifetime);
+
+        /// <summary>
+        /// Decorates the original implementation with a custom decorator.
+        /// The factory method is provided with an original implementation instance.
+        /// The lifetime of decorated implementation is used.
+        /// </summary>
+        IConfigurableNSubContainer Decorate<TKey>(Func<TKey, INSubResolver, TKey> factory);
     }
 
     public static class ConfigurableNSubContainerExtensions

--- a/src/NSubstitute/Core/DependencyInjection/NSubContainer.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubContainer.cs
@@ -85,8 +85,8 @@ namespace NSubstitute.Core.DependencyInjection
 
             object Factory(Scope scope)
             {
-                // Resolve original implementation using registration from parent container.
-                // This way we avoid recursion and support even nested decorators.
+                // Freeze original registration discovered during decoration.
+                // This way we avoid recursion and support nested decorators.
                 var originalInstance = (TKey) scope.Resolve(existingRegistration);
                 return factory.Invoke(originalInstance, scope);
             }

--- a/tests/NSubstitute.Acceptance.Specs/NSubContainerTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/NSubContainerTests.cs
@@ -246,6 +246,120 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(result1.Dep, Is.SameAs(result2.Dep));
         }
 
+        [Test]
+        public void ShouldDecorateTheExistingRegistration()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+
+            var sutFork = sut
+                .Customize()
+                .Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var result = sutFork.Resolve<ITestInterface>();
+
+            Assert.That(result, Is.TypeOf<TestImplDecorator>());
+            Assert.That(((TestImplDecorator) result).Inner, Is.TypeOf<TestImplSingleCtor>());
+        }
+
+        [Test]
+        public void ShouldBePossibleToCreateNestedDecorators()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+
+            var sutFork = sut
+                .Customize()
+                .Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var sutForkFork = sutFork
+                .Customize()
+                .Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var result = sutForkFork.Resolve<ITestInterface>();
+
+            var mostInner = ((result as TestImplDecorator)?.Inner as TestImplDecorator)?.Inner;
+            Assert.That(mostInner, Is.TypeOf<TestImplSingleCtor>());
+        }
+
+        [Test]
+        public void ShouldFailIfTypeToDecorateDoesNotExist()
+        {
+            var sut = new NSubContainer();
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => sut.Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl)));
+            Assert.That(ex.Message, Contains.Substring("implementation is not registered"));
+        }
+
+        [Test]
+        public void ShouldDecorateWhenRegisteredOnSameContainer()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            sut.Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var result = sut.Resolve<ITestInterface>();
+
+            Assert.That(result, Is.TypeOf<TestImplDecorator>());
+        }
+
+        [Test]
+        public void ShouldPinDecoratedRegistrationAtRegistrationTime()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+            var sutFork = sut.Customize().Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+
+            // Override registration. Very rare case
+            sut.Register<ITestInterface, TestImplSingleCtor2>(NSubLifetime.Transient);
+            var result = sutFork.Resolve<ITestInterface>();
+
+            Assert.That(result, Is.TypeOf<TestImplDecorator>());
+            Assert.That(((TestImplDecorator) result).Inner, Is.TypeOf<TestImplSingleCtor>());
+        }
+
+        [Test]
+        public void ShouldUseSameLifetimeForDecorator_TransientCase()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Transient);
+
+            sut.Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var scope = sut.CreateScope();
+            var result1 = scope.Resolve<ITestInterface>();
+            var result2 = scope.Resolve<ITestInterface>();
+
+            Assert.That(result1, Is.Not.SameAs(result2));
+            Assert.That(((TestImplDecorator) result1).Inner, Is.Not.SameAs(((TestImplDecorator) result2).Inner));
+        }
+
+        [Test]
+        public void ShouldUseSameLifetimeForDecorator_PerScopeCase()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.PerScope);
+
+            sut.Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var scope = sut.CreateScope();
+            var result1 = scope.Resolve<ITestInterface>();
+            var result2 = scope.Resolve<ITestInterface>();
+
+            Assert.That(result1, Is.SameAs(result2));
+            Assert.That(((TestImplDecorator) result1).Inner, Is.SameAs(((TestImplDecorator) result2).Inner));
+        }
+
+        [Test]
+        public void ShouldUseSameLifetimeForDecorator_SingletonCase()
+        {
+            var sut = new NSubContainer();
+            sut.Register<ITestInterface, TestImplSingleCtor>(NSubLifetime.Singleton);
+
+            sut.Decorate<ITestInterface>((impl, r) => new TestImplDecorator(impl));
+            var result1 = sut.Resolve<ITestInterface>();
+            var result2 = sut.Resolve<ITestInterface>();
+
+            Assert.That(result1, Is.SameAs(result2));
+            Assert.That(((TestImplDecorator) result1).Inner, Is.SameAs(((TestImplDecorator) result2).Inner));
+        }
+
         public interface ITestInterface
         {
         }
@@ -298,6 +412,16 @@ namespace NSubstitute.Acceptance.Specs
             {
                 TestInterfaceDep = testInterfaceDep;
                 ClassWithDependencyDep = classWithDependencyDep;
+            }
+        }
+
+        public class TestImplDecorator : ITestInterface
+        {
+            public ITestInterface Inner { get; }
+
+            public TestImplDecorator(ITestInterface inner)
+            {
+                Inner = inner;
             }
         }
     }


### PR DESCRIPTION
Feature allows to decorate existing dependencies without knowing their actual implementation.
That might be useful e.g. for logging.

I faced this issue when tried to customize NSubstitute. I just wanted to decorate the default implementation to add some extra logic without knowing actual implementation types. It was impossible to do that, so knowledge of exact implementation type was required and my code was fragile. Now I can do it nicely and it will be more robust to further changes.

I also like how nicely it fit into our container.