### PR TITLE
Migrate from NUnit 3 to NUnit 4

### DIFF
--- a/tests/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -109,8 +110,8 @@ public class AutoValuesForSubs
     public void Should_auto_return_for_iqueryable()
     {
         var sample = Substitute.For<ISample>();
-        Assert.IsEmpty(sample.Queryable().Select(x => x + 1).ToList());
-        Assert.NotNull(sample.Queryable().Expression);
+        ClassicAssert.IsEmpty(sample.Queryable().Select(x => x + 1).ToList());
+        ClassicAssert.NotNull(sample.Queryable().Expression);
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/CallbackCalling.cs
+++ b/tests/NSubstitute.Acceptance.Specs/CallbackCalling.cs
@@ -1,6 +1,7 @@
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -119,7 +120,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        Assert.AreEqual(new List<int> { 1 }, calls);
+        ClassicAssert.AreEqual(new List<int> { 1 }, calls);
     }
 
     [Test]
@@ -132,7 +133,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        Assert.AreEqual(new List<int> { 1, 2 }, calls);
+        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
     }
 
     [Test]
@@ -149,7 +150,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        Assert.AreEqual(new List<int> { 1, 2 }, calls);
+        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
     }
 
     [Test]
@@ -166,11 +167,11 @@ public class CallbackCalling
         );
 
         _something.Count();
-        Assert.IsTrue(first);
+        ClassicAssert.IsTrue(first);
         _something.Count();
-        Assert.IsTrue(then);
+        ClassicAssert.IsTrue(then);
         _something.Count();
-        Assert.IsTrue(secondThen);
+        ClassicAssert.IsTrue(secondThen);
     }
 
     [Test]
@@ -187,11 +188,11 @@ public class CallbackCalling
         );
 
         _something.Count();
-        Assert.IsTrue(first);
+        ClassicAssert.IsTrue(first);
         _something.Count();
-        Assert.IsTrue(then);
+        ClassicAssert.IsTrue(then);
         _something.Count();
-        Assert.AreEqual(3, callCount);
+        ClassicAssert.AreEqual(3, callCount);
     }
 
     [Test]
@@ -208,10 +209,10 @@ public class CallbackCalling
 
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         var ex = Assert.Throws<Exception>(() => _something.Count());
-        Assert.AreSame(exception, ex);
+        ClassicAssert.AreSame(exception, ex);
 
         _something.Count();
-        Assert.AreEqual(new List<int> { 1 }, calls);
+        ClassicAssert.AreEqual(new List<int> { 1 }, calls);
     }
 
     [Test]
@@ -230,10 +231,10 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         var ex = Assert.Throws<Exception>(() => _something.Count());
-        Assert.AreSame(exception, ex);
+        ClassicAssert.AreSame(exception, ex);
 
         _something.Count();
-        Assert.AreEqual(new List<int> { 1, 2 }, calls);
+        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
     }
 
     [Test]
@@ -250,7 +251,7 @@ public class CallbackCalling
 
         Assert.Throws<Exception>(() => _something.Count());
         Assert.Throws<Exception>(() => _something.Count());
-        Assert.AreEqual(2, callCount);
+        ClassicAssert.AreEqual(2, callCount);
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ClearSubstitute.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ClearSubstitute.cs
@@ -1,6 +1,7 @@
 using NSubstitute.ClearExtensions;
 using NSubstitute.Exceptions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -40,7 +41,7 @@ public class ClearSubstitute
         var substitute = Substitute.For<ICalculator>();
         substitute.Add(1, 1).Returns(12);
         substitute.ClearSubstitute(ClearOptions.ReturnValues);
-        Assert.AreEqual(0, substitute.Add(1, 1));
+        ClassicAssert.AreEqual(0, substitute.Add(1, 1));
     }
 
     [Test]
@@ -53,6 +54,6 @@ public class ClearSubstitute
         substitute.Add(1, 1);
         substitute.Add(1, 1);
         substitute.Add(1, 1);
-        Assert.AreEqual(0, count);
+        ClassicAssert.AreEqual(0, count);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/CompatArgsTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/CompatArgsTests.cs
@@ -1,6 +1,7 @@
-﻿using System.Reflection;
-using NSubstitute.Compatibility;
+﻿using NSubstitute.Compatibility;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Reflection;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -17,7 +18,7 @@ public class CompatArgsTests
         var compatInstanceMembers =
             typeof(CompatArg).GetMethods(flags).Select(DescribeMethod).OrderBy(x => x);
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             compatMembers.ToList(), compatInstanceMembers.ToList(),
             "Arg.Compat and CompatArg should have static/instance versions of the same methods"
             );
@@ -32,7 +33,7 @@ public class CompatArgsTests
         var compatMembers =
             typeof(Arg.Compat).GetMethods(flags).Select(DescribeMethod).OrderBy(x => x);
 
-        Assert.AreEqual(
+        ClassicAssert.AreEqual(
             argMembers.ToList(), compatMembers.ToList(),
             "Arg and Arg.Compat should have the same methods (just vary by out/ref)"
             );

--- a/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
+++ b/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
@@ -1,5 +1,6 @@
 using NSubstitute.Exceptions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -25,7 +26,7 @@ public class EventChecking
         source.Started += () => raised = true;
         source.Started += Raise.Event<Action>();
 
-        Assert.IsTrue(raised);
+        ClassicAssert.IsTrue(raised);
     }
 
     [Test]
@@ -40,9 +41,9 @@ public class EventChecking
         source.Started += () => raised3 = true;
         source.Started += Raise.Event<Action>();
 
-        Assert.IsTrue(raised1, "The first handler was not called");
-        Assert.IsTrue(raised2, "The second handler was not called");
-        Assert.IsTrue(raised3, "The third handler was not called");
+        ClassicAssert.IsTrue(raised1, "The first handler was not called");
+        ClassicAssert.IsTrue(raised2, "The second handler was not called");
+        ClassicAssert.IsTrue(raised3, "The third handler was not called");
     }
 
     public interface IEngine

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/EqualsBehaviourOnClassSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/EqualsBehaviourOnClassSubs.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -10,8 +11,8 @@ public class EqualsBehaviourOnClassSubs
         var firstSub = Substitute.For<AClass>();
         var secondSub = Substitute.For<AClass>();
 
-        Assert.AreEqual(firstSub, firstSub);
-        Assert.AreNotEqual(firstSub, secondSub);
+        ClassicAssert.AreEqual(firstSub, firstSub);
+        ClassicAssert.AreNotEqual(firstSub, secondSub);
     }
 
     public class AClass { }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -16,11 +17,11 @@ public class Issue225_ConfiguredValueIsUsedInSubsequentSetups
         target.Echo(Arg.Is(1)).Returns("10", "11", "12");
 
         // Assert
-        Assert.AreEqual("00", target.Echo(0));
-        Assert.AreEqual("10", target.Echo(1));
-        Assert.AreEqual("01", target.Echo(0));
-        Assert.AreEqual("11", target.Echo(1));
-        Assert.AreEqual("02", target.Echo(0));
-        Assert.AreEqual("12", target.Echo(1));
+        ClassicAssert.AreEqual("00", target.Echo(0));
+        ClassicAssert.AreEqual("10", target.Echo(1));
+        ClassicAssert.AreEqual("01", target.Echo(0));
+        ClassicAssert.AreEqual("11", target.Echo(1));
+        ClassicAssert.AreEqual("02", target.Echo(0));
+        ClassicAssert.AreEqual("12", target.Echo(1));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue271_DelegateOutArgument.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue271_DelegateOutArgument.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -15,6 +16,6 @@ public class Issue271_DelegateOutArgument
 
         foo(out bar);
 
-        Assert.AreEqual(42, bar);
+        ClassicAssert.AreEqual(42, bar);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -24,7 +25,7 @@ public class Issue282_MultipleReturnValuesParallelism
 
         var results = Task.WhenAll(runningTask1, runningTask2).Result;
 
-        Assert.Contains(ret1, results);
-        Assert.Contains(ret2, results);
+        ClassicAssert.Contains(ret1, results);
+        ClassicAssert.Contains(ret2, results);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -29,7 +30,7 @@ public class Issue291_CannotReconfigureThrowingConfiguration
 
         // Assert
         Assert.Throws<InvalidOperationException>(() => deliver.Send(new Message1()));
-        Assert.AreSame(response, deliver.Send(new Message2()));
+        ClassicAssert.AreSame(response, deliver.Send(new Message2()));
     }
 
     [Test]
@@ -44,6 +45,6 @@ public class Issue291_CannotReconfigureThrowingConfiguration
 
         // Assert
         Assert.Throws<InvalidOperationException>(() => something.Echo(100));
-        Assert.AreEqual("42", something.Echo(42));
+        ClassicAssert.AreEqual("42", something.Echo(42));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue372_InterfaceSameNameOfMethods.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue372_InterfaceSameNameOfMethods.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -22,6 +23,6 @@ public class Issue372_InterfaceSameNameOfMethods
     public void Should_create_substitute()
     {
         var sut = Substitute.For<X>();
-        Assert.NotNull(sut);
+        ClassicAssert.NotNull(sut);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue59_ArgDoWithReturns.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue59_ArgDoWithReturns.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -21,9 +22,9 @@ public class Issue59_ArgDoWithReturns
         sub.Say("hello").Returns("world");
         var resultOfHowdy = sub.Say("howdy");
 
-        Assert.AreEqual("", resultOfHowdy);
-        Assert.AreEqual("howdy", lastArgUsedInCallToSayMethod);
-        Assert.AreEqual("world", sub.Say("hello"));
+        ClassicAssert.AreEqual("", resultOfHowdy);
+        ClassicAssert.AreEqual("howdy", lastArgUsedInCallToSayMethod);
+        ClassicAssert.AreEqual("world", sub.Say("hello"));
     }
 
     [Test]
@@ -36,8 +37,8 @@ public class Issue59_ArgDoWithReturns
         sub.Name = "Jane";
         sub.Name.Returns("Bob");
 
-        Assert.AreEqual("Jane", name);
-        Assert.AreEqual("Bob", sub.Name);
+        ClassicAssert.AreEqual("Jane", name);
+        ClassicAssert.AreEqual("Bob", sub.Name);
     }
 
     [Test]
@@ -51,7 +52,7 @@ public class Issue59_ArgDoWithReturns
 
         sub.Name.Returns("Bob");
 
-        Assert.AreEqual("Jane", name);
-        Assert.AreEqual("Bob", sub.Name);
+        ClassicAssert.AreEqual("Jane", name);
+        ClassicAssert.AreEqual("Bob", sub.Name);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue61_ArgAnyStringRegression.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue61_ArgAnyStringRegression.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -12,6 +13,6 @@ public class ArgAnyStringRegression
         var foo = Substitute.For<IFoo>();
         foo.Bar(Arg.Any<string>(), Arg.Any<double>()).ReturnsForAnyArgs("hello");
 
-        Assert.AreEqual("hello", foo.Bar(null, 0));
+        ClassicAssert.AreEqual("hello", foo.Bar(null, 0));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Acceptance.Specs/OutAndRefParameters.cs
+++ b/tests/NSubstitute.Acceptance.Specs/OutAndRefParameters.cs
@@ -1,5 +1,6 @@
 using NSubstitute.Exceptions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 

--- a/tests/NSubstitute.Acceptance.Specs/PartialSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/PartialSubs.cs
@@ -2,6 +2,7 @@
 using NSubstitute.Exceptions;
 using NSubstitute.Extensions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -31,7 +32,7 @@ public class PartialSubs
         var testAbstractClass = Substitute.ForPartsOf<TestAbstractClass>();
         testAbstractClass.VoidAbstractMethod();
         var result = testAbstractClass.AbstractMethodReturnsSameInt(123);
-        Assert.AreEqual(0, result);
+        ClassicAssert.AreEqual(0, result);
     }
 
     [Test]
@@ -90,7 +91,7 @@ public class PartialSubs
     public void ReturnDefaultForUnimplementedAbstractMethod()
     {
         var testAbstractClass = Substitute.ForPartsOf<TestAbstractClass>();
-        Assert.AreEqual(default(int), testAbstractClass.AbstractMethodReturnsSameInt(1));
+        ClassicAssert.AreEqual(default(int), testAbstractClass.AbstractMethodReturnsSameInt(1));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
@@ -1,6 +1,7 @@
 using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 

--- a/tests/NSubstitute.Acceptance.Specs/ReturnsAndDoes.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReturnsAndDoes.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -44,8 +45,8 @@ public class ReturnsAndDoes
         var result2 = sub.GetBar(9999);
         Assert.That(wasCalled, Is.True);
         Assert.That(argsUsed, Is.EquivalentTo(new[] { 42, 9999 }));
-        Assert.AreSame(result1, bar);
-        Assert.AreSame(result2, bar);
+        ClassicAssert.AreSame(result1, bar);
+        ClassicAssert.AreSame(result2, bar);
     }
 
     [Test]
@@ -59,7 +60,7 @@ public class ReturnsAndDoes
         sub.When(x => x.GetBar(2)).Do(x => calledViaWhenDo = true);
         sub.GetBar(Arg.Do<int>(x => calledViaArgDo = true));
 
-        Assert.False(calledViaAndDoes && calledViaArgDo && calledViaWhenDo);
+        ClassicAssert.False(calledViaAndDoes && calledViaArgDo && calledViaWhenDo);
 
         sub.GetBar(2);
 

--- a/tests/NSubstitute.Acceptance.Specs/SubstitutingForDelegates.cs
+++ b/tests/NSubstitute.Acceptance.Specs/SubstitutingForDelegates.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -36,7 +37,7 @@ public class SubstitutingForDelegates
     {
         var func = Substitute.For<Func<int>>();
         func().Returns(10);
-        Assert.AreEqual(10, func());
+        ClassicAssert.AreEqual(10, func());
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ThrowingAsyncExceptions.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ThrowingAsyncExceptions.cs
@@ -1,6 +1,7 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -36,7 +37,7 @@ public class ThrowingAsyncExceptions
             _something.Async().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.Async());
-            Assert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
         }
 
         [Test]
@@ -47,8 +48,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.Async());
 
-            Assert.IsNotNull(exceptionThrown.InnerException);
-            Assert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
+            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
         }
 
         [Test]
@@ -136,7 +137,7 @@ public class ThrowingAsyncExceptions
             _something.CountAsync().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.CountAsync());
-            Assert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
         }
 
         [Test]
@@ -147,8 +148,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.CountAsync());
 
-            Assert.IsNotNull(exceptionThrown.InnerException);
-            Assert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
+            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
         }
 
         [Test]
@@ -237,7 +238,7 @@ public class ThrowingAsyncExceptions
             _something.CountValueTaskAsync().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<int, Exception>(() => _something.CountValueTaskAsync());
-            Assert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
         }
 
         [Test]
@@ -248,8 +249,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<int, Exception>(() => _something.CountValueTaskAsync());
 
-            Assert.IsNotNull(exceptionThrown.InnerException);
-            Assert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
+            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
         }
 
         [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ThrowingExceptions.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ThrowingExceptions.cs
@@ -1,6 +1,7 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -41,7 +42,7 @@ public class ThrowingExceptions
         _something.Count().Throws(new Exception(exceptionMessage));
 
         Exception exceptionThrown = Assert.Catch<Exception>(() => _something.Count());
-        Assert.AreEqual(exceptionMessage, exceptionThrown.Message);
+        ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
     }
 
     [Test]
@@ -52,8 +53,8 @@ public class ThrowingExceptions
 
         Exception exceptionThrown = Assert.Catch<Exception>(() => _something.Count());
 
-        Assert.IsNotNull(exceptionThrown.InnerException);
-        Assert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+        ClassicAssert.IsNotNull(exceptionThrown.InnerException);
+        ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
     }
 
     [Test]

--- a/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
+++ b/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes:
- Migrate to NUnit4
- Update nuget packages for test projects

note: no changes in product, no need to release new nuget package