### PR TITLE
Make dotnet build work without having NetFX installed

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -4,13 +4,20 @@
     <Description>NSubstitute is a friendly substitute for .NET mocking libraries. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
     <Version>3.0.0</Version>
     <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin;Alex Povar</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>
     <PackageIconUrl>https://nsubstitute.github.io/images/nsubstitute-100x100.png</PackageIconUrl>
     <PackageProjectUrl>https://nsubstitute.github.io/</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -38,6 +45,11 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
+  <!-- ReferenceAssemblies so we can build netfx targets on non-windows enviroments -->
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0-*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
@@ -48,7 +60,7 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)'=='net46'">
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45</TargetFrameworks>
-
+    <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>    
     <!-- Enable the latest C# features -->
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -15,13 +15,18 @@
     <OutputPath>..\..\bin\Release\NSubstitute.Acceptance.Specs\</OutputPath>
   </PropertyGroup>
 
+  <!-- ReferenceAssemblies so we can build netfx targets on non-windows enviroments -->
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
+++ b/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
+    <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -17,6 +18,12 @@
     <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
     <None Remove="BenchmarkDotNet.Artifacts\**" />
   </ItemGroup>
+
+  <!-- ReferenceAssemblies so we can build netfx targets on non-windows enviroments -->
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />


### PR DESCRIPTION
- Added a reference to [Microsoft.NETFramework.ReferenceAssemblies](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies/)
- Small re-organization on `.csproj` file to easily identify the supported target frameworks
- Add a custom property `TargetIsNetFx` to easily identify when `netfx` is being used.

Tested on WSL (Ubuntu 18.04):

`dotnet build`
```
 Restore completed in 16.67 ms for /mnt/d/github/NSubstitute/src/NSubstitute/NSubstitute.csproj.
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/net45/NSubstitute.dll
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/net46/NSubstitute.dll
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/netstandard2.0/NSubstitute.dll
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/netstandard1.3/NSubstitute.dll

Build succeeded.
    0 Warning(s)                                                                                                                                                                                                     0 Error(s)
```

`dotnet build -f net45`
```
 Restore completed in 16.82 ms for /mnt/d/github/NSubstitute/src/NSubstitute/NSubstitute.csproj.
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/net45/NSubstitute.dll

Build succeeded.
    0 Warning(s)                                                                                                                                                                                                     0 Error(s)
```

`dotnet build -f net46`
```
 Restore completed in 16.84 ms for /mnt/d/github/NSubstitute/src/NSubstitute/NSubstitute.csproj.
  NSubstitute -> /mnt/d/github/NSubstitute/bin/Debug/NSubstitute/net46/NSubstitute.dll

Build succeeded.
    0 Warning(s)                                                                                                                                                                                                     0 Error(s)
```

As a side note: I think it would be valuable to introuce a [Directory.Build.props](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets) file in order to improve the overall organization of the `csproj`s files. I took a quick look and I saw there's some repetition in a few things, like: 

`'$(TargetFramework)' == 'net45' OR '$(TargetFramework)'=='net46'"` or ` <LangVersion>latest</LangVersion>`. These properties can all be defined once in the top-level `.props` file and all projects would get these values. This way, the individual `csproj` is even smaller and focused on what they should be focused on. I would be glad to work on it, in case you think it's relevant 😊

Closes #335