### PR TITLE
Do not invoke configured result in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### unreleased
 * [FIX] It might be impossible to assign `ref` and `out` arguments using type-compatible value. (#577, @zvirja)
+* [FIX] Configured result is returned in the `Received.InOrder` check causing tests to fail sometimes. (#569, @zvirja)
 
 ### 4.2.0 (May 2019)
 

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -34,7 +34,6 @@ namespace NSubstitute.Routing
             return new Route(new ICallHandler[] {
                 new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
                 , new AddCallToQueryResultHandler(_threadLocalContext)
-                , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, _callSpecificationFactory)
                 , ReturnDefaultForReturnTypeHandler()
             });

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue569_QueryShouldNotInvokeConfiguredResult.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue569_QueryShouldNotInvokeConfiguredResult.cs
@@ -1,0 +1,83 @@
+using System;
+using NSubstitute.Acceptance.Specs.Infrastructure;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue569_QueryShouldNotInvokeConfiguredResult
+    {
+        [Test]
+        public void Should_not_invoke_configured_handler_in_query_original()
+        {
+            // Arrange
+            var substitute = Substitute.For<Func<int>>();
+            substitute.Invoke().Returns(x => throw new Exception("SOME EXCEPTION"));
+
+            // Act
+            try
+            {
+                substitute.Invoke();
+                Assert.Fail();
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            // Assert
+            Assert.DoesNotThrow(() =>
+            {
+                Received.InOrder(() =>
+                {
+                    substitute.Invoke();
+                });
+            });
+        }
+
+        [Test]
+        public void Should_not_throw_configured_exception_in_query()
+        {
+            // Arrange
+            var substitute = Substitute.For<ISomething>();
+            substitute.Echo(Arg.Any<int>()).Throws<InvalidOperationException>();
+            try
+            {
+                substitute.Echo(42);
+            }
+            catch (InvalidOperationException)
+            {
+                // Ignore
+            }
+
+            // Act & Assert
+            Assert.DoesNotThrow(() =>
+            {
+                Received.InOrder(() =>
+                {
+                    substitute.Echo(Arg.Any<int>());
+                });
+            });
+        }
+
+        [Test]
+        public void Should_not_invoke_configured_argument_actions_in_query()
+        {
+            // Arrange
+            var substitute = Substitute.For<ISomething>();
+            bool wasCalled = false;
+            substitute.Echo(Arg.Do<int>(_ => wasCalled = true));
+            substitute.Echo(42);
+
+            // Act
+            wasCalled = false;
+            Received.InOrder(() =>
+            {
+                substitute.Echo(42);
+            });
+
+            // Assert
+            Assert.That(wasCalled, Is.False);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #569.

As agreed, do not invoke configured result handler in call query.