### PR TITLE
Handle protected and internal property setters

### DIFF
--- a/src/NSubstitute/Core/PropertyHelper.cs
+++ b/src/NSubstitute/Core/PropertyHelper.cs
@@ -25,7 +25,7 @@ namespace NSubstitute.Core
 
         private bool PropertySetterExistsAndHasAGetMethod(PropertyInfo propertySetter)
         {
-            return propertySetter != null && propertySetter.GetGetMethod() != null;
+            return propertySetter != null && propertySetter.GetGetMethod(nonPublic: true) != null;
         }
 
         private PropertyInfo GetPropertyFromSetterCallOrNull(ICall call)
@@ -41,7 +41,7 @@ namespace NSubstitute.Core
                 throw new InvalidOperationException("Could not find a GetMethod for \"" + callToSetter.GetMethodInfo() + "\"");
             }
 
-            var getter = propertyInfo.GetGetMethod();
+            var getter = propertyInfo.GetGetMethod(nonPublic: true);
             var getterArgs = SkipLast(callToSetter.GetOriginalArguments());
             var getterArgumentSpecifications = GetGetterCallSpecificationsFromSetterCall(callToSetter);
 

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue262_NonPublicSetterCall.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue262_NonPublicSetterCall.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    /// <summary>
+    /// Scenarios for the issue: https://github.com/nsubstitute/NSubstitute/issues/626
+    ///
+    /// Do not test internal members, as we don't want to set InternalsVisibleTo attribute.
+    /// </summary>
+    public class Issue262_NonPublicSetterCall
+    {
+        [Test]
+        public void ShouldHandleProtectedProperties()
+        {
+            var subs = Substitute.For<TestClass>();
+
+            subs.SetProtectedProp(42);
+
+            var result = subs.GetProtectedProp();
+            Assert.That(result, Is.EqualTo(expected: 42));
+        }
+
+        [Test]
+        public void ShouldHandlePropertyWithProtectedSetter()
+        {
+            var subs = Substitute.For<TestClass>();
+
+            subs.SetProtectedSetterProp(42);
+
+            var result = subs.ProtectedSetterProp;
+            Assert.That(result, Is.EqualTo(expected: 42));
+        }
+        [Test]
+        public void ShouldHandlePropertyWithProtectedGetter()
+        {
+            var subs = Substitute.For<TestClass>();
+
+            subs.ProtectedGetterProp = 42;
+
+            var result = subs.GetProtectedGetterProp();
+            Assert.That(result, Is.EqualTo(expected: 42));
+        }
+
+        public abstract class TestClass
+        {
+            protected abstract int ProtectedProp { get; set; }
+            public void SetProtectedProp(int value) => ProtectedProp = value;
+            public int GetProtectedProp() => ProtectedProp;
+
+            public abstract int ProtectedSetterProp { get; protected set; }
+            public void SetProtectedSetterProp(int value) => ProtectedSetterProp = value;
+            
+            public abstract int ProtectedGetterProp { protected get; set; }
+            public int GetProtectedGetterProp() => ProtectedGetterProp;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #626

This change adds support for the non-public property setters. The original issue was about internal properties and this change handles them as well.

I didn't add unit test for internal properties as I didn't want to set `assembly: InternalsVisibleTo()` attribute for the test assembly to not affect the existing tests.

Please kindly take a look and give your feedback! Thanks!