### PR TITLE
Add .NET 5 target and arrange nullability attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,8 @@
 root = true
 
+[*]
+trim_trailing_whitespace = true
+
 [*.{cs,fs,fsx}]
 indent_size = 4
 indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
 dist: xenial
-dotnet: 2.1.502
+dotnet: 5.0.100
 mono: none
-env: CONFIGURATION=Release FRAMEWORK=netcoreapp2.1
+env: CONFIGURATION=Release FRAMEWORK=net5.0
 
 before_script:
   - dotnet --info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### unreleased
+* [NEW] Add .NET 5 support
 
 ### 4.2.2 (Jun 2020)
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,12 @@
 <Project>
 
   <!-- Contains global properties for all projects in the solution.
-  These can be overridden in inner folders, if necessary. 
+  These can be overridden in inner folders, if necessary.
   See more here https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019 -->
-  
+
   <PropertyGroup>
     <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
+    <TargetIsNet5 Condition="'$(TargetFramework)' == 'net5.0'">true</TargetIsNet5>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
-os: Visual Studio 2017
+os: Visual Studio 2019
 build: off
 
 environment:
   CONFIGURATION: Release
 
 install:
-  - set PATH=C:\Ruby22\bin;%PATH%
+  - set PATH=C:\Ruby25\bin;%PATH%
   - bundle install      
 
 before_test:

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -2,6 +2,9 @@ using System;
 using System.Linq.Expressions;
 using NSubstitute.Core.Arguments;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     /// <summary>
@@ -89,7 +92,7 @@ namespace NSubstitute
         /// </summary>
         public static ref T Do<T>(Action<T> useArgument)
         {
-            return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(T)), x => useArgument((T) x));
+            return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(T)), x => useArgument((T) x!));
         }
 
         /// <summary>

--- a/src/NSubstitute/Callback.cs
+++ b/src/NSubstitute/Callback.cs
@@ -3,6 +3,9 @@ using System.Collections.Concurrent;
 using NSubstitute.Callbacks;
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     /// <summary>
@@ -72,7 +75,8 @@ namespace NSubstitute
             return AlwaysThrow(info => exception);
         }
 
-        protected static Action<CallInfo> ToCallback<TException>(Func<CallInfo, TException> throwThis) where TException : Exception
+        protected static Action<CallInfo> ToCallback<TException>(Func<CallInfo, TException> throwThis)
+            where TException : notnull, Exception
         {
             return ci => { if (throwThis != null) throw throwThis(ci); };
         }
@@ -111,8 +115,7 @@ namespace NSubstitute
 
         private void CallFromStack(CallInfo callInfo)
         {
-            Action<CallInfo> callback;
-            if (callbackQueue.TryDequeue(out callback))
+            if (callbackQueue.TryDequeue(out var callback))
             {
                 callback(callInfo);
             }

--- a/src/NSubstitute/Callbacks/ConfiguredCallback.cs
+++ b/src/NSubstitute/Callbacks/ConfiguredCallback.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.Callbacks
 {
     public class ConfiguredCallback : EndCallbackChain

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Linq.Expressions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.Compatibility
 {
     /// <summary>

--- a/src/NSubstitute/Compatibility/DiagnosticsNullabilityAttributes.cs
+++ b/src/NSubstitute/Compatibility/DiagnosticsNullabilityAttributes.cs
@@ -1,0 +1,142 @@
+#if !SYSTEM_DIAGNOSTICS_CODEANALYSIS_NULLABILITY
+
+// This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// and updated to have the scope of the attributes be internal.
+namespace System.Diagnostics.CodeAnalysis
+{
+
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+}
+#endif

--- a/src/NSubstitute/Core/Argument.cs
+++ b/src/NSubstitute/Core/Argument.cs
@@ -5,15 +5,15 @@ namespace NSubstitute.Core
 {
     public class Argument
     {
-        private readonly ICall _call;
+        private readonly ICall? _call;
         private readonly int _argIndex;
 
-        private readonly Type _declaredType;
-        private readonly Func<object> _getValue;
-        private readonly Action<object> _setValue;
+        private readonly Type? _declaredType;
+        private readonly Func<object?>? _getValue;
+        private readonly Action<object?>? _setValue;
 
         [Obsolete("This constructor overload is deprecated and will be removed in the next version.")]
-        public Argument(Type declaredType, Func<object> getValue, Action<object> setValue)
+        public Argument(Type declaredType, Func<object?> getValue, Action<object?> setValue)
         {
             _declaredType = declaredType;
             _getValue = getValue;
@@ -26,9 +26,9 @@ namespace NSubstitute.Core
             _argIndex = argIndex;
         }
 
-        public object Value
+        public object? Value
         {
-            get => _getValue != null ? _getValue() : _call.GetArguments()[_argIndex];
+            get => _getValue != null ? _getValue() : _call!.GetArguments()[_argIndex];
             set
             {
                 if (_setValue != null)
@@ -37,14 +37,14 @@ namespace NSubstitute.Core
                 }
                 else
                 {
-                    _call.GetArguments()[_argIndex] = value;
+                    _call!.GetArguments()[_argIndex] = value;
                 }
             }
         }
 
         public bool IsByRef => DeclaredType.IsByRef;
 
-        public Type DeclaredType => _declaredType ?? _call.GetParameterInfos()[_argIndex].ParameterType;
+        public Type DeclaredType => _declaredType ?? _call!.GetParameterInfos()[_argIndex].ParameterType;
 
         public Type ActualType => Value == null ? DeclaredType : Value.GetType();
 
@@ -65,7 +65,7 @@ namespace NSubstitute.Core
 
         private static Type AsNonByRefType(Type type)
         {
-            return type.IsByRef ? type.GetElementType() : type;
+            return type.IsByRef ? type.GetElementType()! : type;
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/AnyArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/AnyArgumentMatcher.cs
@@ -13,6 +13,6 @@ namespace NSubstitute.Core.Arguments
 
         public override string ToString() => "any " + _typeArgMustBeCompatibleWith.GetNonMangledTypeName();
 
-        public bool IsSatisfiedBy(object argument) => argument.IsCompatibleWith(_typeArgMustBeCompatibleWith);
+        public bool IsSatisfiedBy(object? argument) => argument.IsCompatibleWith(_typeArgMustBeCompatibleWith);
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentFormatter.cs
@@ -8,13 +8,13 @@ namespace NSubstitute.Core.Arguments
     {
         internal static IArgumentFormatter Default { get; } = new ArgumentFormatter();
 
-        public string Format(object argument, bool highlight)
+        public string Format(object? argument, bool highlight)
         {
             var formatted = Format(argument);
             return highlight ? "*" + formatted + "*" : formatted;
         }
 
-        private string Format(object arg)
+        private string Format(object? arg)
         {
             switch (arg)
             {
@@ -24,11 +24,11 @@ namespace NSubstitute.Core.Arguments
                 case string str:
                     return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", str);
 
-                case object obj when obj.GetType().GetMethod(nameof(ToString), Type.EmptyTypes).DeclaringType == typeof(object):
+                case object obj when obj.GetType().GetMethod(nameof(ToString), Type.EmptyTypes)!.DeclaringType == typeof(object):
                     return arg.GetType().GetNonMangledTypeName();
 
                 default:
-                    return arg.ToString();
+                    return arg.ToString() ?? string.Empty;
             }
        }
     }

--- a/src/NSubstitute/Core/Arguments/ArgumentMatchInfo.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatchInfo.cs
@@ -2,14 +2,14 @@
 {
     public class ArgumentMatchInfo
     {
-        public ArgumentMatchInfo(int index, object argument, IArgumentSpecification specification)
+        public ArgumentMatchInfo(int index, object? argument, IArgumentSpecification specification)
         {
             Index = index;
             _argument = argument;
             _specification = specification;
         }
 
-        private readonly object _argument;
+        private readonly object? _argument;
         private readonly IArgumentSpecification _specification;
         public int Index { get; private set; }
 
@@ -23,14 +23,14 @@
             return string.Format("{0}{1}", argIndexPrefix, describeNonMatch.Replace("\n", "\n".PadRight(argIndexPrefix.Length + 1)));
         }
 
-        public bool Equals(ArgumentMatchInfo other)
+        public bool Equals(ArgumentMatchInfo? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return other.Index == Index && Equals(other._argument, _argument) && Equals(other._specification, _specification);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -44,7 +44,7 @@
             {
                 int result = Index;
                 result = (result*397) ^ (_argument != null ? _argument.GetHashCode() : 0);
-                result = (result*397) ^ (_specification != null ? _specification.GetHashCode() : 0);
+                result = (result*397) ^ _specification.GetHashCode();
                 return result;
             }
         }

--- a/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NSubstitute.Core.Arguments
 {
@@ -8,7 +9,7 @@ namespace NSubstitute.Core.Arguments
         /// Enqueues a matcher for the method argument in current position and returns the value which should be
         /// passed back to the method you invoke.
         /// </summary>
-        public static ref T Enqueue<T>(IArgumentMatcher<T> argumentMatcher)
+        public static ref T? Enqueue<T>(IArgumentMatcher<T> argumentMatcher)
         {
             if (argumentMatcher == null) throw new ArgumentNullException(nameof(argumentMatcher));
 
@@ -25,17 +26,17 @@ namespace NSubstitute.Core.Arguments
             return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), nonGenericMatcher));
         }
 
-        internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher)
+        internal static ref T? Enqueue<T>(IArgumentMatcher argumentMatcher)
         {
             return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher));
         }
 
-        internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher, Action<object> action)
+        internal static ref T? Enqueue<T>(IArgumentMatcher argumentMatcher, Action<object?> action)
         {
             return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher, action));
         }
 
-        private static ref T EnqueueArgSpecification<T>(IArgumentSpecification specification)
+        private static ref T? EnqueueArgSpecification<T>(IArgumentSpecification specification)
         {
             SubstitutionContext.Current.ThreadContext.EnqueueArgumentSpecification(specification);
             return ref new DefaultValueContainer<T>().Value;
@@ -50,7 +51,7 @@ namespace NSubstitute.Core.Arguments
                 _matcher = matcher;
             }
 
-            public bool IsSatisfiedBy(object argument) => _matcher.IsSatisfiedBy((T) argument);
+            public bool IsSatisfiedBy(object? argument) => _matcher.IsSatisfiedBy((T) argument!);
         }
 
         private class GenericToNonGenericMatcherProxyWithDescribe<T> : GenericToNonGenericMatcherProxy<T>, IDescribeNonMatches
@@ -60,12 +61,12 @@ namespace NSubstitute.Core.Arguments
                 if (matcher as IDescribeNonMatches == null) throw new ArgumentException("Should implement IDescribeNonMatches type.");
             }
 
-            public string DescribeFor(object argument) => ((IDescribeNonMatches) _matcher).DescribeFor(argument);
+            public string DescribeFor(object? argument) => ((IDescribeNonMatches) _matcher).DescribeFor(argument);
         }
 
         private class DefaultValueContainer<T>
         {
-            public T Value;
+            public T? Value;
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
@@ -4,30 +4,30 @@ namespace NSubstitute.Core.Arguments
 {
     public class ArgumentSpecification : IArgumentSpecification
     {
-        private static readonly Action<object> NoOpAction = x => { };
+        private static readonly Action<object?> NoOpAction = x => { };
  
         private readonly IArgumentMatcher _matcher;
-        private readonly Action<object> _action;
+        private readonly Action<object?> _action;
         public Type ForType { get; }
         public bool HasAction => _action != NoOpAction;
 
         public ArgumentSpecification(Type forType, IArgumentMatcher matcher) : this(forType, matcher, NoOpAction) { }
 
-        public ArgumentSpecification(Type forType, IArgumentMatcher matcher, Action<object> action)
+        public ArgumentSpecification(Type forType, IArgumentMatcher matcher, Action<object?> action)
         {
             ForType = forType;
             _matcher = matcher;
             _action = action;
         }
 
-        public bool IsSatisfiedBy(object argument)
+        public bool IsSatisfiedBy(object? argument)
         {
             if (!IsCompatibleWith(argument)) return false;
             try { return _matcher.IsSatisfiedBy(argument); }
             catch { return false; }
         }
 
-        public string DescribeNonMatch(object argument)
+        public string DescribeNonMatch(object? argument)
         {
             var describable = _matcher as IDescribeNonMatches;
             if (describable == null) return string.Empty;
@@ -35,7 +35,7 @@ namespace NSubstitute.Core.Arguments
             return IsCompatibleWith(argument) ? describable.DescribeFor(argument) : GetIncompatibleTypeMessage(argument);
         }
 
-        public string FormatArgument(object argument)
+        public string FormatArgument(object? argument)
         {
             var isSatisfiedByArg = IsSatisfiedBy(argument);
             var matcherFormatter = _matcher as IArgumentFormatter;
@@ -44,7 +44,7 @@ namespace NSubstitute.Core.Arguments
                 : matcherFormatter.Format(argument, isSatisfiedByArg);
         }
 
-        public override string ToString() => _matcher.ToString();
+        public override string ToString() => _matcher.ToString() ?? string.Empty;
 
         public IArgumentSpecification CreateCopyMatchingAnyArgOfType(Type requiredType)
         {
@@ -56,23 +56,23 @@ namespace NSubstitute.Core.Arguments
                 _action == NoOpAction ? NoOpAction : RunActionIfTypeIsCompatible);
         }
 
-        public void RunAction(object argument)
+        public void RunAction(object? argument)
         {
             _action(argument);
         }
 
-        private void RunActionIfTypeIsCompatible(object argument)
+        private void RunActionIfTypeIsCompatible(object? argument)
         {
             if (!argument.IsCompatibleWith(ForType)) return;
             _action(argument);
         }
 
-        private bool IsCompatibleWith(object argument)
+        private bool IsCompatibleWith(object? argument)
         {
             return argument.IsCompatibleWith(ForType);
         }
 
-        private string GetIncompatibleTypeMessage(object argument)
+        private string GetIncompatibleTypeMessage(object? argument)
         {
             var argumentType = argument == null ? typeof(object) : argument.GetType();
             return string.Format("Expected an argument compatible with type {0}. Actual type was {1}.", ForType, argumentType);

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationCompatibilityTester.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationCompatibilityTester.cs
@@ -12,14 +12,14 @@ namespace NSubstitute.Core.Arguments
             _defaultChecker = defaultChecker ?? throw new ArgumentNullException(nameof(defaultChecker));
         }
 
-        public bool IsSpecificationCompatible(IArgumentSpecification specification, object argumentValue, Type argumentType)
+        public bool IsSpecificationCompatible(IArgumentSpecification specification, object? argumentValue, Type argumentType)
         {
             var typeArgSpecIsFor = specification.ForType;
             return AreTypesCompatible(argumentType, typeArgSpecIsFor)
                    && IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(argumentValue, typeArgSpecIsFor);
         }
 
-        private bool IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(object argument, Type typeArgSpecIsFor)
+        private bool IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(object? argument, Type typeArgSpecIsFor)
         {
             return _defaultChecker.IsDefault(argument, typeArgSpecIsFor);
         }

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationFactory.cs
@@ -8,7 +8,7 @@ namespace NSubstitute.Core.Arguments
 {
     public class ArgumentSpecificationFactory : IArgumentSpecificationFactory
     {
-        public IArgumentSpecification Create(object argument, IParameterInfo parameterInfo,
+        public IArgumentSpecification Create(object? argument, IParameterInfo parameterInfo,
             ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
         {
             return parameterInfo.IsParams
@@ -16,7 +16,7 @@ namespace NSubstitute.Core.Arguments
                 : CreateSpecFromNonParamsArg(argument, parameterInfo, suppliedArgumentSpecifications);
         }
 
-        private IArgumentSpecification CreateSpecFromNonParamsArg(object argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
+        private IArgumentSpecification CreateSpecFromNonParamsArg(object? argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
         {
             if (suppliedArgumentSpecifications.IsNextFor(argument, parameterInfo.ParameterType))
             {
@@ -32,7 +32,7 @@ namespace NSubstitute.Core.Arguments
             throw new AmbiguousArgumentsException();
         }
 
-        private IArgumentSpecification CreateSpecFromParamsArg(object argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
+        private IArgumentSpecification CreateSpecFromParamsArg(object? argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
         {
             // Next specification is for the whole params array.
             if (suppliedArgumentSpecifications.IsNextFor(argument, parameterInfo.ParameterType))
@@ -60,11 +60,11 @@ namespace NSubstitute.Core.Arguments
                 throw new SubstituteInternalException($"Expected to get array argument, but got argument of '{argument.GetType().FullName}' type.");
             }
 
-            var arrayArgumentSpecifications = UnwrapParamsArguments(arrayArg.Cast<object>(), parameterInfo.ParameterType.GetElementType(), suppliedArgumentSpecifications);
+            var arrayArgumentSpecifications = UnwrapParamsArguments(arrayArg.Cast<object?>(), parameterInfo.ParameterType.GetElementType()!, suppliedArgumentSpecifications);
             return new ArgumentSpecification(parameterInfo.ParameterType, new ArrayContentsArgumentMatcher(arrayArgumentSpecifications));
         }
 
-        private IEnumerable<IArgumentSpecification> UnwrapParamsArguments(IEnumerable<object> args, Type paramsElementType, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
+        private IEnumerable<IArgumentSpecification> UnwrapParamsArguments(IEnumerable<object?> args, Type paramsElementType, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
         {
             var fakeParameterInfo = new ParameterInfoFromType(paramsElementType);
             var result = new List<IArgumentSpecification>();

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationsFactory.cs
@@ -16,7 +16,7 @@ namespace NSubstitute.Core.Arguments
             _suppliedArgumentSpecificationsFactory = suppliedArgumentSpecificationsFactory;
         }
 
-        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs)
+        public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object?[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs)
         {
             var suppliedArgumentSpecifications = _suppliedArgumentSpecificationsFactory.Create(argumentSpecs);
 

--- a/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
@@ -13,7 +13,7 @@ namespace NSubstitute.Core.Arguments
             _argumentSpecifications = argumentSpecifications.ToArray();
         }
 
-        public bool IsSatisfiedBy(object argument)
+        public bool IsSatisfiedBy(object? argument)
         {
             if (argument != null)
             {
@@ -33,10 +33,9 @@ namespace NSubstitute.Core.Arguments
             return string.Join(", ", _argumentSpecifications.Select(x => x.ToString()));
         }
 
-        public string Format(object argument, bool highlight)
+        public string Format(object? argument, bool highlight)
         {
-            var enumerableArgs = argument as IEnumerable;
-            var argArray = enumerableArgs != null ? enumerableArgs.Cast<object>().ToArray() : new object[0];
+            var argArray = argument is IEnumerable enumerableArgs ? enumerableArgs.Cast<object>().ToArray() : new object[0];
             return Format(argArray, _argumentSpecifications).Join(", ");
         }
 

--- a/src/NSubstitute/Core/Arguments/DefaultChecker.cs
+++ b/src/NSubstitute/Core/Arguments/DefaultChecker.cs
@@ -12,7 +12,7 @@ namespace NSubstitute.Core.Arguments
             _defaultForType = defaultForType;
         }
 
-        public bool IsDefault(object value, Type forType)
+        public bool IsDefault(object? value, Type forType)
         {
             return EqualityComparer<object>.Default.Equals(value, _defaultForType.GetDefaultFor(forType));
         }

--- a/src/NSubstitute/Core/Arguments/EqualsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/EqualsArgumentMatcher.cs
@@ -4,15 +4,15 @@ namespace NSubstitute.Core.Arguments
 {
     public class EqualsArgumentMatcher : IArgumentMatcher
     {
-        private readonly object _value;
+        private readonly object? _value;
 
-        public EqualsArgumentMatcher(object value)
+        public EqualsArgumentMatcher(object? value)
         {
             _value = value;
         }
 
         public override string ToString() => ArgumentFormatter.Default.Format(_value, false);
 
-        public bool IsSatisfiedBy(object argument) => EqualityComparer<object>.Default.Equals(_value, argument);
+        public bool IsSatisfiedBy(object? argument) => EqualityComparer<object>.Default.Equals(_value, argument);
     }
 }

--- a/src/NSubstitute/Core/Arguments/ExpressionArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ExpressionArgumentMatcher.cs
@@ -14,9 +14,9 @@ namespace NSubstitute.Core.Arguments
             _predicateDescription = predicate.ToString();
         }
 
-        public bool IsSatisfiedBy(object argument)
+        public bool IsSatisfiedBy(object? argument)
         {
-            return _predicate((T)argument);
+            return _predicate((T)argument!);
         }
 
         public override string ToString() { return _predicateDescription; }

--- a/src/NSubstitute/Core/Arguments/IArgumentFormatter.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentFormatter.cs
@@ -2,6 +2,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentFormatter
     {
-        string Format(object arg, bool highlight);
+        string Format(object? arg, bool highlight);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
@@ -10,7 +10,7 @@ namespace NSubstitute.Core.Arguments
         /// Checks whether the <paramref name="argument"/> satisfies the condition of the matcher.
         /// If this throws an exception the argument will be treated as non-matching.
         /// </summary>
-        bool IsSatisfiedBy(object argument);
+        bool IsSatisfiedBy(object? argument);
     }
 
     /// <summary>
@@ -24,6 +24,6 @@ namespace NSubstitute.Core.Arguments
         /// Checks whether the <paramref name="argument"/> satisfies the condition of the matcher.
         /// If this throws an exception the argument will be treated as non-matching.
         /// </summary>
-        bool IsSatisfiedBy(T argument);
+        bool IsSatisfiedBy(T? argument);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecification.cs
@@ -4,12 +4,12 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentSpecification
     {
-        bool IsSatisfiedBy(object argument);
+        bool IsSatisfiedBy(object? argument);
         Type ForType { get; }
         IArgumentSpecification CreateCopyMatchingAnyArgOfType(Type requiredType);
         bool HasAction { get; }
-        void RunAction(object argument);
-        string DescribeNonMatch(object argument);
-        string FormatArgument(object argument);
+        void RunAction(object? argument);
+        string DescribeNonMatch(object? argument);
+        string FormatArgument(object? argument);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecificationCompatibilityTester.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecificationCompatibilityTester.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentSpecificationCompatibilityTester
     {
-        bool IsSpecificationCompatible(IArgumentSpecification specification, object argumentValue, Type argumentType);
+        bool IsSpecificationCompatible(IArgumentSpecification specification, object? argumentValue, Type argumentType);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecificationFactory.cs
@@ -2,6 +2,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentSpecificationFactory
     {
-        IArgumentSpecification Create(object argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications);
+        IArgumentSpecification Create(object? argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecificationsFactory.cs
@@ -5,6 +5,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IArgumentSpecificationsFactory
     {
-        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs);
+        IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object?[] arguments, IParameterInfo[] parameterInfos, MethodInfo methodInfo, MatchArgs matchArgs);
     }
 }

--- a/src/NSubstitute/Core/Arguments/IDefaultChecker.cs
+++ b/src/NSubstitute/Core/Arguments/IDefaultChecker.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Core.Arguments
 {
     public interface IDefaultChecker
     {
-        bool IsDefault(object value, Type forType);
+        bool IsDefault(object? value, Type forType);
     }
 }

--- a/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
@@ -5,8 +5,8 @@ namespace NSubstitute.Core.Arguments
 {
     public interface ISuppliedArgumentSpecifications
     {
-        bool AnyFor(object argument, Type argumentType);
-        bool IsNextFor(object argument, Type argumentType);
+        bool AnyFor(object? argument, Type argumentType);
+        bool IsNextFor(object? argument, Type argumentType);
         IArgumentSpecification Dequeue();
         IEnumerable<IArgumentSpecification> DequeueRemaining();
     }

--- a/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
@@ -18,12 +18,12 @@ namespace NSubstitute.Core.Arguments
         }
 
 
-        public bool AnyFor(object argument, Type argumentType)
+        public bool AnyFor(object? argument, Type argumentType)
         {
             return AllSpecifications.Any(x => _argSpecCompatibilityTester.IsSpecificationCompatible(x, argument, argumentType));
         }
 
-        public bool IsNextFor(object argument, Type argumentType)
+        public bool IsNextFor(object? argument, Type argumentType)
         {
             if (_queue.Count <= 0) { return false; }
             var nextArgSpec = _queue.Peek();

--- a/src/NSubstitute/Core/Call.cs
+++ b/src/NSubstitute/Core/Call.cs
@@ -11,17 +11,17 @@ namespace NSubstitute.Core
     public class Call : ICall, /* Performance optimization */ CallCollection.IReceivedCallEntry
     {
         private readonly MethodInfo _methodInfo;
-        private readonly object[] _arguments;
-        private object[] _originalArguments;
+        private readonly object?[] _arguments;
+        private object?[] _originalArguments;
         private readonly object _target;
         private readonly IList<IArgumentSpecification> _argumentSpecifications;
-        private IParameterInfo[] _parameterInfosCached;
+        private IParameterInfo[]? _parameterInfosCached;
         private long? _sequenceNumber;
-        private readonly Func<object> _baseMethod;
+        private readonly Func<object>? _baseMethod;
 
         [Obsolete("This constructor is deprecated and will be removed in future version of product.")]
         public Call(MethodInfo methodInfo,
-            object[] arguments,
+            object?[] arguments,
             object target,
             IList<IArgumentSpecification> argumentSpecifications,
             IParameterInfo[] parameterInfos,
@@ -32,10 +32,10 @@ namespace NSubstitute.Core
         }
 
         public Call(MethodInfo methodInfo,
-            object[] arguments,
+            object?[] arguments,
             object target,
             IList<IArgumentSpecification> argumentSpecifications,
-            Func<object> baseMethod)
+            Func<object>? baseMethod)
         {
             _methodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
             _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
@@ -83,24 +83,24 @@ namespace NSubstitute.Core
 
         public bool CanCallBase => _baseMethod != null;
 
-        public Maybe<object> TryCallBase()
+        public Maybe<object?> TryCallBase()
         {
-            return _baseMethod == null ? Maybe.Nothing<object>() : Maybe.Just(_baseMethod());
+            return _baseMethod == null ? Maybe.Nothing<object?>() : Maybe.Just<object?>(_baseMethod());
         }
 
         public Type GetReturnType() => _methodInfo.ReturnType;
 
         public MethodInfo GetMethodInfo() => _methodInfo;
 
-        public object[] GetArguments()
+        public object?[] GetArguments()
         {
             // This method assumes that result might be mutated.
             // Therefore, we should guard our array with original values to ensure it's unmodified.
             // Also if array is empty - no sense to make a copy.
-            object[] originalArray = _originalArguments;
+            object?[] originalArray = _originalArguments;
             if (originalArray == _arguments && originalArray.Length > 0)
             {
-                object[] copy = originalArray.ToArray();
+                object?[] copy = originalArray.ToArray();
                 // If it happens that _originalArguments doesn't point to the `_arguments` anymore -
                 // it might happen that other thread already created a copy and mutated the original `_arguments` array.
                 // In this case it's unsafe to replace it with a copy.
@@ -110,7 +110,7 @@ namespace NSubstitute.Core
             return _arguments;
         }
 
-        public object[] GetOriginalArguments()
+        public object?[] GetOriginalArguments()
         {
             return _originalArguments;
         }

--- a/src/NSubstitute/Core/CallActions.cs
+++ b/src/NSubstitute/Core/CallActions.cs
@@ -55,7 +55,7 @@ namespace NSubstitute.Core
                 return;
             }
  
-            CallInfo callInfo = null;
+            CallInfo? callInfo = null;
             foreach (var action in _actions)
             {
                 if (!action.IsSatisfiedBy(call))

--- a/src/NSubstitute/Core/CallCollection.cs
+++ b/src/NSubstitute/Core/CallCollection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NSubstitute.Exceptions;
 
@@ -44,7 +45,7 @@ namespace NSubstitute.Core
         {
             return _callEntries
                 .Where(e => !e.IsSkipped)
-                .Select(e => e.Call)
+                .Select(e => e.Call!)
                 .ToArray();
         }
 
@@ -60,7 +61,8 @@ namespace NSubstitute.Core
         /// </summary>
         internal interface IReceivedCallEntry
         {
-            ICall Call { get; }
+            ICall? Call { get; }
+            [MemberNotNullWhen(false, nameof(Call))]
             bool IsSkipped { get; }
             void Skip();
             bool TryTakeEntryOwnership();
@@ -73,8 +75,9 @@ namespace NSubstitute.Core
         /// </summary>
         private class ReceivedCallEntry : IReceivedCallEntry
         {
-            public ICall Call { get; private set; }
+            public ICall? Call { get; private set; }
 
+            [MemberNotNullWhen(false, nameof(Call))]
             public bool IsSkipped => Call == null;
 
             public void Skip() => Call = null; // Null the hold value to reclaim a bit of memory.

--- a/src/NSubstitute/Core/CallFactory.cs
+++ b/src/NSubstitute/Core/CallFactory.cs
@@ -8,12 +8,12 @@ namespace NSubstitute.Core
 {
     public class CallFactory : ICallFactory
     {
-        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object> baseMethod)
+        public ICall Create(MethodInfo methodInfo, object?[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object>? baseMethod)
         {
             return new Call(methodInfo, arguments, target, argumentSpecifications , baseMethod);
         }
 
-        public ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications)
+        public ICall Create(MethodInfo methodInfo, object?[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications)
         {
             return new Call(methodInfo, arguments, target, argumentSpecifications, baseMethod: null);
         }

--- a/src/NSubstitute/Core/CallInfo.cs
+++ b/src/NSubstitute/Core/CallInfo.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NSubstitute.Exceptions;
+
+// Disable nullability for entry-point API
+#nullable disable annotations
 
 namespace NSubstitute.Core
 {
@@ -75,15 +79,15 @@ namespace NSubstitute.Core
             throw new ArgumentNotFoundException("Can not find an argument of type " + typeof(T).FullName + " to this call.");
         }
 
-        private bool TryGetArg<T>(Func<Argument, bool> condition, out T value)
+        private bool TryGetArg<T>(Func<Argument, bool> condition, [MaybeNull] out T value)
         {
-            value = default(T);
+            value = default;
 
             var matchingArgs = _callArguments.Where(condition);
             if (!matchingArgs.Any()) return false;
             ThrowIfMoreThanOne<T>(matchingArgs);
 
-            value = (T)matchingArgs.First().Value;
+            value = (T)matchingArgs.First().Value!;
             return true;
         }
 
@@ -107,24 +111,22 @@ namespace NSubstitute.Core
         /// <typeparam name="T">The type of the argument to retrieve</typeparam>
         /// <param name="position">The zero-based position of the argument to retrieve</param>
         /// <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
+        [return: MaybeNull]
         public T ArgAt<T>(int position)
         {
-            T arg;
             if (position >= _callArguments.Length)
             {
                 throw new ArgumentOutOfRangeException("position", "There is no argument at position " + position);
             }
             try
             {
-                arg = (T) (_callArguments[position].Value);
+                return (T) _callArguments[position].Value!;
             }
             catch (InvalidCastException)
             {
                 throw new InvalidCastException("Couldn't convert parameter at position"
                     + position + " to type " + typeof(T).FullName);
             }
-            
-            return arg;
         }
         
         private static string DisplayTypes(IEnumerable<Type> types)

--- a/src/NSubstitute/Core/CallResults.cs
+++ b/src/NSubstitute/Core/CallResults.cs
@@ -21,7 +21,7 @@ namespace NSubstitute.Core
             _results.Push(new ResultForCallSpec(callSpecification, result));
         }
 
-        public bool TryGetResult(ICall call, out object result)
+        public bool TryGetResult(ICall call, out object? result)
         {
             result = default;
             if (ReturnsVoidFrom(call))
@@ -82,7 +82,7 @@ namespace NSubstitute.Core
             }
 
             public bool IsResultFor(ICall call) => _callSpecification.IsSatisfiedBy(call);
-            public object GetResult(ICall call, ICallInfoFactory callInfoFactory)
+            public object? GetResult(ICall call, ICallInfoFactory callInfoFactory)
             {
                 if (_resultToReturn is ICallIndependentReturn callIndependentReturn)
                 {

--- a/src/NSubstitute/Core/CallRouter.cs
+++ b/src/NSubstitute/Core/CallRouter.cs
@@ -58,7 +58,7 @@ namespace NSubstitute.Core
         public void SetRoute(Func<ISubstituteState, IRoute> getRoute) => 
             _threadContext.SetNextRoute(this, getRoute);
 
-        public object Route(ICall call)
+        public object? Route(ICall call)
         {
             _threadContext.SetLastCallRouter(this);
 
@@ -71,7 +71,7 @@ namespace NSubstitute.Core
             return routeToUse.Handle(call);
         }
 
-        private IRoute ResolveCurrentRoute(ICall call, bool isQuerying, Func<ICall, object[]> pendingRaisingEventArgs, Func<ISubstituteState, IRoute> queuedNextRouteFactory)
+        private IRoute ResolveCurrentRoute(ICall call, bool isQuerying, Func<ICall, object?[]>? pendingRaisingEventArgs, Func<ISubstituteState, IRoute>? queuedNextRouteFactory)
         {
             if (isQuerying)
             {

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -92,7 +92,7 @@ namespace NSubstitute.Core
 
         private bool IsMatchingArgumentSpecifications(ICall call)
         {
-            object[] arguments = call.GetOriginalArguments();
+            object?[] arguments = call.GetOriginalArguments();
             for (int i = 0; i < arguments.Length; i++)
             {
                 if (!_argumentSpecifications[i].IsSatisfiedBy(arguments[i]))
@@ -114,7 +114,7 @@ namespace NSubstitute.Core
 
         public override string ToString()
         {
-            var argSpecsAsStrings = _argumentSpecifications.Select(x => x.ToString()).ToArray();
+            var argSpecsAsStrings = _argumentSpecifications.Select(x => x.ToString() ?? string.Empty).ToArray();
             return CallFormatter.Default.Format(GetMethodInfo(), argSpecsAsStrings);
         }
 
@@ -123,7 +123,7 @@ namespace NSubstitute.Core
             return CallFormatter.Default.Format(call.GetMethodInfo(), FormatArguments(call.GetOriginalArguments()));
         }
 
-        private IEnumerable<string> FormatArguments(IEnumerable<object> arguments)
+        private IEnumerable<string> FormatArguments(IEnumerable<object?> arguments)
         {
             return arguments.Zip(_argumentSpecifications, (arg, spec) => spec.FormatArgument(arg)).ToArray();
         }

--- a/src/NSubstitute/Core/DefaultForType.cs
+++ b/src/NSubstitute/Core/DefaultForType.cs
@@ -10,7 +10,7 @@ namespace NSubstitute.Core
         private static readonly object BoxedLong = default(long);
         private static readonly object BoxedDouble = default(double);
 
-        public object GetDefaultFor(Type type)
+        public object? GetDefaultFor(Type type)
         {
             if (IsVoid(type)) return null;
             if (type.GetTypeInfo().IsValueType) return DefaultInstanceOfValueType(type);
@@ -42,7 +42,7 @@ namespace NSubstitute.Core
                 return BoxedDouble;
             }
 
-            return Activator.CreateInstance(returnType);
+            return Activator.CreateInstance(returnType)!;
         }
     }
 }

--- a/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
+++ b/src/NSubstitute/Core/DependencyInjection/INSubContainer.cs
@@ -4,7 +4,7 @@ namespace NSubstitute.Core.DependencyInjection
 {
     public interface INSubResolver
     {
-        T Resolve<T>();
+        T Resolve<T>() where T : notnull;
     }
 
     public interface INSubContainer : INSubResolver
@@ -24,32 +24,39 @@ namespace NSubstitute.Core.DependencyInjection
 
     public interface IConfigurableNSubContainer : INSubContainer
     {
-        IConfigurableNSubContainer Register<TKey, TImpl>(NSubLifetime lifetime) where TImpl : TKey;
+        IConfigurableNSubContainer Register<TKey, TImpl>(NSubLifetime lifetime)
+            where TKey : notnull
+            where TImpl : TKey;
 
-        IConfigurableNSubContainer Register<TKey>(Func<INSubResolver, TKey> factory, NSubLifetime lifetime);
+        IConfigurableNSubContainer Register<TKey>(Func<INSubResolver, TKey> factory, NSubLifetime lifetime)
+            where TKey : notnull;
 
         /// <summary>
         /// Decorates the original implementation with a custom decorator.
         /// The factory method is provided with an original implementation instance.
         /// The lifetime of decorated implementation is used.
         /// </summary>
-        IConfigurableNSubContainer Decorate<TKey>(Func<TKey, INSubResolver, TKey> factory);
+        IConfigurableNSubContainer Decorate<TKey>(Func<TKey, INSubResolver, TKey> factory)
+            where TKey : notnull;
     }
 
     public static class ConfigurableNSubContainerExtensions
     {
         public static IConfigurableNSubContainer RegisterPerScope<TKey, TImpl>(this IConfigurableNSubContainer container)
+            where TKey : notnull
             where TImpl : TKey
         {
             return container.Register<TKey, TImpl>(NSubLifetime.PerScope);
         }
 
         public static IConfigurableNSubContainer RegisterPerScope<TKey>(this IConfigurableNSubContainer container, Func<INSubResolver, TKey> factory)
+            where TKey : notnull
         {
             return container.Register(factory, NSubLifetime.PerScope);
         }
 
         public static IConfigurableNSubContainer RegisterSingleton<TKey, TImpl>(this IConfigurableNSubContainer container)
+            where TKey : notnull
             where TImpl : TKey
         {
             return container.Register<TKey, TImpl>(NSubLifetime.Singleton);

--- a/src/NSubstitute/Core/EventCallFormatter.cs
+++ b/src/NSubstitute/Core/EventCallFormatter.cs
@@ -21,12 +21,12 @@ namespace NSubstitute.Core
 
         public bool CanFormat(MethodInfo methodInfo)
         {
-            return methodInfo.DeclaringType.GetEvents().Any(x => _eventsToFormat(methodInfo)(x));
+            return methodInfo.DeclaringType!.GetEvents().Any(x => _eventsToFormat(methodInfo)(x));
         }
 
         public string Format(MethodInfo methodInfo, IEnumerable<string> arguments)
         {
-            var eventInfo = methodInfo.DeclaringType.GetEvents().First(x => _eventsToFormat(methodInfo)(x));
+            var eventInfo = methodInfo.DeclaringType!.GetEvents().First(x => _eventsToFormat(methodInfo)(x));
             return Format(eventInfo, _eventOperator, arguments);
         }
 

--- a/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
+++ b/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
@@ -6,21 +6,24 @@ namespace NSubstitute.Core.Events
 {
     public class DelegateEventWrapper<T> : RaiseEventWrapper
     {
-        readonly object[] _providedArguments;
+        readonly object?[] _providedArguments;
         protected override string RaiseMethodName { get { return "Raise.Event"; } }
 
-        public DelegateEventWrapper(params object[] arguments)
+        public DelegateEventWrapper(params object?[] arguments)
         {
             _providedArguments = arguments ?? new object[0];
         }
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
         public static implicit operator T(DelegateEventWrapper<T> wrapper)
         {
             RaiseEvent(wrapper);
             return default(T);
         }
+#nullable restore annotations
 
-        protected override object[] WorkOutRequiredArguments(ICall call)
+        protected override object?[] WorkOutRequiredArguments(ICall call)
         {
             var requiredArgs = typeof(T).GetInvokeMethod().GetParameters();
 
@@ -44,10 +47,10 @@ namespace NSubstitute.Core.Events
                    typeof(EventArgs).IsAssignableFrom(parameters[1].ParameterType);
         }
 
-        object[] WorkOutSenderAndEventArgs(Type eventArgsType, ICall call)
+        object?[] WorkOutSenderAndEventArgs(Type eventArgsType, ICall call)
         {
-            object sender;
-            object eventArgs;
+            object? sender;
+            object? eventArgs;
             if (_providedArguments.Length == 0)
             {
                 sender = call.Target();
@@ -66,7 +69,7 @@ namespace NSubstitute.Core.Events
             return new[] { sender, eventArgs };
         }
 
-        bool RequiredArgsHaveBeenProvided(object[] providedArgs, ParameterInfo[] requiredArgs)
+        bool RequiredArgsHaveBeenProvided(object?[] providedArgs, ParameterInfo[] requiredArgs)
         {
             if (providedArgs.Length != requiredArgs.Length) return false;
             for (var i = 0; i < providedArgs.Length; i++)

--- a/src/NSubstitute/Core/Events/EventHandlerWrapper.cs
+++ b/src/NSubstitute/Core/Events/EventHandlerWrapper.cs
@@ -4,20 +4,22 @@ namespace NSubstitute.Core.Events
 {
     public class EventHandlerWrapper<TEventArgs> : RaiseEventWrapper where TEventArgs : EventArgs
     {
-        readonly object _sender;
-        readonly EventArgs _eventArgs;
+        readonly object? _sender;
+        readonly EventArgs? _eventArgs;
         protected override string RaiseMethodName { get { return "Raise.EventWith"; } }
 
         public EventHandlerWrapper() : this(null, null) { }
 
-        public EventHandlerWrapper(EventArgs eventArgs) : this(null, eventArgs) { }
+        public EventHandlerWrapper(EventArgs? eventArgs) : this(null, eventArgs) { }
 
-        public EventHandlerWrapper(object sender, EventArgs eventArgs)
+        public EventHandlerWrapper(object? sender, EventArgs? eventArgs)
         {
             _sender = sender;
             _eventArgs = eventArgs;
         }
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
         public static implicit operator EventHandler(EventHandlerWrapper<TEventArgs> wrapper)
         {
             RaiseEvent(wrapper);
@@ -29,6 +31,7 @@ namespace NSubstitute.Core.Events
             RaiseEvent(wrapper);
             return null;
         }
+#nullable restore annotations
 
         protected override object[] WorkOutRequiredArguments(ICall call)
         {

--- a/src/NSubstitute/Core/Events/RaiseEventWrapper.cs
+++ b/src/NSubstitute/Core/Events/RaiseEventWrapper.cs
@@ -6,7 +6,7 @@ namespace NSubstitute.Core.Events
 {
     public abstract class RaiseEventWrapper
     {
-        protected abstract object[] WorkOutRequiredArguments(ICall call);
+        protected abstract object?[] WorkOutRequiredArguments(ICall call);
         protected abstract string RaiseMethodName { get; }
 
         protected EventArgs GetDefaultForEventArgType(Type type)
@@ -24,7 +24,7 @@ namespace NSubstitute.Core.Events
             return (EventArgs)defaultConstructor.Invoke(new object[0]);
         }
 
-        static ConstructorInfo GetDefaultConstructor(Type type)
+        static ConstructorInfo? GetDefaultConstructor(Type type)
         {
             return type.GetConstructor(Type.EmptyTypes);
         }

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core
 {
@@ -11,9 +12,9 @@ namespace NSubstitute.Core
         /// <summary>
         /// Checks if the instance can be used when a <paramref name="type"/> is expected.
         /// </summary>
-        public static bool IsCompatibleWith(this object instance, Type type)
+        public static bool IsCompatibleWith(this object? instance, Type type)
         {
-            var requiredType = type.IsByRef ? type.GetElementType() : type;
+            var requiredType = type.IsByRef ? type.GetElementType()! : type;
             return instance == null ? TypeCanBeNull(requiredType) : requiredType.IsInstanceOfType(instance);
         }
 
@@ -44,7 +45,7 @@ namespace NSubstitute.Core
 
         public static MethodInfo GetInvokeMethod(this Type type)
         {
-            return type.GetMethod("Invoke");
+            return type.GetMethod("Invoke") ?? throw new SubstituteInternalException("Expected delegate type");
         }
 
         private static bool TypeCanBeNull(Type type)
@@ -66,7 +67,7 @@ namespace NSubstitute.Core
 
             void AppendTypeNameRecursively(Type currentType)
             {
-                Type declaringType = currentType.DeclaringType;
+                Type? declaringType = currentType.DeclaringType;
                 if (declaringType != null)
                 {
                     AppendTypeNameRecursively(declaringType);
@@ -102,7 +103,7 @@ namespace NSubstitute.Core
 
             string GetTypeNameWithoutGenericArity(Type t)
             {
-                var tn = t.Name;
+                var tn = t.Name!;
                 var indexOfBacktick = tn.IndexOf('`');
                 // For nested generic types the back stick symbol might be missing.
                 return indexOfBacktick > -1 ? tn.Substring(0, indexOfBacktick) : tn;

--- a/src/NSubstitute/Core/ICall.cs
+++ b/src/NSubstitute/Core/ICall.cs
@@ -9,14 +9,14 @@ namespace NSubstitute.Core
     {
         Type GetReturnType();
         MethodInfo GetMethodInfo();
-        object[] GetArguments();
-        object[] GetOriginalArguments();
+        object?[] GetArguments();
+        object?[] GetOriginalArguments();
         object Target();
         IParameterInfo[] GetParameterInfos();
         IList<IArgumentSpecification> GetArgumentSpecifications();
         void AssignSequenceNumber(long number);
         long GetSequenceNumber();
         bool CanCallBase { get; }
-        Maybe<object> TryCallBase();
+        Maybe<object?> TryCallBase();
     }
 }

--- a/src/NSubstitute/Core/ICallFactory.cs
+++ b/src/NSubstitute/Core/ICallFactory.cs
@@ -7,7 +7,7 @@ namespace NSubstitute.Core
 {
     public interface ICallFactory
     {
-        ICall Create(MethodInfo methodInfo, object[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object> baseMethod);
-        ICall Create(MethodInfo methodInfo, object[] getterArgs, object target, IList<IArgumentSpecification> getArgumentSpecifications);
+        ICall Create(MethodInfo methodInfo, object?[] arguments, object target, IList<IArgumentSpecification> argumentSpecifications, Func<object>? baseMethod);
+        ICall Create(MethodInfo methodInfo, object?[] getterArgs, object target, IList<IArgumentSpecification> getArgumentSpecifications);
     }
 }

--- a/src/NSubstitute/Core/ICallResults.cs
+++ b/src/NSubstitute/Core/ICallResults.cs
@@ -3,7 +3,7 @@ namespace NSubstitute.Core
     public interface ICallResults
     {
         void SetResult(ICallSpecification callSpecification, IReturn result);
-        bool TryGetResult(ICall call, out object result);
+        bool TryGetResult(ICall call, out object? result);
 	    void Clear();
     }
 }

--- a/src/NSubstitute/Core/ICallRouter.cs
+++ b/src/NSubstitute/Core/ICallRouter.cs
@@ -15,7 +15,7 @@ namespace NSubstitute.Core
         /// </remarks>
         bool CallBaseByDefault { get; set; }
         ConfiguredCall LastCallShouldReturn(IReturn returnValue, MatchArgs matchArgs, PendingSpecificationInfo pendingSpecInfo);
-        object Route(ICall call);
+        object? Route(ICall call);
         IEnumerable<ICall> ReceivedCalls();
         [Obsolete("This method is deprecated and will be removed in future versions of the product. " +
                   "Please use " + nameof(IThreadLocalContext) + "." + nameof(IThreadLocalContext.SetNextRoute) + " method instead.")]

--- a/src/NSubstitute/Core/IDefaultForType.cs
+++ b/src/NSubstitute/Core/IDefaultForType.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Core
 {
     public interface IDefaultForType
     {
-        object GetDefaultFor(Type type);
+        object? GetDefaultFor(Type type);
     }
 }

--- a/src/NSubstitute/Core/IDescribeNonMatches.cs
+++ b/src/NSubstitute/Core/IDescribeNonMatches.cs
@@ -8,6 +8,6 @@ namespace NSubstitute.Core
         /// </summary>
         /// <param name="argument"></param>
         /// <returns>Description of the non-match, or <see cref="string.Empty" /> if no description can be provided.</returns>
-        string DescribeFor(object argument);
+        string DescribeFor(object? argument);
     }
 }

--- a/src/NSubstitute/Core/IPendingSpecification.cs
+++ b/src/NSubstitute/Core/IPendingSpecification.cs
@@ -3,7 +3,7 @@
     public interface IPendingSpecification
     {
         bool HasPendingCallSpecInfo();
-        PendingSpecificationInfo UseCallSpecInfo();
+        PendingSpecificationInfo? UseCallSpecInfo();
         void SetCallSpecification(ICallSpecification callSpecification);
         void SetLastCall(ICall lastCall);
         void Clear();

--- a/src/NSubstitute/Core/IProxyFactory.cs
+++ b/src/NSubstitute/Core/IProxyFactory.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Core
 {
     public interface IProxyFactory
     {
-        object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments);
+        object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments);
     }
 }

--- a/src/NSubstitute/Core/IResultsForType.cs
+++ b/src/NSubstitute/Core/IResultsForType.cs
@@ -4,7 +4,7 @@ namespace NSubstitute.Core
 {
     public interface IResultsForType {
         void SetResult(Type type, IReturn resultToReturn);
-        bool TryGetResult(ICall call, out object result);
+        bool TryGetResult(ICall call, out object? result);
         void Clear();
     }
 }

--- a/src/NSubstitute/Core/IReturn.cs
+++ b/src/NSubstitute/Core/IReturn.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using NSubstitute.Exceptions;
@@ -8,8 +9,8 @@ namespace NSubstitute.Core
 {
     public interface IReturn
     {
-        object ReturnFor(CallInfo info);
-        Type TypeOrNull();
+        object? ReturnFor(CallInfo info);
+        Type? TypeOrNull();
         bool CanBeAssignedTo(Type t);
     }
 
@@ -18,38 +19,38 @@ namespace NSubstitute.Core
     /// </summary>
     internal interface ICallIndependentReturn
     {
-        object GetReturnValue();
+        object? GetReturnValue();
     }
 
     public class ReturnValue : IReturn, ICallIndependentReturn
-    {        
-        private readonly object _value;
+    {
+        private readonly object? _value;
 
-        public ReturnValue(object value)
+        public ReturnValue(object? value)
         {
             _value = value;
         }
- 
-        public object GetReturnValue() => _value;
-        public object ReturnFor(CallInfo info) => GetReturnValue();
-        public Type TypeOrNull() => _value?.GetType();
+
+        public object? GetReturnValue() => _value;
+        public object? ReturnFor(CallInfo info) => GetReturnValue();
+        public Type? TypeOrNull() => _value?.GetType();
         public bool CanBeAssignedTo(Type t) => _value.IsCompatibleWith(t);
     }
 
     public class ReturnValueFromFunc<T> : IReturn
     {
-        private readonly Func<CallInfo, T> _funcToReturnValue;
+        private readonly Func<CallInfo, T?> _funcToReturnValue;
 
-        public ReturnValueFromFunc(Func<CallInfo, T> funcToReturnValue)
+        public ReturnValueFromFunc(Func<CallInfo, T?>? funcToReturnValue)
         {
             _funcToReturnValue = funcToReturnValue ?? ReturnNull();
         }
 
-        public object ReturnFor(CallInfo info) => _funcToReturnValue(info);
+        public object? ReturnFor(CallInfo info) => _funcToReturnValue(info);
         public Type TypeOrNull() => typeof (T);
         public bool CanBeAssignedTo(Type t) => typeof (T).IsAssignableFrom(t);
 
-        private static Func<CallInfo, T> ReturnNull()
+        private static Func<CallInfo, T?> ReturnNull()
         {
             if (typeof(T).GetTypeInfo().IsValueType) throw new CannotReturnNullForValueType(typeof(T));
             return x => default(T);
@@ -58,38 +59,38 @@ namespace NSubstitute.Core
 
     public class ReturnMultipleValues<T> : IReturn, ICallIndependentReturn
     {
-        private readonly ConcurrentQueue<T> _valuesToReturn;
-        private readonly T _lastValue;
+        private readonly ConcurrentQueue<T?> _valuesToReturn;
+        private readonly T? _lastValue;
 
-        public ReturnMultipleValues(T[] values)
+        public ReturnMultipleValues(T?[] values)
         {
-            _valuesToReturn = new ConcurrentQueue<T>(values);
-            _lastValue = values.LastOrDefault();
+            _valuesToReturn = new ConcurrentQueue<T?>(values);
+            _lastValue = values.Last();
         }
 
-        public object GetReturnValue() => GetNext();
-        public object ReturnFor(CallInfo info) => GetReturnValue();
+        public object? GetReturnValue() => GetNext();
+        public object? ReturnFor(CallInfo info) => GetReturnValue();
         public Type TypeOrNull() => typeof (T);
         public bool CanBeAssignedTo(Type t) => typeof (T).IsAssignableFrom(t);
 
-        private T GetNext() => _valuesToReturn.TryDequeue(out var nextResult) ? nextResult : _lastValue;
+        private T? GetNext() => _valuesToReturn.TryDequeue(out var nextResult) ? nextResult : _lastValue;
     }
 
     public class ReturnMultipleFuncsValues<T> : IReturn
     {
-        private readonly ConcurrentQueue<Func<CallInfo, T>> _funcsToReturn;
-        private readonly Func<CallInfo, T> _lastFunc;
+        private readonly ConcurrentQueue<Func<CallInfo, T?>> _funcsToReturn;
+        private readonly Func<CallInfo, T?> _lastFunc;
 
-        public ReturnMultipleFuncsValues(Func<CallInfo, T>[] funcs)
+        public ReturnMultipleFuncsValues(Func<CallInfo, T?>[] funcs)
         {
-            _funcsToReturn = new ConcurrentQueue<Func<CallInfo, T>>(funcs);
-            _lastFunc = funcs.LastOrDefault();
+            _funcsToReturn = new ConcurrentQueue<Func<CallInfo, T?>>(funcs);
+            _lastFunc = funcs.Last();
         }
- 
-        public object ReturnFor(CallInfo info) => GetNext(info);
+
+        public object? ReturnFor(CallInfo info) => GetNext(info);
         public Type TypeOrNull() => typeof (T);
         public bool CanBeAssignedTo(Type t) => typeof (T).IsAssignableFrom(t);
 
-        private T GetNext(CallInfo info) => _funcsToReturn.TryDequeue(out var nextFunc) ? nextFunc(info) : _lastFunc(info);
+        private T? GetNext(CallInfo info) => _funcsToReturn.TryDequeue(out var nextFunc) ? nextFunc(info) : _lastFunc(info);
     }
 }

--- a/src/NSubstitute/Core/ISubstitutionContext.cs
+++ b/src/NSubstitute/Core/ISubstitutionContext.cs
@@ -25,7 +25,7 @@ namespace NSubstitute.Core
         [Obsolete("This property is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.PendingSpecification) + " property instead. " +
                   "For example: SubstitutionContext.Current.ThreadContext." + nameof(IThreadLocalContext.PendingSpecification) + ".")]
-        PendingSpecificationInfo PendingSpecificationInfo { get; set; }
+        PendingSpecificationInfo? PendingSpecificationInfo { get; set; }
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.LastCallShouldReturn) + "() method instead. " +
@@ -55,7 +55,7 @@ namespace NSubstitute.Core
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.UsePendingRaisingEventArgumentsFactory) + "() method instead. " +
                   "For example: SubstitutionContext.Current.ThreadContext." + nameof(IThreadLocalContext.UsePendingRaisingEventArgumentsFactory) + "().")]
-        Func<ICall, object[]> DequeuePendingRaisingEventArguments();
+        Func<ICall, object?[]>? DequeuePendingRaisingEventArguments();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.RunInQueryContext) + "() method instead. " +

--- a/src/NSubstitute/Core/IThreadLocalContext.cs
+++ b/src/NSubstitute/Core/IThreadLocalContext.cs
@@ -21,16 +21,16 @@ namespace NSubstitute.Core
         /// Returns the previously configured next route and resets the stored value.
         /// If route was configured for the different router, returns <see langword="null"/> and persist the route info.
         /// </summary>
-        Func<ISubstituteState, IRoute> UseNextRoute(ICallRouter callRouter);
+        Func<ISubstituteState, IRoute>? UseNextRoute(ICallRouter callRouter);
 
         void EnqueueArgumentSpecification(IArgumentSpecification spec);
         IList<IArgumentSpecification> DequeueAllArgumentSpecifications();
 
-        void SetPendingRaisingEventArgumentsFactory(Func<ICall, object[]> getArguments);
+        void SetPendingRaisingEventArgumentsFactory(Func<ICall, object?[]> getArguments);
         /// <summary>
         /// Returns the previously set arguments factory and resets the stored value.
         /// </summary>
-        Func<ICall, object[]> UsePendingRaisingEventArgumentsFactory();
+        Func<ICall, object?[]>? UsePendingRaisingEventArgumentsFactory();
 
         bool IsQuerying { get; }
         /// <summary>

--- a/src/NSubstitute/Core/Maybe.cs
+++ b/src/NSubstitute/Core/Maybe.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NSubstitute.Core
 {
     /// <summary>
     /// Particularly poor implementation of Maybe/Option type.
-    /// This is just filling an immediate need; use FSharpOption or XSharpx or similar for a 
+    /// This is just filling an immediate need; use FSharpOption or XSharpx or similar for a
     /// real implementation.
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -27,7 +28,7 @@ namespace NSubstitute.Core
         public Maybe<T> OrElse(Maybe<T> other) { return OrElse(() => other); }
         public T ValueOr(Func<T> other) { return Fold(other, x => x); }
         public T ValueOr(T other) { return ValueOr(() => other); }
-        public T ValueOrDefault() { return ValueOr(default(T)); }
+        public T? ValueOrDefault() { return ValueOr(default(T)!); }
 
         public TResult Fold<TResult>(Func<TResult> handleNoValue, Func<T, TResult> handleValue)
         {

--- a/src/NSubstitute/Core/PendingSpecificationInfo.cs
+++ b/src/NSubstitute/Core/PendingSpecificationInfo.cs
@@ -4,30 +4,28 @@ namespace NSubstitute.Core
 {
     public class PendingSpecificationInfo
     {
-        private readonly bool _hasCallSpec;
-        private readonly ICallSpecification _callSpecification;
-        private readonly ICall _lastCall;
+        private readonly ICallSpecification? _callSpecification;
+        private readonly ICall? _lastCall;
 
-        private PendingSpecificationInfo(bool hasCallSpec, ICallSpecification callSpecification, ICall lastCall)
+        private PendingSpecificationInfo(ICallSpecification? callSpecification, ICall? lastCall)
         {
-            _hasCallSpec = hasCallSpec;
             _callSpecification = callSpecification;
             _lastCall = lastCall;
         }
 
         public T Handle<T>(Func<ICallSpecification, T> onCallSpec, Func<ICall, T> onLastCall)
         {
-            return _hasCallSpec ? onCallSpec(_callSpecification) : onLastCall(_lastCall);
+            return _callSpecification != null ? onCallSpec(_callSpecification) : onLastCall(_lastCall!);
         }
 
         public static PendingSpecificationInfo FromLastCall(ICall lastCall)
         {
-            return new PendingSpecificationInfo(false, null, lastCall);
+            return new PendingSpecificationInfo(null, lastCall);
         }
 
         public static PendingSpecificationInfo FromCallSpecification(ICallSpecification callSpecification)
         {
-            return new PendingSpecificationInfo(true, callSpecification, null);
+            return new PendingSpecificationInfo(callSpecification, null);
         }
     }
 }

--- a/src/NSubstitute/Core/PropertyCallFormatter.cs
+++ b/src/NSubstitute/Core/PropertyCallFormatter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core
 {
@@ -14,6 +15,7 @@ namespace NSubstitute.Core
         public string Format(MethodInfo methodInfo, IEnumerable<string> arguments)
         {
             var propertyInfo = GetPropertyFromGetterOrSetterCall(methodInfo);
+            if (propertyInfo is null) throw new SubstituteInternalException("The 'CanFormat' method should have guarded it.");
             var numberOfIndexParams = propertyInfo.GetIndexParameters().Length;
             var propertyName =
                 (numberOfIndexParams == 0)
@@ -23,7 +25,7 @@ namespace NSubstitute.Core
             return propertyName + FormatArgsAfterIndexParamsAsSetterArgs(numberOfIndexParams, arguments);
         }
 
-        private PropertyInfo GetPropertyFromGetterOrSetterCall(MethodInfo methodInfoOfCall)
+        private PropertyInfo? GetPropertyFromGetterOrSetterCall(MethodInfo methodInfoOfCall)
         {
             return methodInfoOfCall.GetPropertyFromSetterCallOrNull() ?? methodInfoOfCall.GetPropertyFromGetterCallOrNull();
         }

--- a/src/NSubstitute/Core/Query.cs
+++ b/src/NSubstitute/Core/Query.cs
@@ -45,9 +45,9 @@ namespace NSubstitute.Core
 
         private class CallSequenceNumberComparer : IEqualityComparer<ICall>
         {
-            public bool Equals(ICall x, ICall y)
+            public bool Equals(ICall? x, ICall? y)
             {
-                return x.GetSequenceNumber() == y.GetSequenceNumber();
+                return x?.GetSequenceNumber() == y?.GetSequenceNumber();
             }
 
             public int GetHashCode(ICall obj)

--- a/src/NSubstitute/Core/ReflectionExtensions.cs
+++ b/src/NSubstitute/Core/ReflectionExtensions.cs
@@ -6,7 +6,7 @@ namespace NSubstitute.Core
 {
     public static class ReflectionExtensions
     {
-        public static PropertyInfo GetPropertyFromSetterCallOrNull(this MethodInfo call)
+        public static PropertyInfo? GetPropertyFromSetterCallOrNull(this MethodInfo call)
         {
             if (!CanBePropertySetterCall(call)) return null;
 
@@ -19,7 +19,7 @@ namespace NSubstitute.Core
             return null;
         }
 
-        public static PropertyInfo GetPropertyFromGetterCallOrNull(this MethodInfo call)
+        public static PropertyInfo? GetPropertyFromGetterCallOrNull(this MethodInfo call)
         {
             return GetAllProperties(call.DeclaringType)
                 .FirstOrDefault(x => x.GetGetMethod(nonPublic: true) == call);
@@ -41,9 +41,11 @@ namespace NSubstitute.Core
             return call.Name.StartsWith("set_", StringComparison.Ordinal);
         }
 
-        private static PropertyInfo[] GetAllProperties(Type type)
+        private static PropertyInfo[] GetAllProperties(Type? type)
         {
-            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return type != null
+                ? type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                : new PropertyInfo[0];
         }
     }
 }

--- a/src/NSubstitute/Core/ResultsForType.cs
+++ b/src/NSubstitute/Core/ResultsForType.cs
@@ -19,7 +19,7 @@ namespace NSubstitute.Core
             _results.SetResult(new MatchingReturnTypeSpecification(type), resultToReturn);
         }
 
-        public bool TryGetResult(ICall call, out object result)
+        public bool TryGetResult(ICall call, out object? result)
         {
             return _results.TryGetResult(call, out result);
         }

--- a/src/NSubstitute/Core/ReturnObservable.cs
+++ b/src/NSubstitute/Core/ReturnObservable.cs
@@ -1,19 +1,20 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NSubstitute.Core
 {
-    internal class ReturnObservable<T> : IObservable<T>
+    internal class ReturnObservable<T> : IObservable<T?>
     {
-        T _value;
+        T? _value;
 
-        public ReturnObservable() : this(default(T)) { }
+        public ReturnObservable() : this(default) { }
 
-        public ReturnObservable(T value)
+        public ReturnObservable(T? value)
         {
             _value = value;
         }
 
-        public IDisposable Subscribe(IObserver<T> observer)
+        public IDisposable Subscribe(IObserver<T?> observer)
         {
             observer.OnNext(_value);
             observer.OnCompleted();

--- a/src/NSubstitute/Core/RobustThreadLocal.cs
+++ b/src/NSubstitute/Core/RobustThreadLocal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace NSubstitute.Core
@@ -11,7 +12,7 @@ namespace NSubstitute.Core
     internal class RobustThreadLocal<T>
     {
         private readonly ThreadLocal<T> _threadLocal;
-        private readonly Func<T> _initalValueFactory;
+        private readonly Func<T>? _initialValueFactory;
 
         public RobustThreadLocal()
         {
@@ -20,7 +21,7 @@ namespace NSubstitute.Core
 
         public RobustThreadLocal(Func<T> initialValueFactory)
         {
-            _initalValueFactory = initialValueFactory ?? throw new ArgumentNullException(nameof(initialValueFactory));
+            _initialValueFactory = initialValueFactory;
             _threadLocal = new ThreadLocal<T>(initialValueFactory);
         }
 
@@ -28,13 +29,15 @@ namespace NSubstitute.Core
         {
             get
             {
+                // Suppress nullability for result, as we trust type by usage.
+                // For non-nullable we expect ctor with default to be used.
                 try
                 {
-                    return _threadLocal.Value;
+                    return _threadLocal.Value!;
                 }
                 catch (ObjectDisposedException)
                 {
-                    return _initalValueFactory != null ? _initalValueFactory.Invoke() : default(T);
+                    return _initialValueFactory != null ? _initialValueFactory.Invoke() : default!;
                 }
             }
             set

--- a/src/NSubstitute/Core/RouteAction.cs
+++ b/src/NSubstitute/Core/RouteAction.cs
@@ -2,22 +2,22 @@ namespace NSubstitute.Core
 {
     public class RouteAction
     {
-        private readonly object _returnValue;
+        private readonly object? _returnValue;
         private readonly bool _hasReturnValue;
 
         public bool HasReturnValue { get { return _hasReturnValue; } }
-        public object ReturnValue { get { return _returnValue; } }
+        public object? ReturnValue { get { return _returnValue; } }
 
         private static readonly RouteAction _continue = new RouteAction();
         public static RouteAction Continue() { return _continue; }
-        public static RouteAction Return(object value) { return new RouteAction(value); }
+        public static RouteAction Return(object? value) { return new RouteAction(value); }
 
         private RouteAction()
         {
             _hasReturnValue = false;
         }
 
-        private RouteAction(object returnValue)
+        private RouteAction(object? returnValue)
         {
             _returnValue = returnValue;
             _hasReturnValue = true;

--- a/src/NSubstitute/Core/RouteFactoryCacheWrapper.cs
+++ b/src/NSubstitute/Core/RouteFactoryCacheWrapper.cs
@@ -53,7 +53,7 @@ namespace NSubstitute.Core
         public IRoute CallBase(ISubstituteState state, MatchArgs matchArgs) =>
             _factory.CallBase(state, matchArgs);
 
-        public IRoute RaiseEvent(ISubstituteState state, Func<ICall, object[]> getEventArguments) =>
+        public IRoute RaiseEvent(ISubstituteState state, Func<ICall, object?[]> getEventArguments) =>
             _factory.RaiseEvent(state, getEventArguments);
 
         private readonly struct CachedRoute

--- a/src/NSubstitute/Core/SequenceChecking/InstanceTracker.cs
+++ b/src/NSubstitute/Core/SequenceChecking/InstanceTracker.cs
@@ -26,7 +26,7 @@ namespace NSubstitute.Core.SequenceChecking
 
         private class ReferenceEqualityComparer : EqualityComparer<object>
         {
-            public override bool Equals(object x, object y) { return object.ReferenceEquals(x, y); }
+            public override bool Equals(object? x, object? y) { return object.ReferenceEquals(x, y); }
             public override int GetHashCode(object obj) { return RuntimeHelpers.GetHashCode(obj); }
         }
     }

--- a/src/NSubstitute/Core/SubstituteFactory.cs
+++ b/src/NSubstitute/Core/SubstituteFactory.cs
@@ -24,7 +24,7 @@ namespace NSubstitute.Core
         /// <param name="typesToProxy"></param>
         /// <param name="constructorArguments"></param>
         /// <returns></returns>
-        public object Create(Type[] typesToProxy, object[] constructorArguments)
+        public object Create(Type[] typesToProxy, object?[] constructorArguments)
         {
             return Create(typesToProxy, constructorArguments, callBaseByDefault: false);
         }
@@ -37,7 +37,7 @@ namespace NSubstitute.Core
         /// <param name="typesToProxy"></param>
         /// <param name="constructorArguments"></param>
         /// <returns></returns>
-        public object CreatePartial(Type[] typesToProxy, object[] constructorArguments)
+        public object CreatePartial(Type[] typesToProxy, object?[] constructorArguments)
         {
             var primaryProxyType = GetPrimaryProxyType(typesToProxy);
             if (!CanCallBaseImplementation(primaryProxyType))
@@ -48,7 +48,7 @@ namespace NSubstitute.Core
             return Create(typesToProxy, constructorArguments, callBaseByDefault: true);
         }
 
-        private object Create(Type[] typesToProxy, object[] constructorArguments, bool callBaseByDefault)
+        private object Create(Type[] typesToProxy, object?[] constructorArguments, bool callBaseByDefault)
         {
             var substituteState = _substituteStateFactory.Create(this);
             substituteState.CallBaseConfiguration.CallBaseByDefault = callBaseByDefault;

--- a/src/NSubstitute/Core/SubstitutionContext.cs
+++ b/src/NSubstitute/Core/SubstitutionContext.cs
@@ -59,7 +59,7 @@ namespace NSubstitute.Core
         [Obsolete("This property is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.PendingSpecification) + " property instead. " +
                   "For example: SubstitutionContext.Current.ThreadContext." + nameof(IThreadLocalContext.PendingSpecification) + ".")]
-        public PendingSpecificationInfo PendingSpecificationInfo
+        public PendingSpecificationInfo? PendingSpecificationInfo
         {
             get
             {
@@ -83,8 +83,8 @@ namespace NSubstitute.Core
                 // Emulate the old API. A bit clumsy, however it's here for the backward compatibility only
                 // and is not expected to be used frequently.
                 var unwrappedValue = value.Handle(
-                    spec => Tuple.Create(spec, (ICall) null),
-                    call => Tuple.Create((ICallSpecification) null, call));
+                    spec => Tuple.Create<ICallSpecification?, ICall?>(spec, null),
+                    call => Tuple.Create<ICallSpecification?, ICall?>(null, call));
 
                 if (unwrappedValue.Item1 != null)
                 {
@@ -92,7 +92,7 @@ namespace NSubstitute.Core
                 }
                 else
                 {
-                    ThreadContext.PendingSpecification.SetLastCall(unwrappedValue.Item2);
+                    ThreadContext.PendingSpecification.SetLastCall(unwrappedValue.Item2!);
                 }
             }
         }
@@ -141,7 +141,7 @@ namespace NSubstitute.Core
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +
                   "Use the " + nameof(ThreadContext) + "." + nameof(IThreadLocalContext.UsePendingRaisingEventArgumentsFactory) + "() method instead. " +
                   "For example: SubstitutionContext.Current.ThreadContext." + nameof(IThreadLocalContext.UsePendingRaisingEventArgumentsFactory) + "().")]
-        public Func<ICall, object[]> DequeuePendingRaisingEventArguments() =>
+        public Func<ICall, object?[]>? DequeuePendingRaisingEventArguments() =>
             ThreadContext.UsePendingRaisingEventArgumentsFactory();
 
         [Obsolete("This method is obsolete and will be removed in a future version of the product. " +

--- a/src/NSubstitute/Core/ThreadLocalContext.cs
+++ b/src/NSubstitute/Core/ThreadLocalContext.cs
@@ -10,22 +10,22 @@ namespace NSubstitute.Core
     {
         private static readonly IArgumentSpecification[] EmptySpecifications = new IArgumentSpecification[0];
 
-        private readonly RobustThreadLocal<ICallRouter> _lastCallRouter;
+        private readonly RobustThreadLocal<ICallRouter?> _lastCallRouter;
         private readonly RobustThreadLocal<IList<IArgumentSpecification>> _argumentSpecifications;
-        private readonly RobustThreadLocal<Func<ICall, object[]>> _getArgumentsForRaisingEvent;
-        private readonly RobustThreadLocal<IQuery> _currentQuery;
+        private readonly RobustThreadLocal<Func<ICall, object?[]>?> _getArgumentsForRaisingEvent;
+        private readonly RobustThreadLocal<IQuery?> _currentQuery;
         private readonly RobustThreadLocal<PendingSpecInfoData> _pendingSpecificationInfo;
-        private readonly RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>> _nextRouteFactory;
+        private readonly RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>?> _nextRouteFactory;
         public IPendingSpecification PendingSpecification { get; }
 
         public ThreadLocalContext()
         {
-            _lastCallRouter = new RobustThreadLocal<ICallRouter>();
+            _lastCallRouter = new RobustThreadLocal<ICallRouter?>();
             _argumentSpecifications = new RobustThreadLocal<IList<IArgumentSpecification>>(() => new List<IArgumentSpecification>());
-            _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object[]>>();
-            _currentQuery = new RobustThreadLocal<IQuery>();
+            _getArgumentsForRaisingEvent = new RobustThreadLocal<Func<ICall, object?[]>?>();
+            _currentQuery = new RobustThreadLocal<IQuery?>();
             _pendingSpecificationInfo = new RobustThreadLocal<PendingSpecInfoData>();
-            _nextRouteFactory = new RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>>();
+            _nextRouteFactory = new RobustThreadLocal<Tuple<ICallRouter, Func<ISubstituteState, IRoute>>?>();
 
             PendingSpecification = new PendingSpecificationWrapper(_pendingSpecificationInfo);
         }
@@ -51,7 +51,7 @@ namespace NSubstitute.Core
                 throw new UnexpectedArgumentMatcherException();
             }
 
-            var pendingSpecInfo = PendingSpecification.UseCallSpecInfo();
+            var pendingSpecInfo = PendingSpecification.UseCallSpecInfo()!;
             var configuredCall = lastCallRouter.LastCallShouldReturn(value, matchArgs, pendingSpecInfo);
             ClearLastCallRouter();
             return configuredCall;
@@ -65,7 +65,7 @@ namespace NSubstitute.Core
             _nextRouteFactory.Value = Tuple.Create(callRouter, nextRouteFactory);
         }
 
-        public Func<ISubstituteState, IRoute> UseNextRoute(ICallRouter callRouter)
+        public Func<ISubstituteState, IRoute>? UseNextRoute(ICallRouter callRouter)
         {
             if (callRouter == null) throw new ArgumentNullException(nameof(callRouter));
             
@@ -115,12 +115,12 @@ namespace NSubstitute.Core
             return queue;
         }
 
-        public void SetPendingRaisingEventArgumentsFactory(Func<ICall, object[]> getArguments)
+        public void SetPendingRaisingEventArgumentsFactory(Func<ICall, object?[]> getArguments)
         {
             _getArgumentsForRaisingEvent.Value = getArguments;
         }
 
-        public Func<ICall, object[]> UsePendingRaisingEventArgumentsFactory()
+        public Func<ICall, object?[]>? UsePendingRaisingEventArgumentsFactory()
         {
             var result = _getArgumentsForRaisingEvent.Value;
             if (result != null)
@@ -169,7 +169,7 @@ namespace NSubstitute.Core
                 return _valueHolder.Value.HasValue;
             }
 
-            public PendingSpecificationInfo UseCallSpecInfo()
+            public PendingSpecificationInfo? UseCallSpecInfo()
             {
                 var info = _valueHolder.Value;
                 Clear();
@@ -194,18 +194,18 @@ namespace NSubstitute.Core
 
         private readonly struct PendingSpecInfoData
         {
-            private readonly ICallSpecification _callSpecification;
-            private readonly ICall _lastCall;
+            private readonly ICallSpecification? _callSpecification;
+            private readonly ICall? _lastCall;
 
             public bool HasValue => _lastCall != null || _callSpecification != null;
 
-            private PendingSpecInfoData(ICallSpecification callSpecification, ICall lastCall)
+            private PendingSpecInfoData(ICallSpecification? callSpecification, ICall? lastCall)
             {
                 _callSpecification = callSpecification;
                 _lastCall = lastCall;
             }
 
-            public PendingSpecificationInfo ToPendingSpecificationInfo()
+            public PendingSpecificationInfo? ToPendingSpecificationInfo()
             {
                 if (_callSpecification != null)
                     return PendingSpecificationInfo.FromCallSpecification(_callSpecification);

--- a/src/NSubstitute/Core/WhenCalled.cs
+++ b/src/NSubstitute/Core/WhenCalled.cs
@@ -17,7 +17,7 @@ namespace NSubstitute.Core
             _substitute = substitute;
             _call = call;
             _matchArgs = matchArgs;
-            _callRouter = context.GetCallRouterFor(substitute);
+            _callRouter = context.GetCallRouterFor(substitute!);
             _routeFactory = context.RouteFactory;
             _threadContext = context.ThreadContext;
         }

--- a/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -29,7 +29,7 @@ namespace NSubstitute.Exceptions
         }
 
         public AmbiguousArgumentsException(MethodInfo method,
-            IEnumerable<object> invocationArguments,
+            IEnumerable<object?> invocationArguments,
             IEnumerable<IArgumentSpecification> matchedSpecifications,
             IEnumerable<IArgumentSpecification> allSpecifications)
             : this(BuildExceptionMessage(method, invocationArguments, matchedSpecifications, allSpecifications))
@@ -37,13 +37,13 @@ namespace NSubstitute.Exceptions
         }
 
         private static string BuildExceptionMessage(MethodInfo method,
-            IEnumerable<object> invocationArguments,
+            IEnumerable<object?> invocationArguments,
             IEnumerable<IArgumentSpecification> matchedSpecifications,
             IEnumerable<IArgumentSpecification> allSpecifications)
         {
-            string methodSignature = null;
-            string methodArgsWithHighlightedPossibleArgSpecs = null;
-            string matchedSpecificationsInfo = null;
+            string? methodSignature = null;
+            string? methodArgsWithHighlightedPossibleArgSpecs = null;
+            string? matchedSpecificationsInfo = null;
             if (CallFormatter.Default.CanFormat(method))
             {
                 var argsWithInlinedParamsArray = invocationArguments.ToArray();
@@ -107,10 +107,10 @@ namespace NSubstitute.Exceptions
                 var type = p.ParameterType;
 
                 if (p.IsOut)
-                    return "out " + type.GetElementType().GetNonMangledTypeName();
+                    return "out " + type.GetElementType()!.GetNonMangledTypeName();
 
                 if (type.IsByRef)
-                    return "ref " + type.GetElementType().GetNonMangledTypeName();
+                    return "ref " + type.GetElementType()!.GetNonMangledTypeName();
 
                 if (p.IsParams())
                     return "params " + type.GetNonMangledTypeName();
@@ -119,7 +119,7 @@ namespace NSubstitute.Exceptions
             });
         }
 
-        private static IEnumerable<string> FormatMethodArguments(IEnumerable<object> arguments)
+        private static IEnumerable<string> FormatMethodArguments(IEnumerable<object?> arguments)
         {
             var defaultChecker = new DefaultChecker(new DefaultForType());
 
@@ -130,9 +130,9 @@ namespace NSubstitute.Exceptions
             });
         }
 
-        private static IEnumerable<string> PadNonMatchedSpecifications(IEnumerable<IArgumentSpecification> matchedSpecifications, IEnumerable<object> allArguments)
+        private static IEnumerable<string> PadNonMatchedSpecifications(IEnumerable<IArgumentSpecification> matchedSpecifications, IEnumerable<object?> allArguments)
         {
-            var allMatchedSpecs = matchedSpecifications.Select(x => x.ToString()).ToArray();
+            var allMatchedSpecs = matchedSpecifications.Select(x => x.ToString() ?? string.Empty).ToArray();
 
             int nonResolvedArgumentsCount = allArguments.Count() - allMatchedSpecs.Length;
             var nonResolvedArgsPlaceholders = Enumerable.Repeat("???", nonResolvedArgumentsCount);

--- a/src/NSubstitute/Exceptions/CouldNotSetReturnException.cs
+++ b/src/NSubstitute/Exceptions/CouldNotSetReturnException.cs
@@ -40,13 +40,13 @@ namespace NSubstitute.Exceptions
 
     public class CouldNotSetReturnDueToTypeMismatchException : CouldNotSetReturnException
     {
-        public CouldNotSetReturnDueToTypeMismatchException(Type returnType, MethodInfo member) : base(DescribeProblem(returnType, member)) { }
+        public CouldNotSetReturnDueToTypeMismatchException(Type? returnType, MethodInfo member) : base(DescribeProblem(returnType, member)) { }
 
-        private static string DescribeProblem(Type typeOfReturnValueOrNull, MethodInfo member)
+        private static string DescribeProblem(Type? typeOfReturnValue, MethodInfo member)
         {
-            return typeOfReturnValueOrNull == null 
-                ? String.Format("Can not return null for {0}.{1} (expected type {2}).", member.DeclaringType.Name, member.Name, member.ReturnType.Name) 
-                : String.Format("Can not return value of type {0} for {1}.{2} (expected type {3}).", typeOfReturnValueOrNull.Name, member.DeclaringType.Name, member.Name, member.ReturnType.Name);
+            return typeOfReturnValue == null 
+                ? string.Format("Can not return null for {0}.{1} (expected type {2}).", member.DeclaringType!.Name, member.Name, member.ReturnType.Name) 
+                : string.Format("Can not return value of type {0} for {1}.{2} (expected type {3}).", typeOfReturnValue.Name, member.DeclaringType!.Name, member.Name, member.ReturnType.Name);
         }
     }
 }

--- a/src/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
+++ b/src/NSubstitute/Exceptions/NullSubstituteReferenceException.cs
@@ -1,7 +1,8 @@
 namespace NSubstitute.Exceptions
 {
-    public class NullSubstituteReferenceException : NotASubstituteException
+    public class NullSubstituteReferenceException : SubstituteException
     {
-        public NullSubstituteReferenceException() { }
+        const string Explanation = "NSubstitute extension methods like .Received() can only be called on non-null objects.";
+        public NullSubstituteReferenceException() : base(Explanation) { }
     }
 }

--- a/src/NSubstitute/Exceptions/SubstituteException.cs
+++ b/src/NSubstitute/Exceptions/SubstituteException.cs
@@ -6,6 +6,6 @@ namespace NSubstitute.Exceptions
     {
         public SubstituteException() : this("") { }
         public SubstituteException(string message) : this(message, null) { }
-        public SubstituteException(string message, Exception innerException) : base(message, innerException) { }
+        public SubstituteException(string message, Exception? innerException) : base(message, innerException) { }
     }
 }

--- a/src/NSubstitute/Exceptions/SubstituteInternalException.cs
+++ b/src/NSubstitute/Exceptions/SubstituteInternalException.cs
@@ -7,7 +7,7 @@ namespace NSubstitute.Exceptions
     {
         public SubstituteInternalException() : this("") { }
         public SubstituteInternalException(string message) : this(message, null) { }
-        public SubstituteInternalException(string message, Exception innerException)
+        public SubstituteInternalException(string message, Exception? innerException)
             : base("Please report this exception at https://github.com/nsubstitute/NSubstitute/issues: \n\n" + message,
                 innerException) { }
     }

--- a/src/NSubstitute/Extensions/ClearExtensions.cs
+++ b/src/NSubstitute/Extensions/ClearExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using NSubstitute.Core;
+using NSubstitute.Exceptions;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute.ClearExtensions
 {
@@ -16,8 +20,10 @@ namespace NSubstitute.ClearExtensions
         /// </remarks>
         public static void ClearSubstitute<T>(this T substitute, ClearOptions options = ClearOptions.All) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
-            var router = context.GetCallRouterFor(substitute);
+            var router = context.GetCallRouterFor(substitute!);
             router.Clear(options);
         }
     }

--- a/src/NSubstitute/Extensions/ConfigurationExtensions.cs
+++ b/src/NSubstitute/Extensions/ConfigurationExtensions.cs
@@ -1,4 +1,9 @@
-﻿using NSubstitute.Core;
+﻿using System;
+using NSubstitute.Core;
+using NSubstitute.Exceptions;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute.Extensions
 {
@@ -21,8 +26,10 @@ namespace NSubstitute.Extensions
         /// </summary>
         public static T Configure<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+ 
             var context = SubstitutionContext.Current;
-            var callRouter = context.GetCallRouterFor(substitute);
+            var callRouter = context.GetCallRouterFor(substitute!);
             context.ThreadContext.SetNextRoute(callRouter, context.RouteFactory.RecordCallSpecification);
 
             return substitute;

--- a/src/NSubstitute/Extensions/ExceptionExtensions.cs
+++ b/src/NSubstitute/Extensions/ExceptionExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.ExceptionExtensions
 {
     public static class ExceptionExtensions
@@ -23,7 +26,7 @@ namespace NSubstitute.ExceptionExtensions
         /// <param name="value"></param>
         /// <returns></returns>
         public static ConfiguredCall Throws<TException>(this object value)
-            where TException : Exception, new()
+            where TException : notnull, Exception, new()
         {
             return value.Returns(_ => { throw new TException(); });
         }
@@ -57,7 +60,7 @@ namespace NSubstitute.ExceptionExtensions
         /// <param name="value"></param>
         /// <returns></returns>
         public static ConfiguredCall ThrowsForAnyArgs<TException>(this object value)
-            where TException : Exception, new()
+            where TException : notnull, Exception, new()
         {
             return value.ReturnsForAnyArgs(_ => { throw new TException(); });
         }

--- a/src/NSubstitute/Extensions/ReceivedExtensions.cs
+++ b/src/NSubstitute/Extensions/ReceivedExtensions.cs
@@ -2,6 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using NSubstitute.Core;
+using NSubstitute.Exceptions;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute.ReceivedExtensions
 {
@@ -16,6 +20,8 @@ namespace NSubstitute.ReceivedExtensions
         /// <returns></returns>
         public static T Received<T>(this T substitute, Quantity requiredQuantity)
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             var callRouter = context.GetCallRouterFor(substitute);
 
@@ -32,6 +38,8 @@ namespace NSubstitute.ReceivedExtensions
         /// <returns></returns>
         public static T ReceivedWithAnyArgs<T>(this T substitute, Quantity requiredQuantity)
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             var callRouter = context.GetCallRouterFor(substitute);
 

--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading.Tasks;
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.ReturnsExtensions
 {
     public static class ReturnsExtensions

--- a/src/NSubstitute/Extensions/ReturnsForAllExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsForAllExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using NSubstitute.Core;
+using NSubstitute.Exceptions;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute.Extensions
 {
@@ -14,8 +18,10 @@ namespace NSubstitute.Extensions
         /// <returns></returns>
         public static void ReturnsForAll<T>(this object substitute, T returnThis)
         {
-            var _callRouter = SubstitutionContext.Current.GetCallRouterFor(substitute);
-            _callRouter.SetReturnForType(typeof(T), new ReturnValue(returnThis));
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
+            var callRouter = SubstitutionContext.Current.GetCallRouterFor(substitute);
+            callRouter.SetReturnForType(typeof(T), new ReturnValue(returnThis));
         }
         
         /// <summary>
@@ -27,6 +33,8 @@ namespace NSubstitute.Extensions
         /// <returns></returns>
         public static void ReturnsForAll<T>(this object substitute, Func<CallInfo, T> returnThis)
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var _callRouter = SubstitutionContext.Current.GetCallRouterFor(substitute);
             _callRouter.SetReturnForType(typeof(T), new ReturnValueFromFunc<T>(returnThis));
         }

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -30,7 +30,14 @@
 
   <PropertyGroup>
     <DocumentationFile>..\..\bin\$(Configuration)\NSubstitute\$(TargetFramework)\NSubstitute.xml</DocumentationFile>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Nullable Condition="'$(TargetIsNet5)' == 'true'">enable</Nullable>
+    <!-- Nullability does not work nicely for older versions of .NET, so just disable nullability for those versions. -->
+    <!-- CS8632 - The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
+    <NoWarn Condition="'$(TargetIsNet5)' != 'true'">$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +45,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*"
                       Condition="'$(TargetIsNet5)' != 'true'" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
@@ -46,6 +53,10 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);SYSTEM_REFLECTION_CUSTOMATTRIBUTES_IS_ARRAY</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetIsNet5)' == 'true'">
+    <DefineConstants>$(DefineConstants);SYSTEM_DIAGNOSTICS_CODEANALYSIS_NULLABILITY</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -3,14 +3,17 @@
   <PropertyGroup>
     <Description>NSubstitute is a friendly substitute for .NET mocking libraries. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
     <Version>3.0.0</Version>
-    <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin;Alex Povar</Authors>
+    <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin;Oleksandr Povar</Authors>
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>
     <PackageTags>mocking;mocks;testing;unit-testing;TDD;AAA</PackageTags>
-    <PackageIconUrl>https://nsubstitute.github.io/images/nsubstitute-100x100.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://nsubstitute.github.io/</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\docs\images\nsubstitute-100x100.png" Pack="true" PackagePath="icon.png" Visible="false" />
+  </ItemGroup>
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,7 +35,8 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0-*" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*"
+                      Condition="'$(TargetIsNet5)' != 'true'" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
@@ -43,11 +44,6 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
- 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);SYSTEM_REFLECTION_CUSTOMATTRIBUTES_IS_ARRAY</DefineConstants>
   </PropertyGroup>

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Castle.DynamicProxy;
@@ -22,14 +23,14 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             _allMethodsExceptCallRouterCallsHook = new AllMethodsExceptCallRouterCallsHook();
         }
 
-        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
         {
             return typeToProxy.IsDelegate()
                 ? GenerateDelegateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments)
                 : GenerateTypeProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments);
         }
 
-        private object GenerateTypeProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        private object GenerateTypeProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
         {
             VerifyClassHasNotBeenPassedAsAnAdditionalInterface(additionalInterfaces);
 
@@ -49,7 +50,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             return proxy;
         }
 
-        private object GenerateDelegateProxy(ICallRouter callRouter, Type delegateType, Type[] additionalInterfaces, object[] constructorArguments)
+        private object GenerateDelegateProxy(ICallRouter callRouter, Type delegateType, Type[]? additionalInterfaces, object?[]? constructorArguments)
         {
             VerifyNoAdditionalInterfacesGivenForDelegate(additionalInterfaces);
             VerifyNoConstructorArgumentsGivenForDelegate(constructorArguments);
@@ -84,8 +85,8 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
                 callRouter);
         }
 
-        private object CreateProxyUsingCastleProxyGenerator(Type typeToProxy, Type[] additionalInterfaces,
-                                                            object[] constructorArguments,
+        private object CreateProxyUsingCastleProxyGenerator(Type typeToProxy, Type[]? additionalInterfaces,
+                                                            object?[]? constructorArguments,
                                                             IInterceptor[] interceptors,
                                                             ProxyGenerationOptions proxyGenerationOptions)
         {
@@ -128,7 +129,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             return options;
         }
 
-        private static void VerifyNoConstructorArgumentsGivenForInterface(object[] constructorArguments)
+        private static void VerifyNoConstructorArgumentsGivenForInterface(object?[]? constructorArguments)
         {
             if (HasItems(constructorArguments))
             {
@@ -136,7 +137,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             }
         }
 
-        private static void VerifyNoConstructorArgumentsGivenForDelegate(object[] constructorArguments)
+        private static void VerifyNoConstructorArgumentsGivenForDelegate(object?[]? constructorArguments)
         {
             if (HasItems(constructorArguments))
             {
@@ -144,7 +145,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             }
         }
 
-        private static void VerifyNoAdditionalInterfacesGivenForDelegate(Type[] constructorArguments)
+        private static void VerifyNoAdditionalInterfacesGivenForDelegate(Type[]? constructorArguments)
         {
             if (HasItems(constructorArguments))
             {
@@ -154,7 +155,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             }
         }
 
-        private static void VerifyClassHasNotBeenPassedAsAnAdditionalInterface(Type[] additionalInterfaces)
+        private static void VerifyClassHasNotBeenPassedAsAnAdditionalInterface(Type[]? additionalInterfaces)
         {
             if (additionalInterfaces != null && additionalInterfaces.Any(x => x.GetTypeInfo().IsClass))
             {
@@ -164,7 +165,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             }
         }
  
-        private static bool HasItems<T>(T[] array)
+        private static bool HasItems<T>(T[]? array)
         {
             return array != null && array.Length > 0;
         }

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
@@ -17,7 +17,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
 
         public virtual ICall Map(IInvocation castleInvocation)
         {
-            Func<object> baseMethod = null;
+            Func<object>? baseMethod = null;
             if (castleInvocation.InvocationTarget != null &&
                 castleInvocation.MethodInvocationTarget.IsVirtual &&
                 !castleInvocation.MethodInvocationTarget.IsAbstract &&

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/ProxyIdInterceptor.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/ProxyIdInterceptor.cs
@@ -9,7 +9,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
     public class ProxyIdInterceptor : IInterceptor
     {
         private readonly Type _primaryProxyType;
-        private string _cachedProxyId;
+        private string? _cachedProxyId;
 
         public ProxyIdInterceptor(Type primaryProxyType)
         {

--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -22,7 +22,7 @@ namespace NSubstitute.Proxies.DelegateProxy
             _castleObjectProxyFactory = objectProxyFactory ?? throw new ArgumentNullException(nameof(objectProxyFactory));
         }
 
-        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
         {
             // Castle factory can now resolve delegate proxies as well.
             return _castleObjectProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments);

--- a/src/NSubstitute/Proxies/ProxyFactory.cs
+++ b/src/NSubstitute/Proxies/ProxyFactory.cs
@@ -16,7 +16,7 @@ namespace NSubstitute.Proxies
             _dynamicProxyFactory = dynamicProxyFactory;
         }
 
-        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[] additionalInterfaces, object[] constructorArguments)
+        public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
         {
             var isDelegate = typeToProxy.IsDelegate();
             return isDelegate 

--- a/src/NSubstitute/Raise.cs
+++ b/src/NSubstitute/Raise.cs
@@ -4,6 +4,9 @@ using System.Reflection;
 using NSubstitute.Core;
 using NSubstitute.Core.Events;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     public static class Raise

--- a/src/NSubstitute/Received.cs
+++ b/src/NSubstitute/Received.cs
@@ -2,6 +2,9 @@
 using NSubstitute.Core;
 using NSubstitute.Core.SequenceChecking;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     public class Received

--- a/src/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoArrayProvider.cs
@@ -9,11 +9,11 @@ namespace NSubstitute.Routing.AutoValues
             return type.IsArray;
         }
 
-        public object GetValue(Type type)
+        public object? GetValue(Type type)
         {
             var rank = type.GetArrayRank();
             var dimensionLengths = new int[rank];
-            return Array.CreateInstance(type.GetElementType(), dimensionLengths);
+            return Array.CreateInstance(type.GetElementType()!, dimensionLengths);
         }
     }
 }

--- a/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoObservableProvider.cs
@@ -20,7 +20,7 @@ namespace NSubstitute.Routing.AutoValues
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IObservable<>);
         }
 
-        public object GetValue(Type type)
+        public object? GetValue(Type type)
         {
             if (!CanProvideValueFor(type)) 
                 throw new InvalidOperationException();
@@ -30,10 +30,10 @@ namespace NSubstitute.Routing.AutoValues
             var value = valueProvider == null ? GetDefault(type) : valueProvider.GetValue(innerType);
             return Activator.CreateInstance(
                     typeof(ReturnObservable<>).MakeGenericType(innerType)
-                    , new object[] { value });
+                    , new object?[] { value });
         }
 
-        private static object GetDefault(Type type)
+        private static object? GetDefault(Type type)
         {
             return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type) : null;
         }

--- a/src/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoQueryableProvider.cs
@@ -11,7 +11,7 @@ namespace NSubstitute.Routing.AutoValues
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryable<>);
         }
 
-        public object GetValue(Type type)
+        public object? GetValue(Type type)
         {
             if (!CanProvideValueFor(type))
                 throw new InvalidOperationException();

--- a/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoTaskProvider.cs
@@ -33,18 +33,18 @@ namespace NSubstitute.Routing.AutoValues
                 var value = valueProvider == null ? GetDefault(type) : valueProvider.GetValue(taskType);
                 var taskCompletionSourceType = typeof(TaskCompletionSource<>).MakeGenericType(taskType);
                 var taskCompletionSource = Activator.CreateInstance(taskCompletionSourceType);
-                taskCompletionSourceType.GetMethod("SetResult").Invoke(taskCompletionSource, new[] { value });
-                return taskCompletionSourceType.GetProperty("Task").GetValue(taskCompletionSource, null);
+                taskCompletionSourceType.GetMethod(nameof(TaskCompletionSource<object>.SetResult))!.Invoke(taskCompletionSource, new[] {value});
+                return taskCompletionSourceType.GetProperty(nameof(TaskCompletionSource<object>.Task))!.GetValue( taskCompletionSource, null)!;
             }
             else
             {
-                var taskCompletionSource = new TaskCompletionSource<object>();
+                var taskCompletionSource = new TaskCompletionSource<object?>();
                 taskCompletionSource.SetResult(null);
                 return taskCompletionSource.Task;
             }
         }
 
-        private static object GetDefault(Type type)
+        private static object? GetDefault(Type type)
         {
             return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type) : null;
         }

--- a/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
+++ b/src/NSubstitute/Routing/AutoValues/AutoValueProvidersFactory.cs
@@ -9,7 +9,7 @@ namespace NSubstitute.Routing.AutoValues
     {
         public IReadOnlyCollection<IAutoValueProvider> CreateProviders(ISubstituteFactory substituteFactory)
         {
-            IAutoValueProvider[] result = null;
+            IAutoValueProvider[]? result = null;
             var lazyResult = new Lazy<IReadOnlyCollection<IAutoValueProvider>>(
                 () => result ?? throw new InvalidOperationException("Value was not constructed yet."),
                 LazyThreadSafetyMode.PublicationOnly);

--- a/src/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
+++ b/src/NSubstitute/Routing/AutoValues/IAutoValueProvider.cs
@@ -5,6 +5,6 @@ namespace NSubstitute.Routing.AutoValues
     public interface IAutoValueProvider
     {
         bool CanProvideValueFor(Type type);
-        object GetValue(Type type);
+        object? GetValue(Type type);
     }
 }

--- a/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/EventSubscriptionHandler.cs
@@ -49,7 +49,7 @@ namespace NSubstitute.Routing.Handlers
                 // It's important to use original arguments, as it provides better performance.
                 // It's safe to use original arguments here, as only by-ref arguments might be modified,
                 // which should never happen for this case.
-                takeThisAction(matchingEvent.Name, call.GetOriginalArguments()[0]);
+                takeThisAction(matchingEvent.Name, call.GetOriginalArguments()[0]!);
             }
         }
 
@@ -66,7 +66,7 @@ namespace NSubstitute.Routing.Handlers
         private static IEnumerable<EventInfo> GetEvents(ICall call, Func<ICall, Predicate<EventInfo>> createPredicate)
         {
             var predicate = createPredicate(call);
-            return call.GetMethodInfo().DeclaringType.GetEvents().Where(x => predicate(x));
+            return call.GetMethodInfo().DeclaringType!.GetEvents().Where(x => predicate(x));
         }
     }
 }

--- a/src/NSubstitute/Routing/Handlers/RaiseEventHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/RaiseEventHandler.cs
@@ -9,9 +9,9 @@ namespace NSubstitute.Routing.Handlers
     public class RaiseEventHandler : ICallHandler
     {
         readonly IEventHandlerRegistry _eventHandlerRegistry;
-        readonly Func<ICall, object[]> _getEventArguments;
+        readonly Func<ICall, object?[]> _getEventArguments;
 
-        public RaiseEventHandler(IEventHandlerRegistry eventHandlerRegistry, Func<ICall, object[]> getEventArguments)
+        public RaiseEventHandler(IEventHandlerRegistry eventHandlerRegistry, Func<ICall, object?[]> getEventArguments)
         {
             _eventHandlerRegistry = eventHandlerRegistry;
             _getEventArguments = getEventArguments;
@@ -20,11 +20,11 @@ namespace NSubstitute.Routing.Handlers
         public RouteAction Handle(ICall call)
         {
             var methodInfo = call.GetMethodInfo();
-            var eventInfo = methodInfo.DeclaringType.GetEvents().FirstOrDefault(
+            var eventInfo = methodInfo.DeclaringType!.GetEvents().FirstOrDefault(
                 x => (x.GetAddMethod() == methodInfo) || (x.GetRemoveMethod() == methodInfo));
             if (eventInfo == null) throw new CouldNotRaiseEventException();
             var handlers = _eventHandlerRegistry.GetHandlers(eventInfo.Name);
-            var eventArguments = _getEventArguments(call);
+            object?[] eventArguments = _getEventArguments(call);
             foreach (Delegate handler in handlers)
             {
                 try
@@ -33,7 +33,7 @@ namespace NSubstitute.Routing.Handlers
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw e.InnerException;
+                    throw e.InnerException!;
                 }
             }
             return RouteAction.Continue();

--- a/src/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnAutoValue.cs
@@ -48,7 +48,7 @@ namespace NSubstitute.Routing.Handlers
             return RouteAction.Continue();
         }
 
-        private object GetResultValueUsingProvider(ICall call, Type type, IAutoValueProvider provider)
+        private object? GetResultValueUsingProvider(ICall call, Type type, IAutoValueProvider provider)
         {
             var valueToReturn = provider.GetValue(type);
             if (_autoValueBehaviour == AutoValueBehaviour.UseValueForSubsequentCalls)

--- a/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
@@ -50,22 +50,22 @@ namespace NSubstitute.Routing.Handlers
 
         public class DynamicStub
         {
-            public ConfiguredCall Returns<T>(T returnThis, params T[] returnThese)
+            public ConfiguredCall Returns<T>(T? returnThis, params T?[] returnThese)
             {
                 return default(T).Returns(returnThis, returnThese);
             }
 
-            public ConfiguredCall Returns<T>(Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
+            public ConfiguredCall Returns<T>(Func<CallInfo, T?> returnThis, params Func<CallInfo, T?>[] returnThese)
             {
                 return default(T).Returns(returnThis, returnThese);
             }
 
-            public ConfiguredCall ReturnsForAnyArgs<T>(T returnThis, params T[] returnThese)
+            public ConfiguredCall ReturnsForAnyArgs<T>(T? returnThis, params T?[] returnThese)
             {
                 return default(T).ReturnsForAnyArgs(returnThis, returnThese);
             }
 
-            public ConfiguredCall ReturnsForAnyArgs<T>(Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese)
+            public ConfiguredCall ReturnsForAnyArgs<T>(Func<CallInfo, T?> returnThis, params Func<CallInfo, T?>[] returnThese)
             {
                 return default(T).ReturnsForAnyArgs(returnThis, returnThese);
             }

--- a/src/NSubstitute/Routing/IRoute.cs
+++ b/src/NSubstitute/Routing/IRoute.cs
@@ -4,6 +4,6 @@ namespace NSubstitute.Routing
 {
     public interface IRoute
     {
-        object Handle(ICall call);
+        object? Handle(ICall call);
     }
 }

--- a/src/NSubstitute/Routing/IRouteFactory.cs
+++ b/src/NSubstitute/Routing/IRouteFactory.cs
@@ -11,7 +11,7 @@ namespace NSubstitute.Routing
         IRoute DoWhenCalled(ISubstituteState state, Action<CallInfo> doAction, MatchArgs matchArgs);
         IRoute DoNotCallBase(ISubstituteState state, MatchArgs matchArgs);
         IRoute CallBase(ISubstituteState state, MatchArgs matchArgs);
-        IRoute RaiseEvent(ISubstituteState state, Func<ICall, object[]> getEventArguments);
+        IRoute RaiseEvent(ISubstituteState state, Func<ICall, object?[]> getEventArguments);
         IRoute RecordCallSpecification(ISubstituteState state);
         IRoute RecordReplay(ISubstituteState state);
     }

--- a/src/NSubstitute/Routing/Route.cs
+++ b/src/NSubstitute/Routing/Route.cs
@@ -15,7 +15,7 @@ namespace NSubstitute.Routing
 
         public IEnumerable<ICallHandler> Handlers => _handlers;
 
-        public object Handle(ICall call)
+        public object? Handle(ICall call)
         {
             // This is a hot method which is invoked frequently and has major impact on performance.
             // Therefore, the LINQ cycle was unwinded to for loop.

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -75,7 +75,7 @@ namespace NSubstitute.Routing
                 , ReturnDefaultForReturnTypeHandler()
             });
         }
-        public IRoute RaiseEvent(ISubstituteState state, Func<ICall, object[]> getEventArguments)
+        public IRoute RaiseEvent(ISubstituteState state, Func<ICall, object?[]> getEventArguments)
         {
             return new Route(new ICallHandler[] {
                 new ClearLastCallRouterHandler(_threadLocalContext)

--- a/src/NSubstitute/Substitute.cs
+++ b/src/NSubstitute/Substitute.cs
@@ -1,6 +1,9 @@
 using System;
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     /// <summary>

--- a/src/NSubstitute/SubstituteExtensions.cs
+++ b/src/NSubstitute/SubstituteExtensions.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute
 {
     public static class SubstituteExtensions
@@ -225,6 +228,8 @@ namespace NSubstitute
         /// </summary>
         public static T Received<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             return substitute.Received(Quantity.AtLeastOne());
         }
 
@@ -233,6 +238,8 @@ namespace NSubstitute
         /// </summary>
         public static T Received<T>(this T substitute, int requiredNumberOfCalls) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             return substitute.Received(Quantity.Exactly(requiredNumberOfCalls));
         }
 
@@ -241,6 +248,8 @@ namespace NSubstitute
         /// </summary>
         public static T DidNotReceive<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException(); 
+
             return substitute.Received(Quantity.None());
         }
 
@@ -249,6 +258,8 @@ namespace NSubstitute
         /// </summary>
         public static T ReceivedWithAnyArgs<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             return substitute.ReceivedWithAnyArgs(Quantity.AtLeastOne());
         }
 
@@ -257,6 +268,8 @@ namespace NSubstitute
         /// </summary>
         public static T ReceivedWithAnyArgs<T>(this T substitute, int requiredNumberOfCalls) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             return substitute.ReceivedWithAnyArgs(Quantity.Exactly(requiredNumberOfCalls));
         }
 
@@ -265,6 +278,8 @@ namespace NSubstitute
         /// </summary>
         public static T DidNotReceiveWithAnyArgs<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             return substitute.ReceivedWithAnyArgs(Quantity.None());
         }
 
@@ -278,6 +293,8 @@ namespace NSubstitute
         /// </remarks>
         public static void ClearReceivedCalls<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             substitute.ClearSubstitute(ClearOptions.ReceivedCalls);
         }
 
@@ -287,6 +304,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<T> When<T>(this T substitute, Action<T> substituteCall) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<T>(context, substitute, substituteCall, MatchArgs.AsSpecifiedInCall);
         }
@@ -297,6 +316,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<T> When<T>(this T substitute, Func<T, Task> substituteCall) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<T>(context, substitute, x => substituteCall(x), MatchArgs.AsSpecifiedInCall);
         }
@@ -307,6 +328,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<TSubstitute> When<TSubstitute, TResult>(this TSubstitute substitute, Func<TSubstitute, ValueTask<TResult>> substituteCall) where TSubstitute : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<TSubstitute>(context, substitute, x => substituteCall(x), MatchArgs.AsSpecifiedInCall);
         }
@@ -317,6 +340,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<T> WhenForAnyArgs<T>(this T substitute, Action<T> substituteCall) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<T>(context, substitute, substituteCall, MatchArgs.Any);
         }
@@ -327,6 +352,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<T> WhenForAnyArgs<T>(this T substitute, Func<T, Task> substituteCall) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<T>(context, substitute, x => substituteCall(x), MatchArgs.Any);
         }
@@ -337,6 +364,8 @@ namespace NSubstitute
         /// </summary>
         public static WhenCalled<TSubstitute> WhenForAnyArgs<TSubstitute, TResult>(this TSubstitute substitute, Func<TSubstitute, ValueTask<TResult>> substituteCall) where TSubstitute : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+
             var context = SubstitutionContext.Current;
             return new WhenCalled<TSubstitute>(context, substitute, x => substituteCall(x), MatchArgs.Any);
         }
@@ -346,9 +375,11 @@ namespace NSubstitute
         /// </summary>
         public static IEnumerable<ICall> ReceivedCalls<T>(this T substitute) where T : class
         {
+            if (substitute == null) throw new NullSubstituteReferenceException();
+ 
             return SubstitutionContext
                 .Current
-                .GetCallRouterFor(substitute)
+                .GetCallRouterFor(substitute!)
                 .ReceivedCalls();
         }
 
@@ -374,7 +405,7 @@ namespace NSubstitute
 
         private static void ReThrowOnNSubstituteFault<T>(Task<T> task)
         {
-            if (task.IsFaulted && task.Exception.InnerExceptions.FirstOrDefault() is SubstituteException)
+            if (task.IsFaulted && task.Exception!.InnerExceptions.FirstOrDefault() is SubstituteException)
             {
                 task.GetAwaiter().GetResult();
             }
@@ -382,7 +413,7 @@ namespace NSubstitute
 
         private static void ReThrowOnNSubstituteFault<T>(ValueTask<T> task)
         {
-            if (task.IsFaulted && task.AsTask().Exception.InnerExceptions.FirstOrDefault() is SubstituteException)
+            if (task.IsFaulted && task.AsTask().Exception!.InnerExceptions.FirstOrDefault() is SubstituteException)
             {
                 task.GetAwaiter().GetResult();
             }

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Decided to play a bit with nullability and enhance this project in the same time 😊 Enabled nullability checks for NET 5. As a side effect also added .NET 5 framework target.

Code was adjusted to ensure it's null-valid. I did not find any subtle bug though. Some details of the implementation:
- Nullability is enabled for .NET 5 target only, as recommended by MS. For older versions we rely on .NET 5 build.
- I disabled nullability annotations for the DSL related API (a.k.a. public surface). This way our clients do not have to tediously fight to the warnings they might get due to nullability. Not sure it's would be a real problem, so we could revisit this decision later.
- `member.DeclaringType` was mostly null-suppressed, as I do not expect nulls there.
- `obj.ToString()` type annotation allows null (against common sense IMO 😖), so I coerce value to an empty string just in case.
- I added null guards to some of the entry points from DSL related API. That is to be able later remove arguments checks in our code via subsequent PRs.

I also plan to also make a subsequent PR and use the latest C# features in our code files. Also want to remove null checks in the code where we enabled nullability. If you have strong opinion against that please speak 😄 

P.S. Also had to maintain the project (update SDK and Ruby on CI) to make sure I can build the project.