### PR TITLE
Fix event params ambiguity and add thread-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### unreleased
 
+* [FIX] Raise events for delegates taking single array argument of reference element type. (#560, @zvirja)
 
 ### 4.1.0 (May 2019)
 

--- a/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
+++ b/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
@@ -22,7 +22,7 @@ namespace NSubstitute.Core.Events
 
         protected override object[] WorkOutRequiredArguments(ICall call)
         {
-            var requiredArgs = typeof(T).GetMethod("Invoke").GetParameters();
+            var requiredArgs = typeof(T).GetInvokeMethod().GetParameters();
 
             if (_providedArguments.Length < 2 && LooksLikeAnEventStyleCall(requiredArgs))
             {

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -42,6 +42,11 @@ namespace NSubstitute.Core
             return type.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate));
         }
 
+        public static MethodInfo GetInvokeMethod(this Type type)
+        {
+            return type.GetMethod("Invoke");
+        }
+
         private static bool TypeCanBeNull(Type type)
         {
             return !type.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(type) != null;

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -72,7 +72,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 
             // Ideally we should use ProxyUtil.CreateDelegateToMixin(proxy, delegateType).
             // But it's slower than code below due to extra checks it performs.
-            return proxy.GetType().GetMethod("Invoke").CreateDelegate(delegateType, proxy);
+            return proxy.GetType().GetInvokeMethod().CreateDelegate(delegateType, proxy);
         }
 
         private CastleForwardingInterceptor CreateForwardingInterceptor(ICallRouter callRouter)

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue560_RaiseEventWithArrayArg.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue560_RaiseEventWithArrayArg.cs
@@ -1,0 +1,110 @@
+using System;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue560_RaiseEventWithArrayArg
+    {
+        [Test]
+        public void Raise_event_declared_as_action_with_ref_array_type()
+        {
+            Widget[] arg = null;
+            Widget w1 = new Widget("hello");
+            Widget w2 = new Widget("world");
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithRefArrayType += x => arg = x;
+
+            eventSamples.ActionWithRefArrayType += Raise.Event<Action<Widget[]>>(new[] {w1, w2});
+            Assert.That(arg, Is.Not.Null);
+            Assert.That(arg.Length, Is.EqualTo(2));
+            Assert.That(arg[0], Is.EqualTo(w1));
+            Assert.That(arg[1], Is.EqualTo(w2));
+        }
+
+        [Test]
+        public void Should_raise_event_for_object_array_arg()
+        {
+            object[] capturedArg = null;
+            var arg1 = new[] {new object(), new object()};
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithParamOfObjectArray += x => capturedArg = x;
+
+            eventSamples.ActionWithParamOfObjectArray += Raise.Event<Action<object[]>>(arg1);
+            Assert.That(capturedArg, Is.EqualTo(arg1));
+        }
+
+        [Test]
+        public void Should_raise_event_for_object_array_arg_with_covariance()
+        {
+            object[] capturedArg = null;
+            var arg1 = new[] {"hello", "world"};
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithParamOfObjectArray += x => capturedArg = x;
+
+            eventSamples.ActionWithParamOfObjectArray += Raise.Event<Action<object[]>>(arg1);
+            Assert.That(capturedArg, Is.EqualTo(arg1));
+        }
+
+        [Test]
+        public void Should_raise_event_for_object_array_arg_provided_without_using_params_syntax()
+        {
+            object[] capturedArg = null;
+            var arg1 = new[] {new object(), new object()};
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithParamOfObjectArray += x => capturedArg = x;
+
+            eventSamples.ActionWithParamOfObjectArray += Raise.Event<Action<object[]>>(new object[] {arg1});
+            Assert.That(capturedArg, Is.EqualTo(arg1));
+        }
+
+        [Test]
+        public void Should_raise_event_for_object_array_arg_provided_without_using_params_syntax_with_covariance()
+        {
+            object[] capturedArg = null;
+            var arg1 = new[] {"hello", "world"};
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithParamOfObjectArray += x => capturedArg = x;
+
+            eventSamples.ActionWithParamOfObjectArray += Raise.Event<Action<object[]>>(new object[] {arg1});
+            Assert.That(capturedArg, Is.EqualTo(arg1));
+        }
+
+        [Test]
+        public void Should_raise_event_for_multiple_object_array_args()
+        {
+            Tuple<object[], object[]> capturedArgs = null;
+            var arg1 = new[] {new object(), new object()};
+            var arg2 = new[] {new object(), new object()};
+
+            var eventSamples = Substitute.For<IEventSamples>();
+            eventSamples.ActionWithParamsOfObjectArray += (a1, a2) => capturedArgs = Tuple.Create(a1, a2);
+
+            eventSamples.ActionWithParamsOfObjectArray += Raise.Event<Action<object[], object[]>>(arg1, arg2);
+            Assert.That(capturedArgs, Is.Not.Null);
+            Assert.That(capturedArgs.Item1, Is.EqualTo(arg1));
+            Assert.That(capturedArgs.Item2, Is.EqualTo(arg2));
+        }
+
+        public interface IEventSamples
+        {
+            event Action<Widget[]> ActionWithRefArrayType;
+            event Action<object[]> ActionWithParamOfObjectArray;
+            event Action<object[], object[]> ActionWithParamsOfObjectArray;
+        }
+
+        public class Widget
+        {
+            public string Name { get; }
+
+            public Widget(string name)
+            {
+                Name = name;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #560

Solved the issue by handling ambiguity. Also spotted that events registry was not thread-safe. Fixed that, as I want NSubstitute to have ultimate thread-safety.