### PR TITLE
Make NSubContainer configurable

### DIFF
--- a/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
+++ b/src/NSubstitute/Core/DependencyInjection/NSubstituteDefaultFactory.cs
@@ -11,11 +11,11 @@ namespace NSubstitute.Core.DependencyInjection
         /// The default NSubstitute registrations. Feel free to configure the existing container to customize
         /// and override NSubstitute parts.
         /// </summary>
-        public static INSubContainer DefaultContainer { get; } = CreateDefaultContainer();
+        public static IConfigurableNSubContainer DefaultContainer { get; } = CreateDefaultContainer();
 
         public static ISubstitutionContext CreateSubstitutionContext() => DefaultContainer.Resolve<ISubstitutionContext>();
 
-        private static INSubContainer CreateDefaultContainer()
+        private static IConfigurableNSubContainer CreateDefaultContainer()
         {
             return new NSubContainer()
                 .RegisterSingleton<SequenceNumberGenerator, SequenceNumberGenerator>()


### PR DESCRIPTION
This allows us to follow the open/closed principle by just overriding specific classes.

**Use case:** I am using Unity, and in Unity, we often use a `UniTask` instead of a `Task`, so I needed to override `IAutoValueProvidersFactory` with my own providers factory which would then register a custom `IAutoValueProvider`, but I didn't want to override anything else.

_On another note, I didn't find a default `IAutoValueProvider` for `ValueTask` either - is this intentional?_

Currently I am just casting, but that breaks encapsulation. It'd be better if we exposed the interface directly, as made in this pull request.

I don't see it as a bad thing to expose more, since it is used for testing.