### PR TITLE
CastleDynamicProxyFactory_HasItem_true_when_array_is_null

### DIFF
--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleDynamicProxyFactory.cs
@@ -164,7 +164,7 @@ namespace NSubstitute.Proxies.CastleDynamicProxy
             }
         }
 
-        private static bool HasItems<T>(T[]? array) => array?.Length != 0;
+        private static bool HasItems<T>(T[]? array) => array?.Length > 0;
 
         private class AllMethodsExceptCallRouterCallsHook : AllMethodsHook
         {


### PR DESCRIPTION
The method HasItem used to check the constructorArguments is incorrect when passing null object.

![image](https://user-images.githubusercontent.com/99241104/156099934-b747c237-34d6-4da3-9e59-37802638d3c0.png)
