### PR TITLE
Feature: allow interception of any generic method call when using Arg.AnyType

### DIFF
--- a/src/NSubstitute/Core/CallInfo.cs
+++ b/src/NSubstitute/Core/CallInfo.cs
@@ -1,9 +1,9 @@
-using NSubstitute.Exceptions;
 using System.Diagnostics.CodeAnalysis;
+using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core;
 
-public class CallInfo(Argument[] callArguments)
+public class CallInfo(Argument[] callArguments, Type[] genericArguments)
 {
 
     /// <summary>
@@ -34,6 +34,12 @@ public class CallInfo(Argument[] callArguments)
             throw new ArgumentSetWithIncompatibleValueException(index, argument.DeclaredType, value.GetType());
         }
     }
+
+    /// <summary>
+    /// Gets the generic type arguments in case of a generic method call or an empty array otherwise.
+    /// </summary>
+    /// <returns>Array of types of the generic type arguments for this method call</returns>
+    public Type[] GenericArgs() => genericArguments;
 
     /// <summary>
     /// Get the arguments passed to this call.

--- a/src/NSubstitute/Core/CallInfoFactory.cs
+++ b/src/NSubstitute/Core/CallInfoFactory.cs
@@ -5,7 +5,8 @@ public class CallInfoFactory : ICallInfoFactory
     public CallInfo Create(ICall call)
     {
         var arguments = GetArgumentsFromCall(call);
-        return new CallInfo(arguments);
+        var genericArguments = call.GetMethodInfo().GetGenericArguments();
+        return new CallInfo(arguments, genericArguments);
     }
 
     private static Argument[] GetArgumentsFromCall(ICall call)


### PR DESCRIPTION
Allow for interception of any call to a generic method, regardless of used generic argument.
Related to issue [854](https://github.com/nsubstitute/NSubstitute/issues/854)