### PR TITLE
Fix matching generic calls with AnyType when the generic argument is also a generic argument in return type, out or ref parameter

### DIFF
--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -93,7 +93,7 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
     private static bool AreEquivalentDefinitions(MethodInfo a, MethodInfo b)
     {
         return a.IsGenericMethod == b.IsGenericMethod
-               && a.ReturnType == b.ReturnType
+               && TypesAreAllEquivalent([a.ReturnType], [b.ReturnType])
                && a.Name.Equals(b.Name, StringComparison.Ordinal);
     }
 

--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -67,6 +67,15 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
             var first = aArgs[i];
             var second = bArgs[i];
 
+            // Get the element types for ref and out parameters, important for matching calls when Arg.AnyType
+            // is used in combination with ref or out parameters.
+            if (first.HasElementType && !first.IsArray
+                && second.HasElementType && !second.IsArray)
+            {
+                first = first.GetElementType()!;
+                second = second.GetElementType()!;
+            }
+
             if (first.IsGenericType && second.IsGenericType
                 && first.GetGenericTypeDefinition() == second.GetGenericTypeDefinition())
             {

--- a/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/GenericArguments.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Globalization;
 using NUnit.Framework;
 
@@ -11,6 +11,9 @@ public class GenericArguments
     {
         void SomeAction<TState>(int level, TState state);
         string SomeFunction<TState>(int level, TState state);
+        ICollection<TState> SomeFunction<TState>(TState state);
+        bool SomeFunctionWithOut<TState>(out IEnumerable<TState> state);
+        bool SomeFunctionWithRef<TState>(ref IEnumerable<TState> state);
         void SomeActionWithGenericConstraints<TState>(int level, TState state) where TState : IEnumerable<int>;
         string SomeFunctionWithGenericConstraints<TState>(int level, TState state) where TState : IEnumerable<int>;
     }
@@ -130,5 +133,48 @@ public class GenericArguments
         var result = something.SomeFunctionWithGenericConstraints(7, new[] { 3409 });
 
         Assert.That(result, Is.EqualTo("matched"));
+    }
+
+    [Test]
+    public void Returns_works_with_AnyType_for_result_with_AnyType_generic_argument()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something
+            .SomeFunction(Arg.Any<Arg.AnyType>())
+            .Returns(x =>
+            {
+                return default!;
+            });
+
+        ICollection<int> result = something.SomeFunction(7);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void Returns_works_with_AnyType_for_out_parameter_with_AnyType_generic_argument()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something
+            .SomeFunctionWithOut(out Arg.Any<IEnumerable<Arg.AnyType>>())
+            .Returns(true);
+
+        bool result = something.SomeFunctionWithOut(out IEnumerable<int> value);
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void Returns_works_with_AnyType_for_ref_parameter_with_AnyType_generic_argument()
+    {
+        ISomethingWithGenerics something = Substitute.For<ISomethingWithGenerics>();
+        something
+            .SomeFunctionWithRef(ref Arg.Any<IEnumerable<Arg.AnyType>>())
+            .Returns(true);
+
+        IEnumerable<int> refParameter = null;
+        bool result = something.SomeFunctionWithRef(ref refParameter);
+
+        Assert.That(result, Is.True);
     }
 }


### PR DESCRIPTION
Allow matching the following methods with use of `Arg.AnyType`:
``` csharp
IEnumerable<T> SomeMethod<T>()
void SomeMethod<T>(out IEnumerable<T> result)
void SomeMethod<T>(ref IEnumerable<T> result)
```
