### PR TITLE
Use `default` keyword when AnyArg is used

### DIFF
--- a/docs/help/_posts/2010-02-03-return-for-any-args.markdown
+++ b/docs/help/_posts/2010-02-03-return-for-any-args.markdown
@@ -17,9 +17,15 @@ ICalculator calculator;
 A call can be configured to return a value regardless of the arguments passed using the `ReturnsForAnyArgs()` extension method.
 
 ```csharp
-calculator.Add(default, default).ReturnsForAnyArgs(100); 
+calculator.Add(1, 2).ReturnsForAnyArgs(100); 
 Assert.AreEqual(100, calculator.Add(1, 2));
 Assert.AreEqual(100, calculator.Add(-7, 15));
+```
+
+**Tip!** You can also use the `default` C# keyword for better readability:
+
+```csharp
+calculator.Add(default, default).ReturnsForAnyArgs(100);
 ```
 
 The same behaviour can also be achieved using [argument matchers](/help/argument-matchers): it is simply a shortcut for replacing each argument with `Arg.Any<T>()`.

--- a/docs/help/_posts/2010-02-03-return-for-any-args.markdown
+++ b/docs/help/_posts/2010-02-03-return-for-any-args.markdown
@@ -17,7 +17,7 @@ ICalculator calculator;
 A call can be configured to return a value regardless of the arguments passed using the `ReturnsForAnyArgs()` extension method.
 
 ```csharp
-calculator.Add(1, 2).ReturnsForAnyArgs(100); 
+calculator.Add(default, default).ReturnsForAnyArgs(100); 
 Assert.AreEqual(100, calculator.Add(1, 2));
 Assert.AreEqual(100, calculator.Add(-7, 15));
 ```

--- a/docs/help/_posts/2010-02-03-return-from-function.markdown
+++ b/docs/help/_posts/2010-02-03-return-from-function.markdown
@@ -42,7 +42,7 @@ public interface IFoo {
 
 ```csharp
 var foo = Substitute.For<IFoo>();
-foo.Bar(0, "").ReturnsForAnyArgs(x => "Hello " + x.Arg<string>());
+foo.Bar(default, default).ReturnsForAnyArgs(x => "Hello " + x.Arg<string>());
 Assert.That(foo.Bar(1, "World"), Is.EqualTo("Hello World"));
 ```
 
@@ -55,7 +55,7 @@ This technique can also be used to get a callback whenever a call is made:
 ```csharp
 var counter = 0;
 calculator
-    .Add(0, 0)
+    .Add(default, default)
     .ReturnsForAnyArgs(x => {
         counter++;
         return 0;
@@ -72,7 +72,7 @@ Alternatively the callback can be specified after the `Returns` using `AndDoes`:
 ```csharp
 var counter = 0;
 calculator
-    .Add(0, 0)
+    .Add(default, default)
     .ReturnsForAnyArgs(x => 0)
     .AndDoes(x => counter++);
 

--- a/docs/help/_posts/2010-03-01-received-calls.markdown
+++ b/docs/help/_posts/2010-03-01-received-calls.markdown
@@ -114,8 +114,8 @@ NSubstitute can also check calls were received or not received but ignore the ar
 ```csharp
 calculator.Add(1, 3);
 
-calculator.ReceivedWithAnyArgs().Add(1,1);
-calculator.DidNotReceiveWithAnyArgs().Subtract(0,0);
+calculator.ReceivedWithAnyArgs().Add(default, default);
+calculator.DidNotReceiveWithAnyArgs().Subtract(default, default);
 ```
 
 ## Checking calls to properties

--- a/docs/help/_posts/2010-05-01-callbacks.markdown
+++ b/docs/help/_posts/2010-05-01-callbacks.markdown
@@ -19,13 +19,13 @@ ICalculator calculator;
 ```csharp
 var counter = 0;
 calculator
-    .Add(0,0)
+    .Add(default, default)
     .ReturnsForAnyArgs(x => 0)
     .AndDoes(x => counter++);
 
-calculator.Add(7,3);
-calculator.Add(2,2);
-calculator.Add(11,-3);
+calculator.Add(7, 3);
+calculator.Add(2, 2);
+calculator.Add(11, -3);
 Assert.AreEqual(counter, 3);
 ```
 

--- a/docs/help/_posts/2013-02-01-partial-subs.markdown
+++ b/docs/help/_posts/2013-02-01-partial-subs.markdown
@@ -62,7 +62,7 @@ public class EmailServer {
 [Test]
 public void ShouldSendMultipleEmails() {
   var server = Substitute.ForPartsOf<EmailServer>();
-  server.WhenForAnyArgs(x => x.Send("", "", "")).DoNotCallBase(); // Make sure Send won't call real implementation
+  server.WhenForAnyArgs(x => x.Send(default, default, default)).DoNotCallBase(); // Make sure Send won't call real implementation
 
   server.SendMultiple(
     new [] { "alice", "bob", "charlie" },


### PR DESCRIPTION
I found that we always use `default` keyword when using configuration/verification methods disrespecting the actual argument values. It looks way readable, as:
- you are not distracted by actual values, even though those are default
- all args look the same, no matter whether you ref or value types
- the `default` keyword itself is treated like something you don't care about

Decided to share this pattern with our site readers via our samples.

@dtchepak I'm fine if you decide to reject the change - it's just an idea.