### PR TITLE
Update Castle.Core min from 4.4.0 to 4.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,6 @@ docs/_site/*
 
 # Ignore VIM tmp files
 *.swp
+
+# Ignore Ionide files (https://ionide.io/)
+.ionide

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0-*" />
+    <PackageReference Include="Castle.Core" Version="4.4.1-*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*"
                       Condition="'$(TargetIsNet5)' != 'true'" />
   </ItemGroup>

--- a/testDotNetCore.sh
+++ b/testDotNetCore.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+dotnet test -f netcoreapp1.1

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue631_NamespaceDelegate.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue631_NamespaceDelegate.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+
+namespace Na { public delegate void DoNothing(); }
+namespace Ns { public delegate void DoNothing(); }
+namespace Nt { public delegate void DoNothing(); }
+namespace Nz { public delegate void DoNothing(); }
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue631_NamespaceDelegate
+    {
+        [Test] public void Na() { Substitute.For<Na.DoNothing>(); }
+        [Test] public void Ns() { Substitute.For<Ns.DoNothing>(); }
+        [Test] public void Nt() { Substitute.For<Nt.DoNothing>(); }
+        [Test] public void Nz() { Substitute.For<Nz.DoNothing>(); }
+    }
+}


### PR DESCRIPTION
Closes #631.

Misc changes:
- ignore .ionide files
- helper to run test using only dotnet core (without .NET framework).