### PR TITLE
Add RecievedWithin Extension method

### DIFF
--- a/src/NSubstitute/Core/RouteFactoryCacheWrapper.cs
+++ b/src/NSubstitute/Core/RouteFactoryCacheWrapper.cs
@@ -41,8 +41,8 @@ namespace NSubstitute.Core
         public IRoute CallQuery(ISubstituteState state) =>
             _factory.CallQuery(state);
 
-        public IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity) =>
-            _factory.CheckReceivedCalls(state, matchArgs, requiredQuantity);
+        public IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity, TimeSpan timeSpan) =>
+            _factory.CheckReceivedCalls(state, matchArgs, requiredQuantity, timeSpan);
 
         public IRoute DoWhenCalled(ISubstituteState state, Action<CallInfo> doAction, MatchArgs matchArgs) =>
             _factory.DoWhenCalled(state, doAction, matchArgs);

--- a/src/NSubstitute/Extensions/ReceivedExtensions.cs
+++ b/src/NSubstitute/Extensions/ReceivedExtensions.cs
@@ -19,7 +19,24 @@ namespace NSubstitute.ReceivedExtensions
             var context = SubstitutionContext.Current;
             var callRouter = context.GetCallRouterFor(substitute);
 
-            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity));
+            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity, TimeSpan.Zero));
+            return substitute;
+        }
+
+        /// <summary>
+        /// Checks this substitute has received the following call the required number of times.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="substitute"></param>
+        /// <param name="requiredQuantity"></param>
+        /// <param name="timeSpan"></param>
+        /// <returns></returns>
+        public static T ReceivedWithin<T>(this T substitute, Quantity requiredQuantity, TimeSpan timeSpan)
+        {
+            var context = SubstitutionContext.Current;
+            var callRouter = context.GetCallRouterFor(substitute);
+
+            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.AsSpecifiedInCall, requiredQuantity, timeSpan));
             return substitute;
         }
 
@@ -35,7 +52,7 @@ namespace NSubstitute.ReceivedExtensions
             var context = SubstitutionContext.Current;
             var callRouter = context.GetCallRouterFor(substitute);
 
-            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.Any, requiredQuantity));
+            context.ThreadContext.SetNextRoute(callRouter, x => context.RouteFactory.CheckReceivedCalls(x, MatchArgs.Any, requiredQuantity, TimeSpan.Zero));
             return substitute;
         }
     }

--- a/src/NSubstitute/Routing/IRouteFactory.cs
+++ b/src/NSubstitute/Routing/IRouteFactory.cs
@@ -7,7 +7,7 @@ namespace NSubstitute.Routing
     public interface IRouteFactory
     {
         IRoute CallQuery(ISubstituteState state);
-        IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity);
+        IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity, TimeSpan timeSpan);
         IRoute DoWhenCalled(ISubstituteState state, Action<CallInfo> doAction, MatchArgs matchArgs);
         IRoute DoNotCallBase(ISubstituteState state, MatchArgs matchArgs);
         IRoute CallBase(ISubstituteState state, MatchArgs matchArgs);

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -38,12 +38,12 @@ namespace NSubstitute.Routing
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
-        public IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity)
+        public IRoute CheckReceivedCalls(ISubstituteState state, MatchArgs matchArgs, Quantity requiredQuantity, TimeSpan timeSpan)
         {
             return new Route(new ICallHandler[] {
                 new ClearLastCallRouterHandler(_threadLocalContext)
                 , new ClearUnusedCallSpecHandler(_threadLocalContext.PendingSpecification)
-                , new CheckReceivedCallsHandler(state.ReceivedCalls, _callSpecificationFactory, _receivedCallsExceptionThrower, matchArgs, requiredQuantity)
+                , new CheckReceivedCallsHandler(state.ReceivedCalls, _callSpecificationFactory, _receivedCallsExceptionThrower, matchArgs, requiredQuantity, timeSpan)
                 , new ReturnAutoValue(AutoValueBehaviour.ReturnAndForgetValue, state.AutoValueProviders, state.AutoValuesCallResults, _callSpecificationFactory)
                 , ReturnDefaultForReturnTypeHandler()
             });

--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -229,11 +229,27 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Checks this substitute has recieved the following call within the required time period.
+        /// </summary>
+        public static T ReceivedWithin<T>(this T substitute, TimeSpan timeperiod) where T : class
+        {
+            return substitute.ReceivedWithin(Quantity.AtLeastOne(), timeperiod);
+        }
+
+        /// <summary>
         /// Checks this substitute has received the following call the required number of times.
         /// </summary>
         public static T Received<T>(this T substitute, int requiredNumberOfCalls) where T : class
         {
             return substitute.Received(Quantity.Exactly(requiredNumberOfCalls));
+        }
+
+        /// <summary>
+        /// Checks this substitute has received the following call the required number of times within the required time period.
+        /// </summary>
+        public static T ReceivedWithin<T>(this T substitute, int requiredNumberOfCalls, TimeSpan timeperiod) where T : class
+        {
+            return substitute.ReceivedWithin(Quantity.Exactly(requiredNumberOfCalls), timeperiod);
         }
 
         /// <summary>

--- a/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
@@ -331,56 +332,58 @@ namespace NSubstitute.Acceptance.Specs
         [Test]
         public void Throw_when_call_was_not_recieved_within_time_period()
         {
-            var thread = new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
+            var expectedRevCount = 1234;
 
-                Thread.Sleep(TimeSpan.FromMilliseconds(750));
-                _car.Rev();
+            var thread = new Thread(x =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(10));
+                _car.RevAt(expectedRevCount);
             });
 
             thread.Start();
 
             Assert.Throws<ReceivedCallsException>(() =>
-                _car.ReceivedWithin(TimeSpan.FromMilliseconds(50)).Rev()
+                _car.ReceivedWithin(TimeSpan.FromMilliseconds(250)).RevAt(expectedRevCount)
             );
         }
 
         [Test]
         public void Check_when_call_was_recieved_within_time_period()
         {
+            var expectedRevCount = 2345;
+
             var thread = new Thread(() =>
             {
-                Thread.CurrentThread.IsBackground = true;
-
-                Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                _car.Rev();
+                Thread.Sleep(TimeSpan.FromMilliseconds(100));
+                _car.RevAt(expectedRevCount);
             });
 
             thread.Start();
 
-            _car.ReceivedWithin(TimeSpan.FromMilliseconds(500)).Rev();
+            _car.ReceivedWithin(TimeSpan.FromMilliseconds(500)).RevAt(expectedRevCount);
         }
 
         [Test]
         public void Throw_when_all_calls_are_not_recieved_within_time_period()
         {
+            var expectedRevCount = 3456;
+
             var thread = new Thread(() =>
             {
-                Thread.CurrentThread.IsBackground = true;
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                _car.RevAt(expectedRevCount);
 
-                _car.Rev();
-                _car.Rev();
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                _car.RevAt(expectedRevCount);
 
-                Thread.Sleep(TimeSpan.FromMilliseconds(250));
-
-                _car.Rev();
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                _car.RevAt(expectedRevCount);
             });
 
             thread.Start();
 
             Assert.Throws<ReceivedCallsException>(() =>
-                _car.ReceivedWithin(3, TimeSpan.FromMilliseconds(250)).Rev()
+                _car.ReceivedWithin(3, TimeSpan.FromMilliseconds(100)).RevAt(expectedRevCount)
             );
         }
 

--- a/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
@@ -335,14 +335,14 @@ namespace NSubstitute.Acceptance.Specs
             {
                 Thread.CurrentThread.IsBackground = true;
 
-                Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                Thread.Sleep(TimeSpan.FromMilliseconds(750));
                 _car.Rev();
             });
 
             thread.Start();
 
             Assert.Throws<ReceivedCallsException>(() =>
-                _car.ReceivedWithin(TimeSpan.FromMilliseconds(100)).Rev()
+                _car.ReceivedWithin(TimeSpan.FromMilliseconds(50)).Rev()
             );
         }
 


### PR DESCRIPTION
While trying to use NSubstitute along side some higher level automation/integration level tests I came across a situation where I wanted to assert that a mocked dependency had received a call, but I had no guarantee _when_ that call would have been made.

So I thought it would be good if NSubstitute had something akin to Selenium's WaitFind and thought I would throw together a quick Pull Request to see what you thought of a feature like this. I appreciate that you may have deliberately not implemented something like this and so totally understand if it is something you wouldn't even consider merging, I just thought it better to have a go at showing you what it would look like rather than just ask for it in the Issues!

This is my first ever PR into a public repository, and I'm sure that it will need some more tidying up especially since this was just a simple showcase / example, so let me know if you would do it differently or if there is anything that you would want tidying up :)
