### PR TITLE
Rethrow exception wrapped in task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### unreleased
 
+* [FIX] Re-throw captured NSubstitute exceptions when configuring async methods. (#533, @zvirja)
 * [UPDATE] Various performance improvements. (#536, #542, #547, @zvirja)
 * [UPDATE] Use Castle.Proxy library to generate delegate proxies. (#537, @zvirja)
 * [FIX] Do not fail on nested generic type formatting. (#515, @zvirja)

--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NSubstitute.Core;
 using NSubstitute.ClearExtensions;
 using System.Threading.Tasks;
+using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
 
 namespace NSubstitute
@@ -40,6 +41,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these values next</param>
         public static ConfiguredCall Returns<T>(this Task<T> value, T returnThis, params T[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+ 
             var wrappedReturnValue = CompletedTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedTask).ToArray() : null;
 
@@ -54,6 +57,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these functions next</param>
         public static ConfiguredCall Returns<T>(this Task<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+ 
             var wrappedFunc = WrapFuncInTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInTask).ToArray() : null;
 
@@ -68,6 +73,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these values next</param>
         public static ConfiguredCall Returns<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+ 
             var wrappedReturnValue = CompletedValueTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedValueTask).ToArray() : null;
 
@@ -82,6 +89,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these functions next</param>
         public static ConfiguredCall Returns<T>(this ValueTask<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+ 
             var wrappedFunc = WrapFuncInValueTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInValueTask).ToArray() : null;
 
@@ -96,6 +105,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally return these values next</param>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, T returnThis, params T[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+
             var wrappedReturnValue = CompletedTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedTask).ToArray() : null;
 
@@ -110,6 +121,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these functions next</param>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+
             var wrappedFunc = WrapFuncInTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInTask).ToArray() : null;
             
@@ -124,6 +137,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally return these values next</param>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+
             var wrappedReturnValue = CompletedValueTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(CompletedValueTask).ToArray() : null;
 
@@ -138,6 +153,8 @@ namespace NSubstitute
         /// <param name="returnThese">Optionally use these functions next</param>
         public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
         {
+            ReThrowOnNSubstituteFault(value);
+
             var wrappedFunc = WrapFuncInValueTask(returnThis);
             var wrappedReturnThese = returnThese.Length > 0 ? returnThese.Select(WrapFuncInValueTask).ToArray() : null;
 
@@ -353,6 +370,22 @@ namespace NSubstitute
         private static ValueTask<T> CompletedValueTask<T>(T result)
         {
             return new ValueTask<T>(result);
+        }
+
+        private static void ReThrowOnNSubstituteFault<T>(Task<T> task)
+        {
+            if (task.IsFaulted && task.Exception.InnerExceptions.FirstOrDefault() is SubstituteException)
+            {
+                task.GetAwaiter().GetResult();
+            }
+        }
+
+        private static void ReThrowOnNSubstituteFault<T>(ValueTask<T> task)
+        {
+            if (task.IsFaulted && task.AsTask().Exception.InnerExceptions.FirstOrDefault() is SubstituteException)
+            {
+                task.GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue533_TaskExceptionMightBeSwallowed.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue533_TaskExceptionMightBeSwallowed.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.Exceptions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue533_TaskExceptionMightBeSwallowed
+    {
+        [Test]
+        public void ClientScenario_ShouldFailWithRedundantArgMatcherException()
+        {
+            var substitute = Substitute.For<IMainModule>();
+
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+                MainModuleExtensions
+                    .Work(substitute, Arg.Any<Guid>(), Arg.Any<string>())
+                    .Returns(Guid.Empty)
+            );
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_TaskValue()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoAsync(substitute, Arg.Any<int>()).Returns("42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_TaskValueForAny()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoAsync(substitute, Arg.Any<int>()).ReturnsForAnyArgs("42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_TaskCallback()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoAsync(substitute, Arg.Any<int>()).Returns(c => "42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_TaskCallbackForAny()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoAsync(substitute, Arg.Any<int>()).ReturnsForAnyArgs(c => "42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_ValueTaskValue()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoValueTaskAsync(substitute, Arg.Any<int>()).Returns("42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_ValueTaskValueForAny()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoValueTaskAsync(substitute, Arg.Any<int>()).ReturnsForAnyArgs("42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_ValueTaskCallback()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoValueTaskAsync(substitute, Arg.Any<int>()).Returns(c => "42");
+            });
+        }
+
+        [Test]
+        public void ShouldRethrowOriginalSubstituteException_ValueTaskCallbackForAny()
+        {
+            var substitute = Substitute.For<ISomething>();
+
+            substitute.Say("42"); // If task exception is not unwrapped, then type mismatch exception will be throw.
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                Arg.Any<int>();
+                InvokeEchoValueTaskAsync(substitute, Arg.Any<int>()).ReturnsForAnyArgs(c => "42");
+            });
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_TaskValue()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValue().Returns(42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_TaskValueAnyArg()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValue().ReturnsForAnyArgs(42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_TaskCallback()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValue().Returns(c => 42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_TaskCallbackAnyArg()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValue().ReturnsForAnyArgs(c => 42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_ValueTaskValue()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValueValueTask().Returns(42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_ValueTaskValueAnyArg()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValueValueTask().ReturnsForAnyArgs(42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_ValueTaskCallback()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValueValueTask().Returns(c => 42));
+        }
+
+        [Test]
+        public void ShouldSwallowCustomExceptionThrownFromTask_ValueTaskCallbackAnyArg()
+        {
+            var substitute = Substitute.ForPartsOf<ClassWithThrowingMethods>();
+
+            Assert.DoesNotThrow(() =>
+                substitute.GetValueValueTask().ReturnsForAnyArgs(c => 42));
+        }
+
+        private static async Task<string> InvokeEchoAsync(ISomething something, int value)
+        {
+            return await something.EchoAsync(value);
+        }
+
+        private static async ValueTask<string> InvokeEchoValueTaskAsync(ISomething something, int value)
+        {
+            return await something.EchoValueTaskAsync(value);
+        }
+
+        public interface IMainModule
+        {
+            IWorker Worker { get; }
+        }
+
+        public interface IWorker
+        {
+            Task DoSomethingAsync(Guid userId);
+        }
+
+        private static class MainModuleExtensions
+        {
+            public static async Task<Guid> Work(
+                /* this - extensions are not supported for nested types */ IMainModule mainModule,
+                Guid userId, string s)
+            {
+                await mainModule.Worker.DoSomethingAsync(userId);
+                return Guid.NewGuid();
+            }
+        }
+
+        public class ClassWithThrowingMethods
+        {
+#pragma warning disable 1998 // Async is required here to wrap exception in task.
+            public virtual async Task<int> GetValue() => throw new NotImplementedException();
+            public virtual async ValueTask<int> GetValueValueTask() => throw new NotImplementedException();
+#pragma warning restore 1998
+        }
+    }
+}


### PR DESCRIPTION
Fixes #533

Fix the issue in a way we agreed. Don't re-throw non-NSubstitute exception just in case somebody relies on that behavior.