### PR TITLE
Remove redundant argument specs cleanup

### DIFF
--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -98,8 +98,7 @@ namespace NSubstitute.Routing
         public IRoute RecordReplay(ISubstituteState state)
         {
             return new Route(new ICallHandler[] {
-                new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
-                , new TrackLastCallHandler(_threadLocalContext.PendingSpecification)
+                new TrackLastCallHandler(_threadLocalContext.PendingSpecification)
                 , new RecordCallHandler(state.ReceivedCalls, _sequenceNumberGenerator)
                 , new EventSubscriptionHandler(state.EventHandlerRegistry)
                 , new PropertySetterHandler(_propertyHelper, state.ConfigureCall)


### PR DESCRIPTION
The subsequent handler sets last call, which overrides the pending specification.

@dtchepak I can swear I wasn't looking how to optimize NSubstitute even more. I spotted this code accidentally and after that decided to improve it - given it's the most important route we have.