### PR TITLE
Call forwarding to provided instance for types it has in common with the proxy type.

### DIFF
--- a/src/NSubstitute/Core/IProxyFactory.cs
+++ b/src/NSubstitute/Core/IProxyFactory.cs
@@ -3,4 +3,5 @@ namespace NSubstitute.Core;
 public interface IProxyFactory
 {
     object GenerateProxy(ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, bool isPartial, object?[]? constructorArguments);
+    object GenerateProxy(object targetObject, ICallRouter callRouter, Type typeToProxy, Type[]? additionalInterfaces, bool isPartial, object?[]? constructorArguments);
 }

--- a/src/NSubstitute/Core/ISubstituteFactory.cs
+++ b/src/NSubstitute/Core/ISubstituteFactory.cs
@@ -4,4 +4,5 @@ public interface ISubstituteFactory
 {
     object Create(Type[] typesToProxy, object[] constructorArguments);
     object CreatePartial(Type[] typesToProxy, object[] constructorArguments);
+    object Create(object targetObject, Type[] typesToProxy, object?[] constructorArguments);
 }

--- a/src/NSubstitute/Core/SubstituteFactory.cs
+++ b/src/NSubstitute/Core/SubstituteFactory.cs
@@ -36,6 +36,34 @@ public class SubstituteFactory(ISubstituteStateFactory substituteStateFactory, I
         return Create(typesToProxy, constructorArguments, callBaseByDefault: true, isPartial: true);
     }
 
+    /// <summary>
+    /// Create a substitute for the given types, with calls configured to call the implementation on <paramref name="targetObject"/>
+    /// where possible. (virtual) Parts of the instance can be substituted using
+    /// <see cref="SubstituteExtensions.Returns{T}(T,T,T[])">Returns()</see>.
+    /// </summary>
+    /// <param name="targetObject">The instance whose implementation will be called if a corresponding member from <paramref name="typesToProxy"/> is called.</param>
+    /// <param name="typesToProxy"></param>
+    /// <param name="constructorArguments"></param>
+    /// <returns></returns>
+    public object Create(object targetObject, Type[] typesToProxy, object?[] constructorArguments)
+    {
+        return Create(targetObject, typesToProxy, constructorArguments, callBaseByDefault: false, isPartial: false);
+    }
+
+    private object Create(object targetObject, Type[] typesToProxy, object?[] constructorArguments, bool callBaseByDefault, bool isPartial)
+    {
+        var substituteState = substituteStateFactory.Create(this);
+        substituteState.CallBaseConfiguration.CallBaseByDefault = callBaseByDefault;
+
+        var primaryProxyType = GetPrimaryProxyType(typesToProxy);
+        var canConfigureBaseCalls = callBaseByDefault || CanCallBaseImplementation(primaryProxyType);
+
+        var callRouter = callRouterFactory.Create(substituteState, canConfigureBaseCalls);
+        var additionalTypes = typesToProxy.Where(x => x != primaryProxyType).ToArray();
+        var proxy = proxyFactory.GenerateProxy(targetObject, callRouter, primaryProxyType, additionalTypes, isPartial, constructorArguments);
+        return proxy;
+    }
+
     private object Create(Type[] typesToProxy, object?[] constructorArguments, bool callBaseByDefault, bool isPartial)
     {
         var substituteState = substituteStateFactory.Create(this);

--- a/src/NSubstitute/Substitute.cs
+++ b/src/NSubstitute/Substitute.cs
@@ -109,4 +109,23 @@ public static class Substitute
         var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
         return (TInterface)substituteFactory.CreatePartial([typeof(TInterface), typeof(TClass)], constructorArguments);
     }
+
+    /// <summary>
+    /// Creates a proxy for a class that implements an interface or class, forwarding methods and properties to an instance of the class, effectively mimicking a real instance.
+    /// The proxy will log calls made to the interface and/or virtual class members and delegate them to an instance of the target if it implements them. Specific members can be substituted 
+    /// by using <see cref="WhenCalled{T}.DoNotCallBase()">When(() => call).DoNotCallBase()</see> or by
+    /// <see cref="SubstituteExtensions.Returns{T}(T,T,T[])">setting a value to return value</see> for that member.
+    /// This extension supports sealed classes and non-virtual members, with some limitations. Since the substituted method is non-virtual, internal calls within the object will invoke the original implementation and will not be logged.
+    /// </summary>
+    /// <typeparam name="T">The interface or class the substitute will implement.</typeparam>
+    /// <param name="target">The target instance providing implementation for (parts of) the interface</param>
+    /// <param name="constructorArguments"></param>
+    /// <returns>An object implementing the selected interface or class. Calls will be forwarded to the actual methods if possible, but allows parts to be selectively 
+    /// overridden via `Returns` and `When..DoNotCallBase`.</returns>
+    public static T ForTypeForwardingTo<T>(object target, params object[] constructorArguments)
+        where T : class
+    {
+        var substituteFactory = SubstitutionContext.Current.SubstituteFactory;
+        return (T)substituteFactory.Create(target, [typeof(T)], constructorArguments);
+    }
 }

--- a/tests/NSubstitute.Acceptance.Specs/TypeForwarding.cs
+++ b/tests/NSubstitute.Acceptance.Specs/TypeForwarding.cs
@@ -54,6 +54,17 @@ public class TypeForwarding
             () => Substitute.ForTypeForwardingTo<ITestInterface, TestRandomConcreteClass>());
     }
 
+
+    [Test]
+    public void SubstitutePartialForwarding()
+    {
+        List<int> wrappedInstance = [2];
+        var sub = Substitute.ForTypeForwardingTo<IReadOnlyList<int>>(wrappedInstance);
+        using var _ = Assert.EnterMultipleScope();
+        Assert.That(sub.Count, Is.EqualTo(1));
+        Assert.That(sub[0], Is.EqualTo(2));
+        Assert.That(sub.FirstOrDefault(), Is.EqualTo(2));
+    }
     [Test]
     public void PartialSubstituteFailsIfClassIsAbstract()
     {


### PR DESCRIPTION
This should allow creation of substitute, providing an instance where the substitute will forward all calls the implemented type(s) that are also implemented by that object.