### PR TITLE
Feature: Extend PartsOf to mock non-virtual methods implementing an i…

### DIFF
--- a/src/NSubstitute/Core/IProxyFactory.cs
+++ b/src/NSubstitute/Core/IProxyFactory.cs
@@ -2,5 +2,5 @@ namespace NSubstitute.Core;
 
 public interface IProxyFactory
 {
-    object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments);
+    object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, bool isPartial, object?[]? constructorArguments);
 }

--- a/src/NSubstitute/Core/SubstituteFactory.cs
+++ b/src/NSubstitute/Core/SubstituteFactory.cs
@@ -14,7 +14,7 @@ public class SubstituteFactory(ISubstituteStateFactory substituteStateFactory, I
     /// <returns></returns>
     public object Create(Type[] typesToProxy, object?[] constructorArguments)
     {
-        return Create(typesToProxy, constructorArguments, callBaseByDefault: false);
+        return Create(typesToProxy, constructorArguments, callBaseByDefault: false, isPartial: false);
     }
 
     /// <summary>
@@ -33,10 +33,10 @@ public class SubstituteFactory(ISubstituteStateFactory substituteStateFactory, I
             throw new CanNotPartiallySubForInterfaceOrDelegateException(primaryProxyType);
         }
 
-        return Create(typesToProxy, constructorArguments, callBaseByDefault: true);
+        return Create(typesToProxy, constructorArguments, callBaseByDefault: true, isPartial: true);
     }
 
-    private object Create(Type[] typesToProxy, object?[] constructorArguments, bool callBaseByDefault)
+    private object Create(Type[] typesToProxy, object?[] constructorArguments, bool callBaseByDefault, bool isPartial)
     {
         var substituteState = substituteStateFactory.Create(this);
         substituteState.CallBaseConfiguration.CallBaseByDefault = callBaseByDefault;
@@ -46,7 +46,7 @@ public class SubstituteFactory(ISubstituteStateFactory substituteStateFactory, I
 
         var callRouter = callRouterFactory.Create(substituteState, canConfigureBaseCalls);
         var additionalTypes = typesToProxy.Where(x => x != primaryProxyType).ToArray();
-        var proxy = proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, constructorArguments);
+        var proxy = proxyFactory.GenerateProxy(callRouter, primaryProxyType, additionalTypes, isPartial, constructorArguments);
         return proxy;
     }
 

--- a/src/NSubstitute/Exceptions/TypeForwardingException.cs
+++ b/src/NSubstitute/Exceptions/TypeForwardingException.cs
@@ -1,0 +1,21 @@
+﻿namespace NSubstitute.Exceptions;
+
+public abstract class TypeForwardingException(string message) : SubstituteException(message)
+{
+}
+
+public sealed class CanNotForwardCallsToClassNotImplementingInterfaceException(Type type) : TypeForwardingException(DescribeProblem(type))
+{
+    private static string DescribeProblem(Type type)
+    {
+        return string.Format("The provided class '{0}' doesn't implement all requested interfaces. ", type.Name);
+    }
+}
+
+public sealed class CanNotForwardCallsToAbstractClassException(Type type) : TypeForwardingException(DescribeProblem(type))
+{
+    private static string DescribeProblem(Type type)
+    {
+        return string.Format("The provided class '{0}' is abstract. ", type.Name);
+    }
+}

--- a/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
+++ b/src/NSubstitute/Proxies/CastleDynamicProxy/CastleInvocationMapper.cs
@@ -10,8 +10,7 @@ public class CastleInvocationMapper(ICallFactory callFactory, IArgumentSpecifica
         Func<object>? baseMethod = null;
         if (castleInvocation.InvocationTarget != null &&
             castleInvocation.MethodInvocationTarget.IsVirtual &&
-            !castleInvocation.MethodInvocationTarget.IsAbstract &&
-            !castleInvocation.MethodInvocationTarget.IsFinal)
+            !castleInvocation.MethodInvocationTarget.IsAbstract)
         {
             baseMethod = CreateBaseResultInvocation(castleInvocation);
         }

--- a/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
+++ b/src/NSubstitute/Proxies/DelegateProxy/DelegateProxyFactory.cs
@@ -8,9 +8,9 @@ public class DelegateProxyFactory(CastleDynamicProxyFactory objectProxyFactory) 
 {
     private readonly CastleDynamicProxyFactory _castleObjectProxyFactory = objectProxyFactory ?? throw new ArgumentNullException(nameof(objectProxyFactory));
 
-    public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
+    public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, bool isPartial, object?[]? constructorArguments)
     {
         // Castle factory can now resolve delegate proxies as well.
-        return _castleObjectProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments);
+        return _castleObjectProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, isPartial, constructorArguments);
     }
 }

--- a/src/NSubstitute/Proxies/ProxyFactory.cs
+++ b/src/NSubstitute/Proxies/ProxyFactory.cs
@@ -5,11 +5,11 @@ namespace NSubstitute.Proxies;
 [Obsolete("This class is deprecated and will be removed in future versions of the product.")]
 public class ProxyFactory(IProxyFactory delegateFactory, IProxyFactory dynamicProxyFactory) : IProxyFactory
 {
-    public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, object?[]? constructorArguments)
+    public object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, bool isPartial, object?[]? constructorArguments)
     {
         var isDelegate = typeToProxy.IsDelegate();
         return isDelegate
-            ? delegateFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments)
-            : dynamicProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, constructorArguments);
+            ? delegateFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, isPartial, constructorArguments)
+            : dynamicProxyFactory.GenerateProxy(callRouter, typeToProxy, additionalInterfaces, isPartial, constructorArguments);
     }
 }

--- a/src/NSubstitute/Substitute.cs
+++ b/src/NSubstitute/Substitute.cs
@@ -89,4 +89,24 @@ public static class Substitute
         var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
         return (T)substituteFactory.CreatePartial([typeof(T)], constructorArguments);
     }
+
+    /// <summary>
+    /// Creates a proxy for a class that implements an interface, forwarding methods and properties to an instance of the class, effectively mimicking a real instance.
+    /// Both the interface and the class must be provided as parameters.
+    /// The proxy will log calls made to the interface members and delegate them to an instance of the class. Specific members can be substituted 
+    /// by using <see cref="WhenCalled{T}.DoNotCallBase()">When(() => call).DoNotCallBase()</see> or by
+    /// <see cref="SubstituteExtensions.Returns{T}(T,T,T[])">setting a value to return value</see> for that member.
+    /// This extension supports sealed classes and non-virtual members, with some limitations. Since the substituted method is non-virtual, internal calls within the object will invoke the original implementation and will not be logged.
+    /// </summary>
+    /// <typeparam name="TInterface">The interface the substitute will implement.</typeparam>
+    /// <typeparam name="TClass">The class type implementing the interface. Must be a class; not a delegate or interface. </typeparam>
+    /// <param name="constructorArguments"></param>
+    /// <returns>An object implementing the selected interface. Calls will be forwarded to the actuall methods, but allows parts to be selectively 
+    /// overridden via `Returns` and `When..DoNotCallBase`.</returns>
+    public static TInterface ForTypeForwardingTo<TInterface, TClass>(params object[] constructorArguments)
+        where TInterface : class
+    {
+        var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
+        return (TInterface)substituteFactory.CreatePartial([typeof(TInterface), typeof(TClass)], constructorArguments);
+    }
 }

--- a/tests/NSubstitute.Acceptance.Specs/SubbingForConcreteTypesAndMultipleInterfaces.cs
+++ b/tests/NSubstitute.Acceptance.Specs/SubbingForConcreteTypesAndMultipleInterfaces.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -29,6 +30,30 @@ public class SubbingForConcreteTypesAndMultipleInterfaces
 
         sub.Received().Number();
         subAsIFirst.Received().First();
+    }
+
+    [Test]
+    public void Can_sub_for_abstract_type_and_implement_other_two_interfaces()
+    {
+        // test from docs
+        var substitute = Substitute.For([typeof(IFirst), typeof(ISecond), typeof(ClassWithCtorArgs)],
+            ["hello world", 5]);
+
+        ClassicAssert.IsInstanceOf<IFirst>(substitute);
+        ClassicAssert.IsInstanceOf<ISecond>(substitute);
+        ClassicAssert.IsInstanceOf<ClassWithCtorArgs>(substitute);
+    }
+
+    [Test]
+    public void Can_sub_for_concrete_type_and_implement_other_two_interfaces()
+    {
+        // test from docs
+        var substitute = Substitute.For([typeof(IFirst), typeof(ISecond), typeof(ConcreteClassWithCtorArgs)],
+            ["hello world", 5]);
+
+        ClassicAssert.IsInstanceOf<IFirst>(substitute);
+        ClassicAssert.IsInstanceOf<ISecond>(substitute);
+        ClassicAssert.IsInstanceOf<ConcreteClassWithCtorArgs>(substitute);
     }
 
     [Test]
@@ -90,8 +115,13 @@ public class SubbingForConcreteTypesAndMultipleInterfaces
         public virtual int Number() { return -1; }
         public int GetNumberPlusOne() { return Number() + 1; }
     }
+
     public abstract class ClassWithCtorArgs(string s, int a)
     {
         public string StringFromCtorArg { get; set; } = s; public int IntFromCtorArg { get; set; } = a;
+    }
+
+    public class ConcreteClassWithCtorArgs(string s, int a) : ClassWithCtorArgs(s, a)
+    {
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/TypeForwarding.cs
+++ b/tests/NSubstitute.Acceptance.Specs/TypeForwarding.cs
@@ -1,0 +1,104 @@
+﻿using NSubstitute.Exceptions;
+using NSubstitute.Extensions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs;
+
+public class TypeForwarding
+{
+    [Test]
+    public void UseImplementedNonVirtualMethod()
+    {
+        var testAbstractClass = Substitute.ForTypeForwardingTo<ITestInterface, TestSealedNonVirtualClass>();
+        Assert.That(testAbstractClass.MethodReturnsSameInt(1), Is.EqualTo(1));
+        Assert.That(testAbstractClass.CalledTimes, Is.EqualTo(1));
+        testAbstractClass.Received().MethodReturnsSameInt(1);
+        Assert.That(testAbstractClass.CalledTimes, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void UseSubstitutedNonVirtualMethod()
+    {
+        var testInterface = Substitute.ForTypeForwardingTo<ITestInterface, TestSealedNonVirtualClass>();
+        testInterface.Configure().MethodReturnsSameInt(1).Returns(2);
+        Assert.That(testInterface.MethodReturnsSameInt(1), Is.EqualTo(2));
+        Assert.That(testInterface.MethodReturnsSameInt(3), Is.EqualTo(3));
+        testInterface.ReceivedWithAnyArgs(2).MethodReturnsSameInt(default);
+        Assert.That(testInterface.CalledTimes, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void UseSubstitutedNonVirtualMethodHonorsDoNotCallBase()
+    {
+        var testInterface = Substitute.ForTypeForwardingTo<ITestInterface, TestSealedNonVirtualClass>();
+        testInterface.Configure().MethodReturnsSameInt(1).Returns(2);
+        testInterface.WhenForAnyArgs(x => x.MethodReturnsSameInt(default)).DoNotCallBase();
+        Assert.That(testInterface.MethodReturnsSameInt(1), Is.EqualTo(2));
+        Assert.That(testInterface.MethodReturnsSameInt(3), Is.EqualTo(0));
+        testInterface.ReceivedWithAnyArgs(2).MethodReturnsSameInt(default);
+        Assert.That(testInterface.CalledTimes, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void PartialSubstituteCallsConstructorWithParameters()
+    {
+        var testInterface = Substitute.ForTypeForwardingTo<ITestInterface, TestSealedNonVirtualClass>(50);
+        Assert.That(testInterface.MethodReturnsSameInt(1), Is.EqualTo(1));
+        Assert.That(testInterface.CalledTimes, Is.EqualTo(51));
+    }
+
+    [Test]
+    public void PartialSubstituteFailsIfClassDoesntImplementInterface()
+    {
+        Assert.Throws<CanNotForwardCallsToClassNotImplementingInterfaceException>(
+            () => Substitute.ForTypeForwardingTo<ITestInterface, TestRandomConcreteClass>());
+    }
+
+    [Test]
+    public void PartialSubstituteFailsIfClassIsAbstract()
+    {
+        Assert.Throws<CanNotForwardCallsToAbstractClassException>(
+            () => Substitute.ForTypeForwardingTo<ITestInterface, TestAbstractClassWithInterface>(), "The provided class is abstract.");
+    }
+
+    public interface ITestInterface
+    {
+        public int CalledTimes { get; set; }
+
+        void VoidTestMethod();
+        int TestMethodReturnsInt();
+        int MethodReturnsSameInt(int i);
+    }
+
+    public sealed class TestSealedNonVirtualClass : ITestInterface
+    {
+        public TestSealedNonVirtualClass(int initialCounter) => CalledTimes = initialCounter;
+        public TestSealedNonVirtualClass() { }
+
+        public int CalledTimes { get; set; }
+
+        public int TestMethodReturnsInt() => throw new NotImplementedException();
+
+        public void VoidTestMethod() => throw new NotImplementedException();
+        public int MethodReturnsSameInt(int i)
+        {
+            CalledTimes++;
+            return i;
+        }
+    }
+
+    public abstract class TestAbstractClassWithInterface : ITestInterface
+    {
+        public int CalledTimes { get; set; }
+
+        public abstract int MethodReturnsSameInt(int i);
+
+        public abstract int TestMethodReturnsInt();
+
+        public abstract void VoidTestMethod();
+    }
+
+    public class TestRandomConcreteClass { }
+
+    public abstract class TestAbstractClass { }
+}


### PR DESCRIPTION
Hi 

I was in need of a feature allowing PartsOf to mock non-virtual methods implementing an interface, just the same as requested in #625.

I decided to tinker a bit to see If there was any way of doing it. Solution came out faster than expected and here are the results. I thought you might find it useful enough to include it.

In short, Castle already provides this feature and the task was, mostly, opening a way to expose it without breaking anything.

How to use:
~~`var substitute = Substitute.ForPartsOf<ISomeInterface,SomeImplementation>(argsList);`~~
`var substitute = Substitute.ForTypeForwardingTo<ISomeInterface,SomeImplementation>(argsList);`

Tests are included, of course, to see it in action.

#### Obvious limitations: 

Overriding virtual methods effectively replaces its implementation both for internal and external calls. With this implementation Nsubstitute will only intercept calls made by client classes using the interface. Calls made from inside the object itself to its own method will hit the actual implementation.

#### Possible improvements

The next logical improvement is to provide mocking for already created objects conforming to an interface. Something like this:

```
ISomeInterface  someObject = new SomeClass();
ISomeInterface substitute = Substitute.ForInstanceForwardingTo<ISomeInterface>(someObject);
```

Please kindly take a look and give your feedback! Thanks!