### PR TITLE
Upgrade System.Threading.Tasks.Extensions to v4.4.0

### DIFF
--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetIsNet5OrNewer)' != 'true'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0-*" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Because netstandard2.0 is not supported by System.Threading.Tasks.Extensions v4.3.0.

We need to target netstandard2.0 for use with Unity3D.