### PR TITLE
Update rake to 13.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem "rake"
+gem "rake", ">= 12.3.3"
 gem "liquid", "4.0"
 gem "jekyll", "3.6.3"
 gem "ruby_dep", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
-    rake (12.3.1)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -52,8 +52,8 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.6.3)
   liquid (= 4.0)
-  rake
+  rake (>= 12.3.3)
   ruby_dep (~> 1.3)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
Contains fix for CVE-2020-8130 affecting rake 12.3.1.
See https://github.com/advisories/GHSA-jppv-gw3r-w3q8