### PR TITLE
Implemented Arg.Is matcher and generic constraints

### DIFF
--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -14,7 +14,7 @@ namespace NSubstitute
     /// </summary>
     public static class Arg
     {
-        public class AnyType
+        public interface AnyType
         {
         }
 
@@ -47,9 +47,9 @@ namespace NSubstitute
         /// Match argument that satisfies <paramref name="predicate"/>.
         /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
         /// </summary>
-        public static ref AnyType Is<T>(Expression<Predicate<object>> predicate) where T : AnyType
+        public static ref T Is<T>(Expression<Predicate<object>> predicate) where T : AnyType
         {
-            return ref ArgumentMatcher.Enqueue<AnyType>(new ExpressionArgumentMatcher<object>(predicate));
+            return ref ArgumentMatcher.Enqueue<T>(new ExpressionArgumentMatcher<object>(predicate));
         }
 
         /// <summary>
@@ -114,9 +114,9 @@ namespace NSubstitute
         /// Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
         /// whenever a matching call is made to the substitute.
         /// </summary>
-        public static ref AnyType Do<T>(Action<object> useArgument) where T : AnyType
+        public static ref T Do<T>(Action<object> useArgument) where T : AnyType
         {
-            return ref ArgumentMatcher.Enqueue<AnyType>(new AnyArgumentMatcher(typeof(AnyType)), x => useArgument(x!));
+            return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(AnyType)), x => useArgument(x!));
         }
 
         /// <summary>

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -44,6 +44,15 @@ namespace NSubstitute
         }
 
         /// <summary>
+        /// Match argument that satisfies <paramref name="predicate"/>.
+        /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+        /// </summary>
+        public static ref AnyType Is<T>(Expression<Predicate<object>> predicate) where T : AnyType
+        {
+            return ref ArgumentMatcher.Enqueue<AnyType>(new ExpressionArgumentMatcher<object>(predicate));
+        }
+
+        /// <summary>
         /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
         /// </summary>
         public static ref Action Invoke()
@@ -140,6 +149,14 @@ namespace NSubstitute
             /// if possible use <see cref="Arg.Is{T}(Expression{Predicate{T}})" /> instead.
             /// </summary>
             public static T Is<T>(Expression<Predicate<T>> predicate) => Arg.Is(predicate);
+
+            /// <summary>
+            /// Match argument that satisfies <paramref name="predicate"/>.
+            /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            /// This is provided for compatibility with older compilers --
+            /// if possible use <see cref="Arg.Is{T}(Expression{Predicate{T}})" /> instead.
+            /// </summary>
+            public static AnyType Is<T>(Expression<Predicate<object>> predicate) where T : AnyType => Arg.Is<T>(predicate);
 
             /// <summary>
             /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -14,6 +14,13 @@ namespace NSubstitute
     /// </summary>
     public static class Arg
     {
+        /// <summary>
+        /// This type can be used with any matcher to match a generic type parameter.
+        /// </summary>
+        /// <remarks>
+        /// If the generic type parameter has constraints, you will have to create a derived class/struct that
+        /// implements those constraints.
+        /// </remarks>
         public interface AnyType
         {
         }

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -51,6 +51,14 @@ namespace NSubstitute.Compatibility
         public T Is<T>(Expression<Predicate<T>> predicate) => Arg.Is(predicate);
 
         /// <summary>
+        /// Match argument that satisfies <paramref name="predicate"/>.
+        /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+        /// This is provided for compatibility with older compilers --
+        /// if possible use <see cref="Arg.Is{T}(Expression{Predicate{object}})" /> instead.
+        /// </summary>
+        public Arg.AnyType Is<T>(Expression<Predicate<object>> predicate) where T : Arg.AnyType => Arg.Is<T>(predicate);
+
+        /// <summary>
         /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
         /// This is provided for compatibility with older compilers --
         /// if possible use <see cref="Arg.Invoke" /> instead.

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -78,7 +78,7 @@ namespace NSubstitute.Core
 	            var second = bArgs[i];
 
                 var areEquivalent = first.IsAssignableFrom(second) || second.IsAssignableFrom(first) ||
-                                    first == typeof(Arg.AnyType) || second == typeof(Arg.AnyType);
+                                    typeof(Arg.AnyType).IsAssignableFrom(first) || typeof(Arg.AnyType).IsAssignableFrom(second);
 	            if (!areEquivalent) return false;
 	        }
 	        return true;

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -14,7 +14,7 @@ namespace NSubstitute.Core
         /// </summary>
         public static bool IsCompatibleWith(this object? instance, Type type)
         {
-            if (type == typeof(Arg.AnyType))
+            if (typeof(Arg.AnyType).IsAssignableFrom(type))
             {
                 return true;
             }

--- a/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
@@ -10,6 +10,7 @@ public class GenericArguments
     public interface ISomethingWithGenerics
     {
         void SomeAction<TState>(int level, TState state);
+        string SomeFunction<TState>(int level, TState state);
     }
 
     [Test]
@@ -53,5 +54,17 @@ public class GenericArguments
         something.SomeAction(7, 3409);
 
         Assert.That(argDoResult, Is.EqualTo(">>340,900.00 %"));
+    }
+
+    [Test]
+    public void Is_matcher_works_with_AnyType()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+
+        something.SomeFunction(Arg.Any<int>(), Arg.Is<Arg.AnyType>(a => (int)a == 3409)).Returns("matched");
+
+        var result = something.SomeFunction(7, 3409);
+
+        Assert.That(result, Is.EqualTo("matched"));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using NUnit.Framework;
 
@@ -11,6 +12,14 @@ public class GenericArguments
     {
         void SomeAction<TState>(int level, TState state);
         string SomeFunction<TState>(int level, TState state);
+        void SomeActionWithGenericConstraints<TState>(int level, TState state) where TState : IEnumerable<int>;
+        string SomeFunctionWithGenericConstraints<TState>(int level, TState state) where TState : IEnumerable<int>;
+    }
+
+    public abstract class MyAnyType : IEnumerable<int>, Arg.AnyType
+    {
+        public abstract IEnumerator<int> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     [Test]
@@ -64,6 +73,62 @@ public class GenericArguments
         something.SomeFunction(Arg.Any<int>(), Arg.Is<Arg.AnyType>(a => (int)a == 3409)).Returns("matched");
 
         var result = something.SomeFunction(7, 3409);
+
+        Assert.That(result, Is.EqualTo("matched"));
+    }
+
+    [Test]
+    public void Any_matcher_works_with_AnyType_and_constraints()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        var state = new[] {3409};
+        something.SomeActionWithGenericConstraints(7, state);
+
+        something.Received().SomeActionWithGenericConstraints(Arg.Any<int>(), Arg.Any<MyAnyType>());
+        something.Received().SomeActionWithGenericConstraints(7, state);
+    }
+
+    [Test]
+    public void When_Do_works_with_AnyType_and_constraints()
+    {
+        int[] whenDoResult = null;
+        bool whenDoCalled = false;
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something
+            .When(substitute => substitute.SomeActionWithGenericConstraints(Arg.Any<int>(), Arg.Any<MyAnyType>()))
+            .Do(info =>
+            {
+                whenDoResult = info.ArgAt<int[]>(1);
+                whenDoCalled = true;
+            });
+
+        var expected = new[] {3409};
+        something.SomeActionWithGenericConstraints(7, expected);
+
+        Assert.That(whenDoCalled, Is.True);
+        Assert.That(whenDoResult, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ArgDo_works_with_AnyType_and_constraints()
+    {
+        string argDoResult = null;
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something.SomeActionWithGenericConstraints(Arg.Any<int>(), Arg.Do<MyAnyType>(a => argDoResult = ">>" + ((int[])a)[0].ToString("P", CultureInfo.InvariantCulture)));
+
+        something.SomeActionWithGenericConstraints(7, new[] {3409});
+
+        Assert.That(argDoResult, Is.EqualTo(">>340,900.00 %"));
+    }
+
+    [Test]
+    public void Is_matcher_works_with_AnyType_and_constraints()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+
+        something.SomeFunctionWithGenericConstraints(Arg.Any<int>(), Arg.Is<MyAnyType>(a => ((int[])a)[0] == 3409)).Returns("matched");
+
+        var result = something.SomeFunctionWithGenericConstraints(7, new[] {3409});
 
         Assert.That(result, Is.EqualTo("matched"));
     }

--- a/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using NSubstitute.Exceptions;
 using NUnit.Framework;
 
 namespace NSubstitute.Acceptance.Specs;
@@ -11,31 +9,49 @@ public class GenericArguments
 {
     public interface ISomethingWithGenerics
     {
-        void Log<TState>(int level, TState state);
+        void SomeAction<TState>(int level, TState state);
     }
 
     [Test]
-    public void Return_result_for_any_argument()
+    public void Any_matcher_works_with_AnyType()
     {
-        string argDoResult = null;
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+
+        something.SomeAction(7, 3409);
+
+        something.Received().SomeAction(Arg.Any<int>(), Arg.Any<Arg.AnyType>());
+        something.Received().SomeAction(7, 3409);
+    }
+
+    [Test]
+    public void When_Do_works_with_AnyType()
+    {
         int? whenDoResult = null;
         bool whenDoCalled = false;
         ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
-        something.Log(Arg.Any<int>(), Arg.Do<Arg.AnyType>(a => argDoResult = ">>" + ((int)a).ToString("P", CultureInfo.InvariantCulture)));
         something
-            .When(substitute => substitute.Log(Arg.Any<int>(), Arg.Any<Arg.AnyType>()))
+            .When(substitute => substitute.SomeAction(Arg.Any<int>(), Arg.Any<Arg.AnyType>()))
             .Do(info =>
             {
                 whenDoResult = info.ArgAt<int>(1);
                 whenDoCalled = true;
             });
 
-        something.Log(7, 3409);
+        something.SomeAction(7, 3409);
 
-        something.Received().Log(Arg.Any<int>(), Arg.Any<Arg.AnyType>());
-        something.Received().Log(7, 3409);
         Assert.That(whenDoCalled, Is.True);
-        Assert.That(argDoResult, Is.EqualTo(">>340,900.00 %"));
         Assert.That(whenDoResult, Is.EqualTo(3409));
+    }
+
+    [Test]
+    public void ArgDo_works_with_AnyType()
+    {
+        string argDoResult = null;
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something.SomeAction(Arg.Any<int>(), Arg.Do<Arg.AnyType>(a => argDoResult = ">>" + ((int)a).ToString("P", CultureInfo.InvariantCulture)));
+
+        something.SomeAction(7, 3409);
+
+        Assert.That(argDoResult, Is.EqualTo(">>340,900.00 %"));
     }
 }


### PR DESCRIPTION
This PR implements a part of #634.

`Arg.AnyType` does not work when the type we replace has generic constraints. Therefore we converted `AnyType` to an interface so that the user can implement a custom class that satisfies the constraints.

`Arg.Is` matcher was not supported by the former PR (#715).

XML-Doc comments have been added to `Arg.AnyType`.