### PR TITLE
Ignore "null handlers" when a substituted event is raised

### DIFF
--- a/src/NSubstitute/Routing/Handlers/RaiseEventHandler.cs
+++ b/src/NSubstitute/Routing/Handlers/RaiseEventHandler.cs
@@ -30,6 +30,11 @@ namespace NSubstitute.Routing.Handlers
             var handlers = _eventHandlerRegistry.GetHandlers(eventInfo.Name);
             foreach (Delegate handler in handlers)
             {
+                if (handler == null)
+                {
+                    continue;
+                }
+
                 try
                 {
                     handler.DynamicInvoke(eventArguments);

--- a/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
+++ b/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
@@ -17,6 +17,18 @@ namespace NSubstitute.Acceptance.Specs
             Assert.Throws<ReceivedCallsException>(() => engine.Received().Started += someOtherHandler);
         }
 
+        [Test]
+        public void Check_if_nullHandlers_are_ignored()
+        {
+            var raised = false;
+            var source = Substitute.For<IEngine>();
+            source.Started += null;
+            source.Started += () => raised = true;
+            source.Started += Raise.Event<Action>();
+
+            Assert.IsTrue(raised);
+        }
+
         public interface IEngine
         {
             event Action Started;

--- a/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
+++ b/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
@@ -29,6 +29,23 @@ namespace NSubstitute.Acceptance.Specs
             Assert.IsTrue(raised);
         }
 
+        [Test]
+        public void Check_if_multiple_handlers_get_called()
+        {
+            var raised1 = false;
+            var raised2 = false;
+            var raised3 = false;
+            var source = Substitute.For<IEngine>();
+            source.Started += () => raised1 = true;
+            source.Started += () => raised2 = true;
+            source.Started += () => raised3 = true;
+            source.Started += Raise.Event<Action>();
+
+            Assert.IsTrue(raised1, "The first handler was not called");
+            Assert.IsTrue(raised2, "The second handler was not called");
+            Assert.IsTrue(raised3, "The third handler was not called");
+        }
+
         public interface IEngine
         {
             event Action Started;


### PR DESCRIPTION
This PR fixes #647 