### PR TITLE
Update target frameworks for .NET 6, .NET Framework 4.6.2, .NET Standard 2.0

### DIFF
--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -1,3 +1,6 @@
+4.5.0 Release
+Now suported platfroms are .NET 6+, .NET Framework 4.6.2+, .NET Standard 2.0
+
 4.0.0 Release
 ================
 

--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -1,4 +1,4 @@
-4.5.0 Release
+5.0.0 Release
 Now suported platfroms are .NET 6+, .NET Framework 4.6.2+, .NET Standard 2.0
 
 4.0.0 Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 5.0.0
+### 5.0.0 (Pending)
 * [UPDATE][BREAKING] Drop unsupported platfroms. Now suported platfroms are .NET 6+, .NET Framework 4.6.2+, .NET Standard 2.0
 
 ### 4.4.0 (Jul 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.5.0
+* [UPDATE][BREAKING] Drop unsupported platfroms. Now suported platfroms are .NET 6+, .NET Framework 4.6.2+, .NET Standard 2.0
+
 ### 4.4.0 (Jul 2022)
 * [FIX] Fix issue checking for constructor args on null object. Thanks to @phongphanq, and @appel1! Thanks also to 
 @Mandroide for code review. (#683, #685)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-### unreleased
-* [NEW] Add `.ThrowsAsync()` that will correctly mock exception on async methods. (#609)
+### 4.4.0 (Jul 2022)
+* [FIX] Fix issue checking for constructor args on null object. Thanks to @phongphanq, and @appel1! Thanks also to 
+@Mandroide for code review. (#683, #685)
+* [UPDATE] Update to Castle Core v5. Thanks @Havunen! (#690, #673)
+* [NEW] Add `.ThrowsAsync()` that will correctly mock exception on async methods. Thanks @Socolin! (#609, #663)
 
 ### 4.3.0 (Jan 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 4.5.0
+### 5.0.0
 * [UPDATE][BREAKING] Drop unsupported platfroms. Now suported platfroms are .NET 6+, .NET Framework 4.6.2+, .NET Standard 2.0
 
 ### 4.4.0 (Jul 2022)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
-    <TargetIsNet5OrNewer Condition="'$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">true</TargetIsNet5OrNewer>
+    <TargetIsNet5OrNewer Condition="'$(TargetFramework)' == 'net6.0'">true</TargetIsNet5OrNewer>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -166,19 +166,16 @@ target "TestCodeFromDocs" <| fun _ ->
     let csproj = """
         <Project Sdk="Microsoft.NET.Sdk">
           <PropertyGroup>
-            <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+            <TargetFrameworks>net6.0;net462</TargetFrameworks>
             <LangVersion>latest</LangVersion>
           </PropertyGroup>
           <ItemGroup>
-            <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-            <PackageReference Include="NUnit" Version="3.8.1" />
-            <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+            <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+            <PackageReference Include="NUnit" Version="3.13.3" />
+            <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
           </ItemGroup>
           <ItemGroup>
             <ProjectReference Include="..\..\..\src\NSubstitute\NSubstitute.csproj" />
-          </ItemGroup>
-          <ItemGroup>
-            <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
           </ItemGroup>
     </Project>
     """

--- a/docs/help/_posts/2015-01-01-how-nsub-works.markdown
+++ b/docs/help/_posts/2015-01-01-how-nsub-works.markdown
@@ -46,14 +46,34 @@ If `DoStuffWith(string s)` is not `virtual`, the `SubstituteForOriginal` class w
 
 This can cause all sorts of problems if we accidentally attempt to configure a non-virtual call, because NSubstitute will get confused about which call you're talking about. Usually this will result in a run-time error, but in the worst case it can affect the outcome of your test, or even the following test in the suite, in non-obvious ways. Thankfully we have [NSubstitute.Analyzers](/help/nsubstitute-analysers) to detect these cases at compile time.
 
-### Internal members
+### Internal members and types
 
-Similar limitations apply to `internal virtual` members. Because `SubstituteForOriginal` gets generated in a separate assembly, `internal` members are invisible to NSubstitute by default. There are two ways to solve this:
+Similar limitations apply to `internal` members and types. Because `SubstituteForOriginal` gets generated in a separate assembly, they are invisible to NSubstitute and your test-assembly by default. There are two ways to solve this:
 
-* Use `[assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)]` in the test assembly so that the `internal` member can be overridden.
-* Make the member [`protected internal virtual`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/protected-internal) so that sub-classes can access the member.
+The first possibility is to change the visibility of the member or type that shall be substituted. If you change the visibility of members to [`protected internal`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/protected-internal), they get _visible_ for types that derive from it. The visibility of `internal` types must be set to [`public`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/public). However, keep in mind that changing visibilities should be well considered. The next alternative has less side effects on the maintainability of your project.
 
-Remember that if the member is non-virtual, NSubstitute will not be able to intercept it regardless of whether it is `internal` or `InternalsVisibleTo` has been added.
+The second possibility is to make the `internal` members and types visible to your test-assembly and to the library that NSubstitute uses under the hood. For this you need to _allow_ specific assemblies to accesss the `internal`s. You can do this by either adding an attribute to the assembly that contains the `internal`s or add an annotation to your project file.
+
+#### Option 1. Use an assembly attribute
+Add the following code to an arbitrary `.cs`-file of the project that contains the `internal` types.
+```
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("name of the assembly that contains your tests")]
+```
+
+#### Option 2. Use a tag in the project file (works with .NET 5 and above)
+Add an `ItemGroup` that contains the `InternalsVisibleTo`-element beneath the `Project`-element in your `.csproj`-file.
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  ...
+  <ItemGroup>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="name of the assembly that contains your tests" />
+  </ItemGroup>
+</Project>
+```
+
+Remember that if members are non-virtual, NSubstitute will not be able to intercept it regardless of whether it is `internal` or `InternalsVisibleTo` has been added.
 
 The good news is that [NSubstitute.Analyzers](/help/nsubstitute-analysers) will also detect attempts to use `internal` members at compile time, and will suggest fixes for these cases.
 

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -11,31 +11,22 @@
     <PackageProjectUrl>https://nsubstitute.github.io/</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\docs\images\nsubstitute-100x100.png" Pack="true" PackagePath="icon.png" Visible="false" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0-*" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0-*" />
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetIsNetFx)' == 'true'">
-    <PackageReference Include="Castle.Core" Version="4.4.1-*" />
+  <ItemGroup Condition="'$(TargetIsNet5OrNewer)' != 'true'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetIsNet5OrNewer)' == 'true'">
-    <PackageReference Include="Castle.Core" Version="5.0.0-*" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);SYSTEM_REFLECTION_CUSTOMATTRIBUTES_IS_ARRAY</DefineConstants>
-  </PropertyGroup>
-
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -57,10 +48,6 @@
     <!-- CS8632 - The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. -->
     <NoWarn Condition="'$(TargetIsNet5OrNewer)' != 'true'">$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0-*" Condition="'$(TargetIsNet5OrNewer)' != 'true'" />
-  </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetIsNet5OrNewer)' == 'true'">
     <DefineConstants>$(DefineConstants);SYSTEM_DIAGNOSTICS_CODEANALYSIS_NULLABILITY</DefineConstants>

--- a/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
+++ b/src/NSubstitute/Routing/Handlers/ReturnFromAndConfigureDynamicCall.cs
@@ -1,8 +1,6 @@
-using System;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using NSubstitute.Core;
+using System;
+using System.Runtime.CompilerServices;
 
 namespace NSubstitute.Routing.Handlers
 {
@@ -39,12 +37,7 @@ namespace NSubstitute.Routing.Handlers
             }
 
             bool isDynamic;
-#if SYSTEM_REFLECTION_CUSTOMATTRIBUTES_IS_ARRAY
             isDynamic = returnParameter.GetCustomAttributes(DynamicAttributeType, inherit: false).Length != 0;
-#else
-            var customAttributes = returnParameter.GetCustomAttributes(DynamicAttributeType, inherit: false);
-            isDynamic = customAttributes != null && customAttributes.Any();
-#endif
             return isDynamic;
         }
 

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net46;net45;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
@@ -20,6 +20,10 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -18,12 +18,4 @@
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-  </ItemGroup>
-
 </Project>

--- a/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
+++ b/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
 What's changed?
- Target frameworks now: .NET 6, .NET Framework 4.6.2, .NET Standard 2.0
- Update some nuget packages

Why target frameworks were changed?

Microsoft recommend to target .NET 6, .NET Standard and minimal supported .NET Framework
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/older-framework-versions-dropped
Castle.Core now have similar list of supported platforms
https://www.nuget.org/packages/castle.core/#dependencies-body-tab


Notes:
.NET Framework 4.6.1 is out of support, .NET Framework 4.6.2 is the older version that is still supported
https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/

.NET 5 is out of support
https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/

.NET Core 3.1 is out of support
https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/

