### PR TITLE
Arg.Any<Arg.AnyType>() does not match arguments passed by reference (#787)

### DIFF
--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -77,7 +77,7 @@ public class CallSpecification : ICallSpecification
             if (first.IsGenericType && second.IsGenericType
                 && first.GetGenericTypeDefinition() == second.GetGenericTypeDefinition())
             {
-                // both are the same generic type. If their GenericTypeArguments match then they are equivalent 
+                // both are the same generic type. If their GenericTypeArguments match then they are equivalent
                 if (!TypesAreAllEquivalent(first.GenericTypeArguments, second.GenericTypeArguments))
                 {
                     return false;
@@ -85,8 +85,13 @@ public class CallSpecification : ICallSpecification
                 continue;
             }
 
-            var areEquivalent = first.IsAssignableFrom(second) || second.IsAssignableFrom(first) ||
-                                typeof(Arg.AnyType).IsAssignableFrom(first) || typeof(Arg.AnyType).IsAssignableFrom(second);
+            var areAssignable = first.IsAssignableFrom(second) || second.IsAssignableFrom(first);
+            var areAnyTypeAssignable = typeof(Arg.AnyType).IsAssignableFrom(first) ||
+                                       typeof(Arg.AnyType).IsAssignableFrom(second);
+            var areByRefAnyTypeAssignable = first.IsByRef && second.IsByRef &&
+                                            (typeof(Arg.AnyType).IsAssignableFrom(first.GetElementType()) ||
+                                             typeof(Arg.AnyType).IsAssignableFrom(second.GetElementType()));
+            var areEquivalent = areAssignable || areAnyTypeAssignable || areByRefAnyTypeAssignable;
             if (!areEquivalent) return false;
         }
         return true;

--- a/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
@@ -316,6 +316,16 @@ public class ReceivedCalls
         StringAssert.Contains("minInclusive must be >= 0, but was -1.", ex.Message);
     }
 
+    [Test]
+    public void Works_with_byref_generic_parameters()
+    {
+        IMyService service = Substitute.For<IMyService>();
+        MyArgument arg = new();
+        service.MyMethod(ref arg);
+
+        service.Received().MyMethod(ref Arg.Any<Arg.AnyType>());
+    }
+
     public interface ICar
     {
         void Start();
@@ -329,4 +339,11 @@ public class ReceivedCalls
         float GetCapacityInLitres();
         event Action Started;
     }
+
+    public interface IMyService
+    {
+        void MyMethod<T>(ref T argument);
+    }
+
+    public class MyArgument { }
 }


### PR DESCRIPTION
Fixes issue #787.