### PR TITLE
Add support for `ReturnsNull` calls for nullable value types

### DIFF
--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -23,6 +23,18 @@ namespace NSubstitute.ReturnsExtensions
         /// <summary>
         /// Set null as returned value for this call.
         /// </summary>
+        public static ConfiguredCall ReturnsNull<T>(this T? value) where T : struct =>
+            value.Returns(default(T?));
+
+        /// <summary>
+        /// Set null as returned value for this call made with any arguments.
+        /// </summary>
+        public static ConfiguredCall ReturnsNullForAnyArgs<T>(this T? value) where T : struct =>
+            value.ReturnsForAnyArgs(default(T?));
+
+        /// <summary>
+        /// Set null as returned value for this call.
+        /// </summary>
         public static ConfiguredCall ReturnsNull<T>(this Task<T> value) where T : class =>
             value.Returns(default(T));
 
@@ -46,5 +58,29 @@ namespace NSubstitute.ReturnsExtensions
         /// <returns></returns>
         public static ConfiguredCall ReturnsNullForAnyArgs<T>(this ValueTask<T> value) where T : class =>
             value.ReturnsForAnyArgs(default(T));
+
+        /// <summary>
+        /// Set null as returned value for this call.
+        /// </summary>
+        public static ConfiguredCall ReturnsNull<T>(this Task<T?> value) where T : struct =>
+            value.Returns(default(T?));
+
+        /// <summary>
+        /// Set null as returned value for this call made with any arguments.
+        /// </summary>
+        public static ConfiguredCall ReturnsNullForAnyArgs<T>(this Task<T?> value) where T : struct =>
+            value.ReturnsForAnyArgs(default(T?));
+
+        /// <summary>
+        /// Set null as returned value for this call.
+        /// </summary>
+        public static ConfiguredCall ReturnsNull<T>(this ValueTask<T?> value) where T : struct =>
+            value.Returns(default(T?));
+
+        /// <summary>
+        /// Set null as returned value for this call made with any arguments.
+        /// </summary>
+        public static ConfiguredCall ReturnsNullForAnyArgs<T>(this ValueTask<T?> value) where T : struct =>
+            value.ReturnsForAnyArgs(default(T?));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
+++ b/tests/NSubstitute.Acceptance.Specs/Infrastructure/ISomething.cs
@@ -16,6 +16,8 @@
         int MethodWithRefParameter(int arg1, ref int arg2);
         int MethodWithMultipleRefParameters(int arg1, ref int arg2, ref int arg3);
         int MethodWithOutParameter(int arg1, out int arg2);
+        int? NullableCount();
+        int? NullableWithParams(int i, string s);
 
         object this[string key] { get; set; }
         System.Threading.Tasks.Task Async();
@@ -26,6 +28,8 @@
         System.Threading.Tasks.Task<string> SayAsync(string s);
         System.Threading.Tasks.Task<SomeClass> SomeActionAsync();
         System.Threading.Tasks.Task<SomeClass> SomeActionWithParamsAsync(int i, string s);
+        System.Threading.Tasks.Task<int?> NullableCountAsync();
+        System.Threading.Tasks.Task<int?> NullableWithParamsAsync(int i, string s);
 
         System.Threading.Tasks.ValueTask<int> CountValueTaskAsync();
         System.Threading.Tasks.ValueTask<string> EchoValueTaskAsync(int i);
@@ -33,5 +37,7 @@
         System.Threading.Tasks.ValueTask<string> SayValueTaskAsync(string s);
         System.Threading.Tasks.ValueTask<SomeClass> SomeActionValueTaskAsync();
         System.Threading.Tasks.ValueTask<SomeClass> SomeActionWithParamsValueTaskAsync(int i, string s);
+        System.Threading.Tasks.ValueTask<int?> NullableCountValueTaskAsync();
+        System.Threading.Tasks.ValueTask<int?> NullableCountValueTaskWithParamsAsync(int i, string s);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReturningResults.cs
@@ -330,6 +330,59 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.CountValueTaskAsync().Result, Is.EqualTo(3), "Fourth return");
         }
 
+        [Test]
+        public void Returns_null_for_nullable_value_type()
+        {
+            _something.NullableCount().ReturnsNull();
+
+            Assert.That(_something.NullableCount(), Is.Null);
+        }
+
+        [Test]
+        public void Returns_null_for_any_args_when_nullable_value_type()
+        {
+            _something.NullableWithParams(2, "test").ReturnsNullForAnyArgs();
+
+            Assert.That(_something.NullableWithParams(123, "something else"), Is.Null);
+        }
+
+        [Test]
+        public void Returns_null_for_task_of_null_value_type()
+        {
+            _something.NullableCountAsync().ReturnsNull();
+
+            Assert.That(_something.NullableCountAsync(), Is.TypeOf<Task<int?>>());
+            Assert.That(_something.NullableCountAsync().Result, Is.Null);
+        }
+
+        [Test]
+        public void Returns_null_for_any_args_when_task_of_null_value_type()
+        {
+            _something.NullableWithParamsAsync(2, "test").ReturnsNullForAnyArgs();
+
+            Assert.That(_something.NullableWithParamsAsync(123, "something else"), Is.TypeOf<Task<int?>>());
+            Assert.That(_something.NullableWithParamsAsync(123, "something else").Result, Is.Null);
+        }
+
+        [Test]
+        public void Returns_null_for_TaskValue_for_null_value_type()
+        {
+            _something.NullableCountValueTaskAsync().ReturnsNull();
+
+            Assert.That(_something.NullableCountValueTaskAsync(), Is.TypeOf<ValueTask<int?>>());
+            Assert.That(_something.NullableCountValueTaskAsync().Result, Is.Null);
+        }
+
+        [Test]
+        public void Returns_null_for_any_args_when_TaskValue_is_of_null_value_type()
+        {
+            _something.NullableCountValueTaskWithParamsAsync(2, "test").ReturnsNullForAnyArgs();
+
+            Assert.That(_something.NullableCountValueTaskWithParamsAsync(123, "something else"),
+                Is.TypeOf<ValueTask<int?>>());
+            Assert.That(_something.NullableCountValueTaskWithParamsAsync(123, "something else").Result, Is.Null);
+        }
+
         [SetUp]
         public void SetUp()
         {


### PR DESCRIPTION
Currently, you are not able to `ReturnsNull()` on nullable value types (eg. `int?` and `Guid?`), and when wrapped in tasks they will throw a nullref, such as:

```cs
var foo = Substitute.For<IFoo>();
foo.Bar().ReturnsNull();
Console.WriteLine(await foo.Bar());

public interface IFoo
{
    public Task<int?> Bar();
}
```

This PR should help fix this by extending the extension methods to handle nullable value types, along with wrapping them in `Task` and `ValueTask` types when necessary.

I have written unit tests such that it tests for nullability on the newly added functionality, please let me know if more thorough tests are needed.

_**Note:** `ReturnsNull()` will still throw a nullref if the value type inside of a `Task` is NOT nullable._

Thank you!