### PR TITLE
Updated NSubstitute to v5 for modern TFMs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -24,6 +24,14 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Castle.Core" Version="4.4.1-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetIsNet5OrNewer)' == 'true'">
+    <PackageReference Include="Castle.Core" Version="5.0.0-*" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);SYSTEM_REFLECTION_CUSTOMATTRIBUTES_IS_ARRAY</DefineConstants>
   </PropertyGroup>
@@ -51,7 +59,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.1-*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" Condition="'$(TargetIsNet5OrNewer)' != 'true'" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">


### PR DESCRIPTION
Updated Castle.Core to v5 for modern TFMs, also updated Microsoft.NET.Framework.ReferenceAssemblies to stable version.
NSubstitute changed their TFM support in v5 release. https://www.nuget.org/packages/Castle.Core/5.0.0#dependencies-tab

This PR fixes: https://github.com/nsubstitute/NSubstitute/issues/673