### PR TITLE
Added .NET 8 to test platforms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
-[*.{sln,csproj,yml}]
+[*.{sln,csproj,fsproj,yml}]
 indent_size = 2
 indent_style = space
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-        framework: [net6.0, net7.0]
+        framework: [net6.0, net7.0, net8.0]
         include:
           - os: windows-latest
             framework: net462
@@ -22,6 +22,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       
       - name: Build
         run: dotnet build
@@ -43,6 +44,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       
       # used for documentation
       - name: Setup Ruby

--- a/NSubstitute.sln
+++ b/NSubstitute.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34309.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSubstitute", "src\NSubstitute\NSubstitute.csproj", "{F59BF5FC-52D8-492E-BDE8-244C183B4C92}"
 EndProject
@@ -11,11 +10,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0E2B9095
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{A8AF7D01-6CE4-47B2-9E23-689A53991C3D}"
 	ProjectSection(SolutionItems) = preProject
-		build\build.fsx = build\build.fsx
-		build\build.sh = build\build.sh
-		build\ExtractDocs.fsx = build\ExtractDocs.fsx
-		build\packages.config = build\packages.config
 		build\build.cmd = build\build.cmd
+		build\build.fs = build\build.fs
+		build\build.sh = build\build.sh
+		build\ExtractDocs.fs = build\ExtractDocs.fs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CA2DD4AA-8DCD-42FB-8081-243281AD2956}"

--- a/build/build.fs
+++ b/build/build.fs
@@ -161,9 +161,9 @@ let initTargets() =
                 <LangVersion>latest</LangVersion>
             </PropertyGroup>
             <ItemGroup>
-                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-                <PackageReference Include="NUnit" Version="3.13.3" />
-                <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+                <PackageReference Include="NUnit" Version="3.14.0" />
+                <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
             </ItemGroup>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\src\NSubstitute\NSubstitute.csproj" />

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <OutputPath>buildOutput</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="build.cmd" />
+    <None Include="build.sh" />
     <Compile Include="ExtractDocs.fs" />
     <Compile Include="build.fs" />
   </ItemGroup>
@@ -21,4 +23,5 @@
     <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
     <PackageReference Include="Fake.Core.Target" Version="6.0.0" />
   </ItemGroup>
+
 </Project>

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">

--- a/tests/NSubstitute.Benchmarks/ActivationBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/ActivationBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class ActivationBenchmark
     {

--- a/tests/NSubstitute.Benchmarks/ArgumentSpecificationUsageBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/ArgumentSpecificationUsageBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class ArgumentSpecificationUsageBenchmark
     {

--- a/tests/NSubstitute.Benchmarks/DispatchConfiguredMatchingCallBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/DispatchConfiguredMatchingCallBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class DispatchConfiguredMatchingCallBenchmark
     {
@@ -17,26 +17,26 @@ namespace NSubstitute.Benchmarks
         {
             _interfaceProxy = Substitute.For<IInterfaceWithSingleMethod>();
             _interfaceProxy.IntMethod("42").Returns(42);
-            _interfaceProxy.When(x => x.VoidMethod("42")).Do(delegate {  });
-            
+            _interfaceProxy.When(x => x.VoidMethod("42")).Do(delegate { });
+
             _abstractClassProxy = Substitute.For<AbstractClassWithSingleMethod>();
             _abstractClassProxy.IntMethod("42").Returns(42);
-            _abstractClassProxy.When(x => x.VoidMethod("42")).Do(delegate {  });
-            
+            _abstractClassProxy.When(x => x.VoidMethod("42")).Do(delegate { });
+
             _classPartialProxy = Substitute.For<ClassWithSingleMethod>();
             _classPartialProxy.IntMethod("42").Returns(42);
-            _classPartialProxy.When(x => x.VoidMethod("42")).Do(delegate {  });
-            
+            _classPartialProxy.When(x => x.VoidMethod("42")).Do(delegate { });
+
             _intDelegateProxy = Substitute.For<IntDelegate>();
             _intDelegateProxy.Invoke("42").Returns(42);
-            
+
             _voidDelegateProxy = Substitute.For<VoidDelegate>();
-            _voidDelegateProxy.When(x => x.Invoke("42")).Do(delegate {  });
+            _voidDelegateProxy.When(x => x.Invoke("42")).Do(delegate { });
         }
 
         [Benchmark]
         public int DispatchInterfaceProxyCall_Int() => _interfaceProxy.IntMethod("42");
-        
+
         [Benchmark]
         public int DispatchAbstractClassProxyCall_Int() => _abstractClassProxy.IntMethod("42");
 
@@ -48,7 +48,7 @@ namespace NSubstitute.Benchmarks
 
         [Benchmark]
         public void DispatchInterfaceProxyCall_Void() => _interfaceProxy.VoidMethod("42");
-        
+
         [Benchmark]
         public void DispatchAbstractClassProxyCall_Void() => _abstractClassProxy.VoidMethod("42");
 

--- a/tests/NSubstitute.Benchmarks/DispatchConfiguredNonMatchingCallBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/DispatchConfiguredNonMatchingCallBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class DispatchConfiguredNonMatchingCallBenchmark
     {

--- a/tests/NSubstitute.Benchmarks/DispatchNonConfiguredCallBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/DispatchNonConfiguredCallBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class DispatchNonConfiguredCallBenchmark
     {
@@ -24,7 +24,7 @@ namespace NSubstitute.Benchmarks
 
         [Benchmark]
         public int DispatchInterfaceProxyCall_Int() => _interfaceProxy.IntMethod(null);
-        
+
         [Benchmark]
         public int DispatchAbstractClassProxyCall_Int() => _abstractClassProxy.IntMethod(null);
 
@@ -36,7 +36,7 @@ namespace NSubstitute.Benchmarks
 
         [Benchmark]
         public void DispatchInterfaceProxyCall_Void() => _interfaceProxy.VoidMethod(null);
-        
+
         [Benchmark]
         public void DispatchAbstractClassProxyCall_Void() => _abstractClassProxy.VoidMethod(null);
 

--- a/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
+++ b/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <StartupObject>NSubstitute.Benchmarks.Program</StartupObject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="BenchmarkDotNet.Artifacts\**" />
-    <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
-    <None Remove="BenchmarkDotNet.Artifacts\**" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />
   </ItemGroup>
+  
 </Project>

--- a/tests/NSubstitute.Benchmarks/ToStringCallBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/ToStringCallBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class ToStringCallBenchmark
     {

--- a/tests/NSubstitute.Benchmarks/VerifyReceivedCallBenchmark.cs
+++ b/tests/NSubstitute.Benchmarks/VerifyReceivedCallBenchmark.cs
@@ -3,7 +3,7 @@ using NSubstitute.Benchmarks.TestTypes;
 
 namespace NSubstitute.Benchmarks
 {
-    [ClrJob, CoreJob]
+    [SimpleJob]
     [MemoryDiagnoser]
     public class VerifyReceivedCallBenchmark
     {


### PR DESCRIPTION
Changes:
- Run tests for .NET 8 platform
- Update some tests dependencies
- Fix warnings from NSubstitute.Benchmarks

note: no changes in product, no need to release new nuget packages