### PR TITLE
Fix thread-safety issue in AutoValueProvidersFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### unreleased
 
 * [UPDATE] Build update to run on non-Windows platforms. Thanks @joaopgrassi! (#592, #335)
+* [FIX] Fix NSubstitute could fail in concurrent environment due to auto-value providers initialization. (#600, @zvirja)
 
 ### 4.2.1 (July 2019)
 

--- a/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
@@ -12,7 +12,7 @@ namespace NSubstitute.Routing.AutoValues
             IAutoValueProvider[] result = null;
             var lazyResult = new Lazy<IReadOnlyCollection<IAutoValueProvider>>(
                 () => result ?? throw new InvalidOperationException("Value was not constructed yet."),
-                LazyThreadSafetyMode.None);
+                LazyThreadSafetyMode.PublicationOnly);
 
             result = new IAutoValueProvider[]
             {


### PR DESCRIPTION
Fixes #600

Use thread-safe option of Lazy.

Also registered a tech dept in #551 to improve this place in future major update. We cannot, unfortunately, do it now, as that requires breaking changes.