### PR TITLE
Simplify build matrix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-        framework: [net6.0, net7.0, net8.0]
-        include:
-          - os: windows-latest
-            framework: net462
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +28,7 @@ jobs:
         run: dotnet build
 
       - name: Test
-        run: dotnet test -f ${{ matrix.framework }} --no-build --no-restore
+        run: dotnet test --no-build --no-restore
 
   test-documentation:
     runs-on: windows-latest

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue500_SpecialMethodsWithoutAttribute.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue500_SpecialMethodsWithoutAttribute.cs
@@ -1,6 +1,6 @@
+using NUnit.Framework;
 using System.Reflection;
 using System.Reflection.Emit;
-using NUnit.Framework;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -52,6 +52,7 @@ public class Issue500_SpecialMethodsWithoutAttribute
         var typeBuilder = module.DefineType("TypeWithMissingSpecialAttributes",
             TypeAttributes.Public | TypeAttributes.Abstract);
 
+        typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
         var evBuilder = typeBuilder.DefineEvent(EventName, EventAttributes.None, typeof(EventHandler));
         var evAdder = typeBuilder.DefineMethod(
             $"add_{EventName}",


### PR DESCRIPTION
Changes:
- Simplify build matrix

no need to have pipeline for OS + target framework combination
make sense to run on every OS tests for all target frameworks that supported for OS

why?
- Make build system simpler (less configuration)
- Make build system faster  (just less pipline count)

