### PR TITLE
[CI] Do not build on every push

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,5 +1,9 @@
 name: Build, Test, and Format
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
After the change we will not trigger CI on every push to any branch. It will be done for pushes to main only.