### PR TITLE
Add Throws for exceptions to the docs

### DIFF
--- a/build/ExtractDocs.fs
+++ b/build/ExtractDocs.fs
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using NSubstitute.Extensions;
 using NSubstitute.Compatibility;
+using NSubstitute.ExceptionExtensions;
 
 namespace NSubstitute.Samples {
     public class Tests_%s {

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -28,7 +28,7 @@ Assert.Throws<Exception>(() => calculator.Add(-2, -2));
 ```
 
 ### Returns
-Another way is to use the underlying method, `.Returns`. See also [Callbacks](/help/callbacks) 
+Another way is to use the underlying method, `.Returns`. See also [Callbacks](/help/callbacks).
 
 ```csharp
 //For non-voids:

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -15,12 +15,12 @@ The `Throws` and `ThrowsAsync` helpers in the namespace NSubstitute.ExceptionExt
 
 ```csharp
 //For non-voids:
-calculator.Add(-1, -1).Throws(new Exception()); // Or .Throws<Exception>();
+calculator.Add(-1, -1).Throws(new Exception()); // Or .Throw<Exception>() - don't use Throw*s*
 
 //For voids and non-voids:
 calculator
     .When(x => x.Add(-2, -2))
-    .Throw(x => new Exception()); // Or .Throws<Exception>();
+    .Throw(x => new Exception()); // Or .Throw<Exception>(); 
 
 //Both calls will now throw.
 Assert.Throws<Exception>(() => calculator.Add(-1, -1));

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -5,7 +5,6 @@ layout: post
 
 <!--
 ```requiredcode
-using NSubstitute.ExceptionExtensions;
 public interface ICalculator { int Add(int a, int b); }
 ICalculator calculator;
 [SetUp] public void SetUp() { calculator = Substitute.For<ICalculator>(); }

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -11,7 +11,7 @@ ICalculator calculator;
 ```
 -->
 
-The `Throws` and `ThrowsAsync` helpers in the namespace NSubstitute.ExceptionExtensions could be use d
+The `Throws` and `ThrowsAsync` helpers in the `NSubstitute.ExceptionExtensions` namespace can be used to throw exceptions when a member is called.
 
 ```csharp
 //For non-voids:

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -3,8 +3,6 @@ title: Throwing exceptions
 layout: post
 ---
 
-The `Throws` and `ThrowsAsync` helpers in the namespace NSubstitute.ExceptionExtensions could be use d
-
 <!--
 ```requiredcode
 public interface ICalculator { int Add(int a, int b); }
@@ -13,6 +11,7 @@ ICalculator calculator;
 ```
 -->
 
+The `Throws` and `ThrowsAsync` helpers in the namespace NSubstitute.ExceptionExtensions could be use d
 
 ```csharp
 //For non-voids:
@@ -30,14 +29,6 @@ Assert.Throws<Exception>(() => calculator.Add(-2, -2));
 
 ### Returns
 Another way is to use the underlying method, `.Returns`. See also [Callbacks](/help/callbacks) 
-
-<!--
-```requiredcode
-public interface ICalculator { int Add(int a, int b); }
-ICalculator calculator;
-[SetUp] public void SetUp() { calculator = Substitute.For<ICalculator>(); }
-```
--->
 
 ```csharp
 //For non-voids:

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -15,7 +15,7 @@ The `Throws` and `ThrowsAsync` helpers in the `NSubstitute.ExceptionExtensions` 
 
 ```csharp
 //For non-voids:
-calculator.Add(-1, -1).Throws(new Exception()); // Or .Throw<Exception>()
+calculator.Add(-1, -1).Throws(new Exception()); // Or .Throws<Exception>()
 
 //For voids and non-voids:
 calculator

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -15,12 +15,12 @@ The `Throws` and `ThrowsAsync` helpers in the `NSubstitute.ExceptionExtensions` 
 
 ```csharp
 //For non-voids:
-calculator.Add(-1, -1).Throws(new Exception()); // Or .Throw<Exception>() - don't use Throw*s*
+calculator.Add(-1, -1).Throws(new Exception()); // Or .Throw<Exception>()
 
 //For voids and non-voids:
 calculator
     .When(x => x.Add(-2, -2))
-    .Throw(x => new Exception()); // Or .Throw<Exception>(); 
+    .Throw(x => new Exception()); // Or .Throw<Exception>() -  - don't use .Throw*s* in this case
 
 //Both calls will now throw.
 Assert.Throws<Exception>(() => calculator.Add(-1, -1));

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -28,9 +28,8 @@ Assert.Throws<Exception>(() => calculator.Add(-1, -1));
 Assert.Throws<Exception>(() => calculator.Add(-2, -2));
 ```
 
-
 ### Returns
-Another way is to use the underlyning method, .Returns. See also [Callbacks](/help/callbacks) 
+Another way is to use the underlying method, `.Returns`. See also [Callbacks](/help/callbacks) 
 
 <!--
 ```requiredcode

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -5,6 +5,7 @@ layout: post
 
 <!--
 ```requiredcode
+using NSubstitute.ExceptionExtensions;
 public interface ICalculator { int Add(int a, int b); }
 ICalculator calculator;
 [SetUp] public void SetUp() { calculator = Substitute.For<ICalculator>(); }

--- a/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
+++ b/docs/help/_posts/2010-05-02-throwing-exceptions.markdown
@@ -3,7 +3,34 @@ title: Throwing exceptions
 layout: post
 ---
 
-[Callbacks](/help/callbacks) can be used to throw exceptions when a member is called.
+The `Throws` and `ThrowsAsync` helpers in the namespace NSubstitute.ExceptionExtensions could be use d
+
+<!--
+```requiredcode
+public interface ICalculator { int Add(int a, int b); }
+ICalculator calculator;
+[SetUp] public void SetUp() { calculator = Substitute.For<ICalculator>(); }
+```
+-->
+
+
+```csharp
+//For non-voids:
+calculator.Add(-1, -1).Throws(new Exception()); // Or .Throws<Exception>();
+
+//For voids and non-voids:
+calculator
+    .When(x => x.Add(-2, -2))
+    .Throw(x => new Exception()); // Or .Throws<Exception>();
+
+//Both calls will now throw.
+Assert.Throws<Exception>(() => calculator.Add(-1, -1));
+Assert.Throws<Exception>(() => calculator.Add(-2, -2));
+```
+
+
+### Returns
+Another way is to use the underlyning method, .Returns. See also [Callbacks](/help/callbacks) 
 
 <!--
 ```requiredcode


### PR DESCRIPTION
It's confusing that the docs talk about using .Returns, while we have .Throws (not sure from which version)

Not sure what I should do with the date in de post name. Should I update it?

(Please squash on merge PR)

Fixes https://github.com/nsubstitute/NSubstitute/issues/750