### PR TITLE
Add NSubstitute.Analyzers recommendation to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,11 +10,14 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 An example to help us reproduce the behaviour. (If you'd like some tips on the kind of information to include have a look at StackOverflow's [creating a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve).)
 
+Please make sure you are using [NSubstitute.Analyzers](https://nsubstitute.github.io/help/nsubstitute-analysers/) and that it does not pick up any problems with the reproduction code. The analyzers can help detect the cause of many issues.
+
 **Expected behaviour**
 A clear and concise description of what you expected to happen, compared to what actually happened.
 
 **Environment:**
  - NSubstitute version: [e.g. 3.1.0]
+ - NSubstitute.Analyzers version: [e.g. CSharp 1.0.9]
  - Platform: [e.g. dotnetcore2.0 project on Mac]
 
 **Additional context**


### PR DESCRIPTION
Encouraging people to run NSubstitute.Analyzers over their reproduction code before submitting a bug report. If people do this it could reduce bug reports due to common root causes like subbing non-virtuals, but even if they don't it should help to raise awareness about the excellent Analyzers tool. :)