### PR TITLE
Remove Visual Studio for Mac from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Assert.That(eventWasRaised);
 
 ### Building
 
-NSubstitute and its tests can be compiled and run using Visual Studio and Visual Studio for Mac. Note that some tests are marked `[Pending]` and are not meant to pass at present, so it is a good idea to exclude tests in the Pending category from test runs.
+NSubstitute and its tests can be compiled and run using Visual Studio, Visual Studio Code or any other editor with .NET support. Note that some tests are marked `[Pending]` and are not meant to pass at present, so it is a good idea to exclude tests in the Pending category from test runs.
 
 There are also build scripts in the `./build` directory for command line builds, and CI configurations in the project root.
 

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -3,7 +3,6 @@ using NSubstitute.Core.Arguments;
 
 // Disable nullability for client API, so it does not affect clients.
 #nullable disable annotations
-#pragma warning disable CS1574
 #pragma warning disable CS0419
 
 namespace NSubstitute;

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -2,7 +2,6 @@
 
 // Disable nullability for client API, so it does not affect clients.
 #nullable disable annotations
-#pragma warning disable CS1574
 #pragma warning disable CS0419
 
 namespace NSubstitute.Compatibility;


### PR DESCRIPTION
- Remove some not needed warning suppressions
- Remove Visual Studio for Mac from readme

Visual Studio for Mac is deprecated
https://devblogs.microsoft.com/visualstudio/visual-studio-for-mac-retirement-announcement/

note: no changes in product, no need to release new nuget package