### PR TITLE
Improve output for expected argument matchers

### DIFF
--- a/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
@@ -38,6 +38,9 @@ public static class ArgumentMatcher
         protected readonly IArgumentMatcher<T> _matcher = matcher;
 
         public bool IsSatisfiedBy(object? argument) => _matcher.IsSatisfiedBy((T?)argument!);
+
+        public override string ToString() =>
+            (_matcher as IDescribeSpecification)?.DescribeSpecification() ?? _matcher.ToString() ?? "";
     }
 
     private class GenericToNonGenericMatcherProxyWithDescribe<T> : GenericToNonGenericMatcherProxy<T>, IDescribeNonMatches
@@ -48,6 +51,9 @@ public static class ArgumentMatcher
         }
 
         public string DescribeFor(object? argument) => ((IDescribeNonMatches)_matcher).DescribeFor(argument);
+
+        public override string ToString() =>
+            (_matcher as IDescribeSpecification)?.DescribeSpecification() ?? _matcher.ToString() ?? "";
     }
 
     private class DefaultValueContainer<T>

--- a/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
@@ -40,7 +40,9 @@ public static class ArgumentMatcher
         public bool IsSatisfiedBy(object? argument) => _matcher.IsSatisfiedBy((T?)argument!);
 
         public override string ToString() =>
-            (_matcher as IDescribeSpecification)?.DescribeSpecification() ?? _matcher.ToString() ?? "";
+            _matcher is IDescribeSpecification describe
+                ? describe.DescribeSpecification() ?? string.Empty
+                : _matcher.ToString() ?? string.Empty;
     }
 
     private class GenericToNonGenericMatcherProxyWithDescribe<T> : GenericToNonGenericMatcherProxy<T>, IDescribeNonMatches
@@ -51,9 +53,6 @@ public static class ArgumentMatcher
         }
 
         public string DescribeFor(object? argument) => ((IDescribeNonMatches)_matcher).DescribeFor(argument);
-
-        public override string ToString() =>
-            (_matcher as IDescribeSpecification)?.DescribeSpecification() ?? _matcher.ToString() ?? "";
     }
 
     private class DefaultValueContainer<T>

--- a/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecification.cs
@@ -46,7 +46,10 @@ public class ArgumentSpecification(Type forType, IArgumentMatcher matcher, Actio
             : ArgumentFormatter.Default.Format(argument, highlight: !isSatisfiedByArg);
     }
 
-    public override string ToString() => matcher.ToString() ?? string.Empty;
+    public override string ToString() =>
+        matcher is IDescribeSpecification describe
+            ? describe.DescribeSpecification()
+            : matcher.ToString() ?? string.Empty;
 
     public IArgumentSpecification CreateCopyMatchingAnyArgOfType(Type requiredType)
     {

--- a/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentMatcher.cs
@@ -1,8 +1,10 @@
 namespace NSubstitute.Core.Arguments;
 
 /// <summary>
-/// Provides a specification for arguments for use with <see ctype="Arg.Matches (IArgumentMatcher)" />.
-/// Can additionally implement <see cref="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+/// Provides a specification for arguments.
+/// Can implement <see cref="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+/// Can implement <see cref="IDescribeSpecification"/> to give descriptions of expected arguments (otherwise
+/// `ToString()` will be used for descriptions).
 /// </summary>
 public interface IArgumentMatcher
 {
@@ -14,8 +16,10 @@ public interface IArgumentMatcher
 }
 
 /// <summary>
-/// Provides a specification for arguments for use with <see ctype="Arg.Matches &lt; T &gt;(IArgumentMatcher)" />.
-/// Can additionally implement <see ctype="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+/// Provides a specification for arguments.
+/// Can implement <see cref="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+/// Can implement <see cref="IDescribeSpecification"/> to give descriptions of expected arguments (otherwise
+/// `ToString()` will be used for descriptions).
 /// </summary>
 /// <typeparam name="T">Matches arguments of type <typeparamref name="T"/> or compatible type.</typeparam>
 public interface IArgumentMatcher<T>

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -121,7 +121,9 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
 
     public override string ToString()
     {
-        var argSpecsAsStrings = _argumentSpecifications.Select(x => x.ToString() ?? string.Empty).ToArray();
+        var argSpecsAsStrings = _argumentSpecifications.Select(x =>
+            (x as IDescribeSpecification)?.DescribeSpecification() ?? x.ToString() ?? string.Empty
+        ).ToArray();
         return CallFormatter.Default.Format(GetMethodInfo(), argSpecsAsStrings);
     }
 

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -121,9 +121,11 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
 
     public override string ToString()
     {
-        var argSpecsAsStrings = _argumentSpecifications.Select(x =>
-            (x as IDescribeSpecification)?.DescribeSpecification() ?? x.ToString() ?? string.Empty
-        ).ToArray();
+        var argSpecsAsStrings = Array.ConvertAll(_argumentSpecifications, x =>
+            x is IDescribeSpecification describe
+                ? describe.DescribeSpecification() ?? string.Empty
+                : x.ToString() ?? string.Empty
+        );
         return CallFormatter.Default.Format(GetMethodInfo(), argSpecsAsStrings);
     }
 

--- a/src/NSubstitute/Core/IDescribeNonMatches.cs
+++ b/src/NSubstitute/Core/IDescribeNonMatches.cs
@@ -1,5 +1,10 @@
 namespace NSubstitute.Core;
 
+/// <summary>
+/// A type that can describe how an argument does not match a required condition.
+/// Use in conjunction with <see cref="NSubstitute.Core.Arguments.IArgumentMatcher"/> to provide information about
+/// non-matches.
+/// </summary>
 public interface IDescribeNonMatches
 {
     /// <summary>

--- a/src/NSubstitute/Core/IDescribeSpecification.cs
+++ b/src/NSubstitute/Core/IDescribeSpecification.cs
@@ -1,0 +1,16 @@
+namespace NSubstitute.Core;
+
+/// <summary>
+/// A type that can describe the required conditions to meet a specification.
+/// Use in conjunction with <see cref="NSubstitute.Core.Arguments.IArgumentMatcher"/> to provide information about
+/// what it requires to match an argument.
+/// </summary>
+public interface IDescribeSpecification
+{
+
+    /// <summary>
+    /// A concise description of the conditions required to match this specification.
+    /// </summary>
+    /// <returns></returns>
+    string DescribeSpecification();
+}

--- a/src/NSubstitute/Core/IDescribeSpecification.cs
+++ b/src/NSubstitute/Core/IDescribeSpecification.cs
@@ -7,10 +7,10 @@ namespace NSubstitute.Core;
 /// </summary>
 public interface IDescribeSpecification
 {
-
     /// <summary>
-    /// A concise description of the conditions required to match this specification.
+    /// A concise description of the conditions required to match this specification, or <see cref="string.Empty"/>
+    /// if a detailed description can not be provided.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>Description of the specification, or <see cref="string.Empty" /> if no description can be provided.</returns>
     string DescribeSpecification();
 }

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -862,9 +862,19 @@ public class ArgumentMatching
     {
         var ex = Assert.Throws<ReceivedCallsException>(() =>
         {
-            _something.Received().Add(23, ArgumentMatcher.Enqueue(new CustomDescribeSpecMatcher()));
+            _something.Received().Add(23, ArgumentMatcher.Enqueue(new CustomDescribeSpecMatcher("DescribeSpec")));
         });
         Assert.That(ex.Message, Contains.Substring("Add(23, DescribeSpec)"));
+    }
+
+    [Test]
+    public void Should_use_empty_string_for_null_describe_spec_for_custom_arg_matcher_when_implemented()
+    {
+        var ex = Assert.Throws<ReceivedCallsException>(() =>
+        {
+            _something.Received().Add(23, ArgumentMatcher.Enqueue(new CustomDescribeSpecMatcher(null)));
+        });
+        Assert.That(ex.Message, Contains.Substring("Add(23, )"));
     }
 
     class CustomMatcher : IArgumentMatcher, IDescribeNonMatches, IArgumentMatcher<int>
@@ -875,8 +885,8 @@ public class ArgumentMatching
         public override string ToString() => "Custom match";
     }
 
-    class CustomDescribeSpecMatcher : CustomMatcher, IDescribeSpecification
+    class CustomDescribeSpecMatcher(string description) : CustomMatcher, IDescribeSpecification
     {
-        public string DescribeSpecification() => "DescribeSpec";
+        public string DescribeSpecification() => description;
     }
 }


### PR DESCRIPTION
- Add IDescribeSpecification to allow custom arg matchers to provide custom output for "expected to receive" entries.
- Fallback to ToString when IDescribeSpecification not implemented.
- Update code comment docs accordingly.

Closes #796.