### PR TITLE
Minor tweaking of build script

### DIFF
--- a/build/build.cmd
+++ b/build/build.cmd
@@ -9,4 +9,4 @@ IF NOT EXIST "%TOOL_PATH%\fake.exe" (
   dotnet tool install fake-cli --tool-path %TOOL_PATH%
 )
 
-"%TOOL_PATH%\fake.exe" run %SCRIPT_DIR%\build.fsx %*
+"%TOOL_PATH%\fake.exe" --silent run %SCRIPT_DIR%\build.fsx %*

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -166,7 +166,8 @@ target "TestCodeFromDocs" <| fun _ ->
     let csproj = """
         <Project Sdk="Microsoft.NET.Sdk">
           <PropertyGroup>
-            <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+            <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+            <LangVersion>latest</LangVersion>
           </PropertyGroup>
           <ItemGroup>
             <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,4 +20,4 @@ if ! [ -e "$FAKE" ]
 then
   dotnet tool install fake-cli --tool-path "$TOOL_PATH"
 fi
-"$FAKE" run "$SCRIPT_PATH/build.fsx" "$@"
+"$FAKE" --silent run "$SCRIPT_PATH/build.fsx" "$@"


### PR DESCRIPTION
Added a few small changes, you could review PR commit by commit:
- Don't print verbose Paket log at the beginning
- Remove `NuGet.exe` binary as we don't need it anymore
- Use .NET Core 2.1 to run doc tests, as 1.1 is veeery old.

Closes #562 

