### PR TITLE
Migrate documentation samples to NUnit4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UPDATE] Migrate documentation validation from build.fsproj to Roslyn code generator
 * [NEW] Added NuGet Package README file.
 * [UPDATE] Make public api and tests the same for all TFMs
+* [UPDATE] Migrate documentation samples to NUnit4
 
 ### 5.3.0 (October 2024)
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ Assert.That(eventWasRaised);
 
 NSubstitute and its tests can be compiled and run using Visual Studio, Visual Studio Code or any other editor with .NET support. Note that some tests are marked `[Pending]` and are not meant to pass at present, so it is a good idea to exclude tests in the Pending category from test runs.
 
-There are also build scripts in the `./build` directory for command line builds, and CI configurations in the project root.
-
-To do [full builds](https://github.com/nsubstitute/NSubstitute/wiki/Release-procedure) you'll also need Ruby, as the jekyll gem is used to generate the website.
+Release-procedure https://github.com/nsubstitute/NSubstitute/wiki/Release-procedure
 
 ### Other libraries you may be interested in
 

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -19,13 +19,13 @@ Used for mocking parts of the NSubstitute mocking library for testing. It is dis
 Moq is not directly used in NSubstitute, but was a great source of inspiration. Moq pioneered Arrange-Act-Assert (AAA) mocking syntax for .NET, as well as removing the distinction between mocks and stubs, both of which have become important parts of NSubstitute. Moq is available under the BSD license [https://www.opensource.org/licenses/bsd-license.php].
 
 ## Jekyll [https://jekyllrb.com/]
-Static website generator written in Ruby, used for NSubstitute's website and documentation. Distributed under the MIT license [https://www.opensource.org/licenses/bsd-license.php].
+Static website generator written in Ruby, used for NSubstitute's website and documentation. Distributed under the MIT license [https://www.opensource.org/licenses/bsd-license.php]. No longer used sine migration to docfx.
 
 ## SyntaxHighlighter [https://alexgorbatchev.com/SyntaxHighlighter/]
 Open source, JavaScript, client-side code highlighter used for highlighting code samples on the NSubstitute website. Distributed under the MIT License [https://en.wikipedia.org/wiki/MIT_License] and the GPL [https://www.gnu.org/copyleft/lesser.html].
 
 ## FAKE [https://fsharp.github.io/FAKE/]
-FAKE (F# Make) is used for NSubstitute's build. It is inspired by `make` and `rake`. FAKE is distributed under a dual Apache 2 / MS-PL license [https://github.com/fsharp/FAKE/blob/master/License.txt].
+FAKE (F# Make) is used for NSubstitute's build. It is inspired by `make` and `rake`. FAKE is distributed under a dual Apache 2 / MS-PL license [https://github.com/fsharp/FAKE/blob/master/License.txt]. No longer used sine migration to source generators.
 
 ## Microsoft .NET Framework [https://www.microsoft.com/net/]
 NSubstitute is coded in C# and compiled using Microsoft .NET. It can also run and compile under Mono [https://www.mono-project.com], an open source implementation of the open .NET standards for C# and the CLI.

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -3,7 +3,7 @@ The aim of this file is to acknowledge the software projects that have been used
 # Software distributed with/compiled into NSubstitute
 
 ## Castle.Core
-NSubstitute is built on the Castle.Core library, particularly Castle.DynamicProxy which is used for generating proxies for types and intercepting calls made to them so that NSubstitute can record them. 
+NSubstitute is built on the Castle.Core library, particularly Castle.DynamicProxy which is used for generating proxies for types and intercepting calls made to them so that NSubstitute can record them.
 
 Castle.Core is maintained by the Castle Project [https://www.castleproject.org/] and is released under the Apache License, Version 2.0 [https://www.apache.org/licenses/LICENSE-2.0.html].
 
@@ -19,13 +19,13 @@ Used for mocking parts of the NSubstitute mocking library for testing. It is dis
 Moq is not directly used in NSubstitute, but was a great source of inspiration. Moq pioneered Arrange-Act-Assert (AAA) mocking syntax for .NET, as well as removing the distinction between mocks and stubs, both of which have become important parts of NSubstitute. Moq is available under the BSD license [https://www.opensource.org/licenses/bsd-license.php].
 
 ## Jekyll [https://jekyllrb.com/]
-Static website generator written in Ruby, used for NSubstitute's website and documentation. Distributed under the MIT license [https://www.opensource.org/licenses/bsd-license.php]. No longer used sine migration to docfx.
+Static website generator written in Ruby, used for NSubstitute's website and documentation. Distributed under the MIT license [https://www.opensource.org/licenses/bsd-license.php]. No longer used since migration to docfx.
 
 ## SyntaxHighlighter [https://alexgorbatchev.com/SyntaxHighlighter/]
 Open source, JavaScript, client-side code highlighter used for highlighting code samples on the NSubstitute website. Distributed under the MIT License [https://en.wikipedia.org/wiki/MIT_License] and the GPL [https://www.gnu.org/copyleft/lesser.html].
 
 ## FAKE [https://fsharp.github.io/FAKE/]
-FAKE (F# Make) is used for NSubstitute's build. It is inspired by `make` and `rake`. FAKE is distributed under a dual Apache 2 / MS-PL license [https://github.com/fsharp/FAKE/blob/master/License.txt]. No longer used sine migration to source generators.
+FAKE (F# Make) is used for NSubstitute's build. It is inspired by `make` and `rake`. FAKE is distributed under a dual Apache 2 / MS-PL license [https://github.com/fsharp/FAKE/blob/master/License.txt]. No longer used since migration to source generators.
 
 ## Microsoft .NET Framework [https://www.microsoft.com/net/]
 NSubstitute is coded in C# and compiled using Microsoft .NET. It can also run and compile under Mono [https://www.mono-project.com], an open source implementation of the open .NET standards for C# and the CLI.

--- a/docs/help/actions-with-arguments/index.md
+++ b/docs/help/actions-with-arguments/index.md
@@ -84,7 +84,7 @@ calculator.Multiply(Arg.Any<int>(), Arg.Do<int>(x => argumentUsed = x));
 
 calculator.Multiply(123, 42);
 
-Assert.AreEqual(42, argumentUsed);
+Assert.That(argumentUsed, Is.EqualTo(42));
 ```
 
 Here we specify that a call to `Multiply` with any first argument should pass the second argument and put it in the `argumentUsed` variable. This can be quite useful when we want to assert several properties on an argument (for types more complex than `int` that is).
@@ -97,7 +97,7 @@ calculator.Multiply(2, 10);
 calculator.Multiply(5, 10);
 calculator.Multiply(7, 4567); //Will not match our Arg.Do as second arg is not 10
 
-Assert.AreEqual(firstArgsBeingMultiplied, new[] { 2, 5 });
+Assert.That(firstArgsBeingMultiplied, Is.EqualTo(new[] { 2, 5 }));
 ```
 
 Here our `Arg.Do` takes whatever `int` is passed as the first argument to `Multiply` and adds it to a list whenever the second argument is 10.
@@ -124,6 +124,6 @@ var results = new[] {
     calculator.Multiply(123, 2) //First arg greater than 0, so spec won't be met.
 };
 
-Assert.AreEqual(3, numberOfCallsWhereFirstArgIsLessThan0); //3 of 4 calls have first arg < 0
-Assert.AreEqual(results, new[] {123, 123, 123, 0}); //Last call returns 0, not 123
+Assert.That(3, Is.EqualTo(numberOfCallsWhereFirstArgIsLessThan0)); //3 of 4 calls have first arg < 0
+Assert.That(results, Is.EqualTo(new[] {123, 123, 123, 0})); //Last call returns 0, not 123
 ```

--- a/docs/help/argument-matchers/index.md
+++ b/docs/help/argument-matchers/index.md
@@ -48,9 +48,9 @@ An argument of type `T` can be ignored using `Arg.Any<T>()`.
 ```csharp
 calculator.Add(Arg.Any<int>(), 5).Returns(7);
 
-Assert.AreEqual(7, calculator.Add(42, 5));
-Assert.AreEqual(7, calculator.Add(123, 5));
-Assert.AreNotEqual(7, calculator.Add(1, 7));
+Assert.That(calculator.Add(42, 5), Is.EqualTo(7));
+Assert.That(calculator.Add(123, 5), Is.EqualTo(7));
+Assert.That(calculator.Add(1, 7), Is.Not.EqualTo(7));
 ```
 
 In this example we return `7` when adding any number to `5`. We use `Arg.Any<int>()` to tell NSubstitute to ignore the first argument.
@@ -87,11 +87,11 @@ If the condition throws an exception for an argument, then it will be assumed th
 ```csharp
 formatter.Format(Arg.Is<string>(x => x.Length <= 10)).Returns("matched");
 
-Assert.AreEqual("matched", formatter.Format("short"));
-Assert.AreNotEqual("matched", formatter.Format("not matched, too long"));
+Assert.That(formatter.Format("short"), Is.EqualTo("matched"));
+Assert.That(formatter.Format("not matched, too long"), Is.Not.EqualTo("matched"));
 // Will not match because trying to access .Length on null will throw an exception when testing
 // our condition. NSubstitute will assume it does not match and swallow the exception.
-Assert.AreNotEqual("matched", formatter.Format(null));
+Assert.That(formatter.Format(null), Is.Not.EqualTo("matched"));
 ```
 
 ## Matching a specific argument
@@ -121,8 +121,8 @@ calculator
     });
 
 var hasEntry = calculator.LoadMemory(1, out var memoryValue);
-Assert.AreEqual(true, hasEntry);
-Assert.AreEqual(42, memoryValue);
+Assert.That(hasEntry, Is.EqualTo(true));
+Assert.That(memoryValue, Is.EqualTo(42));
 ```
 
 See [Setting out and ref args](/help/setting-out-and-ref-arguments/) for more information on working with `out` and `ref`.
@@ -204,8 +204,8 @@ widgetFactory.Make(Arg.Do<WidgetInfo>(info => testLog2.Add(info.Name)));
 subject.StartWithWidget(new WidgetInfo { Name = "Test Widget" });
 
 /* ASSERT */
-Assert.AreEqual(new[] { "Test Widget" }, testLog);
-Assert.AreEqual(new[] { "Test Widget" }, testLog2);
+Assert.That(testLog, Is.EqualTo(new[] { "Test Widget" }));
+Assert.That(testLog2, Is.EqualTo(new[] { "Test Widget" }));
 ```
 
 ### Modifying values being matched
@@ -288,7 +288,7 @@ public void ManualArgSnapshot() {
     lookup.Add(person);
     person.Name = "Vimes";
 
-    Assert.AreEqual("Carrot", namesAdded[0]);
+    Assert.That(namesAdded[0], Is.EqualTo("Carrot"));
 }
 ```
 

--- a/docs/help/auto-and-recursive-mocks/index.md
+++ b/docs/help/auto-and-recursive-mocks/index.md
@@ -27,9 +27,9 @@ var parser = Substitute.For<INumberParser>();
 factory.Create(',').Returns(parser);
 parser.Parse("an expression").Returns(new[] {1,2,3});
 
-Assert.AreEqual(
+Assert.That(
     factory.Create(',').Parse("an expression"),
-    new[] {1,2,3});
+    Is.EqualTo(new[] {1,2,3}));
 ```
 
 Or we could use the fact that a substitute for type `INumberParser` will automatically be returned for `INumberParserFactory.Create()`:
@@ -38,9 +38,9 @@ Or we could use the fact that a substitute for type `INumberParser` will automat
 var factory = Substitute.For<INumberParserFactory>();
 factory.Create(',').Parse("an expression").Returns(new[] {1,2,3});
 
-Assert.AreEqual(
+Assert.That(
     factory.Create(',').Parse("an expression"),
-    new[] {1,2,3});
+     Is.EqualTo(new[] {1,2,3}));
 ```
 
 Each time a recursively-subbed property or method is called with the same arguments it will return the same substitute. If a method is called with different arguments a new substitute will be returned.
@@ -57,8 +57,8 @@ var firstCall = factory.Create(',');
 var secondCall = factory.Create(',');
 var thirdCallWithDiffArg = factory.Create('x');
 
-Assert.AreSame(firstCall, secondCall);
-Assert.AreNotSame(firstCall, thirdCallWithDiffArg);
+Assert.That(firstCall, Is.SameAs(secondCall));
+Assert.That(firstCall, Is.Not.SameAs(thirdCallWithDiffArg));
 ```
 
 _Note:_ Recursive substitutes will not be created for  non-purely virtual classes, as creating and using classes can have potentially unwanted side-effects. You'll therefore need to create and return these explicitly.
@@ -86,9 +86,9 @@ To get the identity of the `CurrentRequest` to return a certain name, we could m
 ```csharp
 var context = Substitute.For<IContext>();
 context.CurrentRequest.Identity.Name.Returns("My pet fish Eric");
-Assert.AreEqual(
-    "My pet fish Eric",
-    context.CurrentRequest.Identity.Name);
+Assert.That(
+    context.CurrentRequest.Identity.Name,
+    Is.EqualTo("My pet fish Eric"));
 ```
 
 Here `CurrentRequest` is automatically going to return a substitute for `IRequest`, and the `IRequest` substitute will automatically return a substitute for `IIdentity`.
@@ -100,6 +100,7 @@ Properties and methods returning types of `String` or `Array` will automatically
 
 ```csharp
 var identity = Substitute.For<IIdentity>();
-Assert.AreEqual(String.Empty, identity.Name);
-Assert.AreEqual(0, identity.Roles().Length);
+
+Assert.That(identity.Name, Is.EqualTo(String.Empty));
+Assert.That(identity.Roles().Length, Is.EqualTo(0));
 ```

--- a/docs/help/callbacks/index.md
+++ b/docs/help/callbacks/index.md
@@ -25,7 +25,7 @@ calculator
 calculator.Add(7, 3);
 calculator.Add(2, 2);
 calculator.Add(11, -3);
-Assert.AreEqual(counter, 3);
+Assert.That(counter, Is.EqualTo(3));
 ```
 
 The [Return from a function](/help/return-from-function) topic has more information on the arguments passed to the callback.
@@ -51,7 +51,7 @@ public void SayHello() {
 
     foo.SayHello("World");
     foo.SayHello("World");
-    Assert.AreEqual(2, counter);
+    Assert.That(counter, Is.EqualTo(2));
 }
 ```
 
@@ -67,8 +67,8 @@ calculator
     .Do(x => counter++);
 
 var result = calculator.Add(1, 2);
-Assert.AreEqual(3, result);
-Assert.AreEqual(1, counter);
+Assert.That(result, Is.EqualTo(3));
+Assert.That(counter, Is.EqualTo(1));
 ```
 
 ## Per argument callbacks

--- a/docs/help/configure/index.md
+++ b/docs/help/configure/index.md
@@ -25,7 +25,7 @@ calculator.Add(Arg.Any<int>(), Arg.Any<int>()).Returns(x => { throw new Exceptio
 calculator.Configure().Add(1, 2).Returns(3);
 
 // Now both the exception callback and our other return have been configured:
-Assert.AreEqual(3, calculator.Add(1, 2));
+Assert.That(calculator.Add(1, 2), Is.EqualTo(3));
 Assert.Throws<Exception>(() => calculator.Add(-2, -2));
 ```
 

--- a/docs/help/creating-a-substitute/index.md
+++ b/docs/help/creating-a-substitute/index.md
@@ -49,9 +49,9 @@ var substitute = Substitute.For(
     new[] { typeof(ICommand), typeof(ISomeInterface), typeof(SomeClassWithCtorArgs) },
     new object[] { 5, "hello world" }
 );
-Assert.IsInstanceOf<ICommand>(substitute);
-Assert.IsInstanceOf<ISomeInterface>(substitute);
-Assert.IsInstanceOf<SomeClassWithCtorArgs>(substitute);
+Assert.That(substitute, Is.InstanceOf<ICommand>());
+Assert.That(substitute, Is.InstanceOf<ISomeInterface>());
+Assert.That(substitute, Is.InstanceOf<SomeClassWithCtorArgs>());
 ```
 
 <!--
@@ -92,7 +92,7 @@ NSubstitute can also substitute for delegate types by using `Substiute.For<T>()`
 var func = Substitute.For<Func<string>>();
 
 func().Returns("hello");
-Assert.AreEqual("hello", func());
+Assert.That(func(), Is.EqualTo("hello"));
 ```
 
 ## Partial substitutes and test spies

--- a/docs/help/multiple-returns/index.md
+++ b/docs/help/multiple-returns/index.md
@@ -17,9 +17,9 @@ A call can also be configured to return a different value over multiple calls. T
 
 ```csharp
 calculator.Mode.Returns("DEC", "HEX", "BIN");
-Assert.AreEqual("DEC", calculator.Mode);
-Assert.AreEqual("HEX", calculator.Mode);
-Assert.AreEqual("BIN", calculator.Mode);
+Assert.That(calculator.Mode, Is.EqualTo("DEC"));
+Assert.That(calculator.Mode, Is.EqualTo("HEX"));
+Assert.That(calculator.Mode, Is.EqualTo("BIN"));
 ```
 
 This can also be achieved by [returning from a function](/help/return-from-function), but passing multiple values to `Returns()` is simpler and reads better.
@@ -30,8 +30,8 @@ This can also be achieved by [returning from a function](/help/return-from-funct
 
 ```csharp
 calculator.Mode.Returns(x => "DEC", x => "HEX", x => { throw new Exception(); });
-Assert.AreEqual("DEC", calculator.Mode);
-Assert.AreEqual("HEX", calculator.Mode);
+Assert.That(calculator.Mode, Is.EqualTo("DEC"));
+Assert.That(calculator.Mode, Is.EqualTo("HEX"));
 Assert.Throws<Exception>(() => { var result = calculator.Mode; });
 ```
 

--- a/docs/help/raising-events/index.md
+++ b/docs/help/raising-events/index.md
@@ -42,14 +42,14 @@ engine.Idling += (sender, args) => wasCalled = true;
 //Tell the substitute to raise the event with a sender and EventArgs:
 engine.Idling += Raise.EventWith(new object(), new EventArgs());
 
-Assert.True(wasCalled);
+Assert.That(wasCalled);
 ```
 
 In the example above we don't really mind what sender and `EventArgs` our event is raised with, just that it was called. In this case NSubstitute can make our life easier by creating the required arguments for our event handler:
 
 ```csharp
 engine.Idling += Raise.Event();
-Assert.True(wasCalled);
+Assert.That(wasCalled, Is.True);
 ```
 
 ## Raising events when arguments do not have a default constructor
@@ -64,7 +64,7 @@ engine.LowFuelWarning += Raise.EventWith(new LowFuelWarningEventArgs(10));
 //Raise event with specific args and sender:
 engine.LowFuelWarning += Raise.EventWith(new object(), new LowFuelWarningEventArgs(10));
 
-Assert.AreEqual(2, numberOfEvents);
+Assert.That(numberOfEvents, Is.EqualTo(2));
 ```
 
 ## Raising `Delegate` events
@@ -93,5 +93,5 @@ engine.RevvedAt += rpm => revvedAt = rpm;
 
 engine.RevvedAt += Raise.Event<Action<int>>(123);
 
-Assert.AreEqual(123, revvedAt);
+Assert.That(revvedAt, Is.EqualTo(123));
 ```

--- a/docs/help/replacing-return-values/index.md
+++ b/docs/help/replacing-return-values/index.md
@@ -9,7 +9,7 @@ calculator.Mode.Returns("DEC,HEX,OCT");
 calculator.Mode.Returns(x => "???");
 calculator.Mode.Returns("HEX");
 calculator.Mode.Returns("BIN");
-Assert.AreEqual(calculator.Mode, "BIN");
+Assert.That(calculator.Mode, Is.EqualTo("BIN"));
 ```
 
 <!--

--- a/docs/help/return-for-any-args/index.md
+++ b/docs/help/return-for-any-args/index.md
@@ -17,8 +17,8 @@ A call can be configured to return a value regardless of the arguments passed us
 
 ```csharp
 calculator.Add(1, 2).ReturnsForAnyArgs(100);
-Assert.AreEqual(100, calculator.Add(1, 2));
-Assert.AreEqual(100, calculator.Add(-7, 15));
+Assert.That(calculator.Add(1, 2), Is.EqualTo(100));
+Assert.That(calculator.Add(-7, 15), Is.EqualTo(100));
 ```
 
 **Tip!** You can also use the `default` C# keyword for better readability:

--- a/docs/help/return-for-args/index.md
+++ b/docs/help/return-for-args/index.md
@@ -18,16 +18,16 @@ Return values can be configured for different combinations of arguments passed t
 ```csharp
 //Return when first arg is anything and second arg is 5:
 calculator.Add(Arg.Any<int>(), 5).Returns(10);
-Assert.AreEqual(10, calculator.Add(123, 5));
-Assert.AreEqual(10, calculator.Add(-9, 5));
-Assert.AreNotEqual(10, calculator.Add(-9, -9));
+Assert.That(calculator.Add(123, 5), Is.EqualTo(10));
+Assert.That(calculator.Add(-9, 5), Is.EqualTo(10));
+Assert.That(calculator.Add(-9, -9), Is.Not.EqualTo(10));
 
 //Return when first arg is 1 and second arg less than 0:
 calculator.Add(1, Arg.Is<int>(x => x < 0)).Returns(345);
-Assert.AreEqual(345, calculator.Add(1, -2));
-Assert.AreNotEqual(345, calculator.Add(1, 2));
+Assert.That(345, Is.EqualTo(calculator.Add(1, -2)));
+Assert.That(calculator.Add(1, 2), Is.Not.EqualTo(345));
 
 //Return when both args equal to 0:
 calculator.Add(Arg.Is(0), Arg.Is(0)).Returns(99);
-Assert.AreEqual(99, calculator.Add(0, 0));
+Assert.That(99, Is.EqualTo(calculator.Add(0, 0)));
 ```

--- a/docs/help/return-from-function/index.md
+++ b/docs/help/return-from-function/index.md
@@ -63,7 +63,7 @@ calculator
 calculator.Add(7,3);
 calculator.Add(2,2);
 calculator.Add(11,-3);
-Assert.AreEqual(counter, 3);
+Assert.That(counter, Is.EqualTo(3));
 ```
 
 Alternatively the callback can be specified after the `Returns` using `AndDoes`:
@@ -77,5 +77,5 @@ calculator
 
 calculator.Add(7,3);
 calculator.Add(2,2);
-Assert.AreEqual(counter, 2);
+Assert.That(counter, Is.EqualTo(2));
 ```

--- a/docs/help/set-return-value/index.md
+++ b/docs/help/set-return-value/index.md
@@ -31,11 +31,11 @@ This value will be returned every time this call is made. `Returns()` will only 
 ```csharp
 //Make a call return 3:
 calculator.Add(1, 2).Returns(3);
-Assert.AreEqual(calculator.Add(1, 2), 3);
-Assert.AreEqual(calculator.Add(1, 2), 3);
+Assert.That(calculator.Add(1, 2), Is.EqualTo(3));
+Assert.That(calculator.Add(1, 2), Is.EqualTo(3));
 
 //Call with different arguments does not return 3
-Assert.AreNotEqual(calculator.Add(3, 6), 3);
+Assert.That(calculator.Add(3, 6), Is.Not.EqualTo(3));
 ```
 
 ## For properties
@@ -43,10 +43,10 @@ The return value for a property can be set in the same way as for a method, usin
 
 ```csharp
 calculator.Mode.Returns("DEC");
-Assert.AreEqual(calculator.Mode, "DEC");
+Assert.That("DEC", Is.EqualTo(calculator.Mode));
 
 calculator.Mode = "HEX";
-Assert.AreEqual(calculator.Mode, "HEX");
+Assert.That("HEX", Is.EqualTo(calculator.Mode));
 ```
 
 

--- a/docs/help/setting-out-and-ref-arguments/index.md
+++ b/docs/help/setting-out-and-ref-arguments/index.md
@@ -26,8 +26,8 @@ lookup
 var result = lookup.TryLookup("hello", out var value);
 
 //Assert
-Assert.True(result);
-Assert.AreEqual(value, "world!");
+Assert.That(result, Is.True);
+Assert.That("world!", Is.EqualTo(value));
 ```
 
 ## Matching after assignments
@@ -49,10 +49,10 @@ lookup
 // value is "", this will match!
 lookup.TryLookup("hello", out value);
 // Call matches, counter is now 1:
-Assert.AreEqual(1, counter);
+Assert.That(counter, Is.EqualTo(1));
 
 // value is now "assigned" but arg matcher is still looking for "", will NOT match anymore!
 lookup.TryLookup("hello", out value);
 // Call does NOT match anymore, counter is still 1:
-Assert.AreEqual(1, counter);
+Assert.That(counter, Is.EqualTo(1));
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ var calculator = Substitute.For<ICalculator>();
 
 //Set a return value:
 calculator.Add(1, 2).Returns(3);
-Assert.AreEqual(3, calculator.Add(1, 2));
+Assert.That(calculator.Add(1, 2), Is.EqualTo(3));
 
 //Check received calls:
 calculator.Received().Add(1, Arg.Any<int>());

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -1,7 +1,6 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
-using NSubstitute.ExceptionExtensions;
 using NSubstitute.Exceptions;
 using NSubstitute.Extensions;
 using NUnit.Framework;

--- a/tests/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/AutoValuesForSubs.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -110,8 +109,8 @@ public class AutoValuesForSubs
     public void Should_auto_return_for_iqueryable()
     {
         var sample = Substitute.For<ISample>();
-        ClassicAssert.IsEmpty(sample.Queryable().Select(x => x + 1).ToList());
-        ClassicAssert.NotNull(sample.Queryable().Expression);
+        Assert.That(sample.Queryable().Select(x => x + 1).ToList(), Is.Empty);
+        Assert.That(sample.Queryable().Expression, Is.Not.Null);
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/CallbackCalling.cs
+++ b/tests/NSubstitute.Acceptance.Specs/CallbackCalling.cs
@@ -1,7 +1,6 @@
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -120,7 +119,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        ClassicAssert.AreEqual(new List<int> { 1 }, calls);
+        Assert.That(calls, Is.EqualTo(new List<int> { 1 }));
     }
 
     [Test]
@@ -133,7 +132,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
+        Assert.That(calls, Is.EqualTo(new List<int> { 1, 2 }));
     }
 
     [Test]
@@ -150,7 +149,7 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         _something.Count();
-        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
+        Assert.That(calls, Is.EqualTo(new List<int> { 1, 2 }));
     }
 
     [Test]
@@ -167,11 +166,11 @@ public class CallbackCalling
         );
 
         _something.Count();
-        ClassicAssert.IsTrue(first);
+        Assert.That(first, Is.True);
         _something.Count();
-        ClassicAssert.IsTrue(then);
+        Assert.That(then, Is.True);
         _something.Count();
-        ClassicAssert.IsTrue(secondThen);
+        Assert.That(secondThen, Is.True);
     }
 
     [Test]
@@ -188,11 +187,11 @@ public class CallbackCalling
         );
 
         _something.Count();
-        ClassicAssert.IsTrue(first);
+        Assert.That(first, Is.True);
         _something.Count();
-        ClassicAssert.IsTrue(then);
+        Assert.That(then, Is.True);
         _something.Count();
-        ClassicAssert.AreEqual(3, callCount);
+        Assert.That(callCount, Is.EqualTo(3));
     }
 
     [Test]
@@ -209,10 +208,10 @@ public class CallbackCalling
 
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         var ex = Assert.Throws<Exception>(() => _something.Count());
-        ClassicAssert.AreSame(exception, ex);
+        Assert.That(ex, Is.SameAs(exception));
 
         _something.Count();
-        ClassicAssert.AreEqual(new List<int> { 1 }, calls);
+        Assert.That(calls, Is.EqualTo(new List<int> { 1 }));
     }
 
     [Test]
@@ -231,10 +230,10 @@ public class CallbackCalling
         Assert.That(callCount, Is.EqualTo(0), "Should not have been called yet");
         _something.Count();
         var ex = Assert.Throws<Exception>(() => _something.Count());
-        ClassicAssert.AreSame(exception, ex);
+        Assert.That(ex, Is.SameAs(exception));
 
         _something.Count();
-        ClassicAssert.AreEqual(new List<int> { 1, 2 }, calls);
+        Assert.That(calls, Is.EqualTo(new List<int> { 1, 2 }));
     }
 
     [Test]
@@ -251,7 +250,7 @@ public class CallbackCalling
 
         Assert.Throws<Exception>(() => _something.Count());
         Assert.Throws<Exception>(() => _something.Count());
-        ClassicAssert.AreEqual(2, callCount);
+        Assert.That(callCount, Is.EqualTo(2));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ClearSubstitute.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ClearSubstitute.cs
@@ -1,7 +1,6 @@
 using NSubstitute.ClearExtensions;
 using NSubstitute.Exceptions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -41,7 +40,7 @@ public class ClearSubstitute
         var substitute = Substitute.For<ICalculator>();
         substitute.Add(1, 1).Returns(12);
         substitute.ClearSubstitute(ClearOptions.ReturnValues);
-        ClassicAssert.AreEqual(0, substitute.Add(1, 1));
+        Assert.That(substitute.Add(1, 1), Is.EqualTo(0));
     }
 
     [Test]
@@ -54,6 +53,6 @@ public class ClearSubstitute
         substitute.Add(1, 1);
         substitute.Add(1, 1);
         substitute.Add(1, 1);
-        ClassicAssert.AreEqual(0, count);
+        Assert.That(count, Is.EqualTo(0));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/CompatArgsTests.cs
+++ b/tests/NSubstitute.Acceptance.Specs/CompatArgsTests.cs
@@ -1,6 +1,5 @@
 ﻿using NSubstitute.Compatibility;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using System.Reflection;
 
 namespace NSubstitute.Acceptance.Specs;
@@ -20,8 +19,8 @@ public class CompatArgsTests
         var compatInstanceMembers =
             typeof(CompatArg).GetMethods(flags).Select(DescribeMethod).OrderBy(x => x);
 
-        ClassicAssert.AreEqual(
-            compatMembers.ToList(), compatInstanceMembers.ToList(),
+        Assert.That(
+            compatInstanceMembers.ToList(), Is.EqualTo(compatMembers.ToList()),
             "Arg.Compat and CompatArg should have static/instance versions of the same methods"
             );
     }
@@ -35,8 +34,8 @@ public class CompatArgsTests
         var compatMembers =
             typeof(Arg.Compat).GetMethods(flags).Select(DescribeMethod).OrderBy(x => x);
 
-        ClassicAssert.AreEqual(
-            argMembers.ToList(), compatMembers.ToList(),
+        Assert.That(
+            compatMembers.ToList(), Is.EqualTo(argMembers.ToList()),
             "Arg and Arg.Compat should have the same methods (just vary by out/ref)"
             );
     }

--- a/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
+++ b/tests/NSubstitute.Acceptance.Specs/EventChecking.cs
@@ -1,6 +1,5 @@
 using NSubstitute.Exceptions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -26,7 +25,7 @@ public class EventChecking
         source.Started += () => raised = true;
         source.Started += Raise.Event<Action>();
 
-        ClassicAssert.IsTrue(raised);
+        Assert.That(raised, Is.True);
     }
 
     [Test]
@@ -41,9 +40,9 @@ public class EventChecking
         source.Started += () => raised3 = true;
         source.Started += Raise.Event<Action>();
 
-        ClassicAssert.IsTrue(raised1, "The first handler was not called");
-        ClassicAssert.IsTrue(raised2, "The second handler was not called");
-        ClassicAssert.IsTrue(raised3, "The third handler was not called");
+        Assert.That(raised1, Is.True, "The first handler was not called");
+        Assert.That(raised2, Is.True, "The second handler was not called");
+        Assert.That(raised3, Is.True, "The third handler was not called");
     }
 
     public interface IEngine

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/EqualsBehaviourOnClassSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/EqualsBehaviourOnClassSubs.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -11,8 +10,8 @@ public class EqualsBehaviourOnClassSubs
         var firstSub = Substitute.For<AClass>();
         var secondSub = Substitute.For<AClass>();
 
-        ClassicAssert.AreEqual(firstSub, firstSub);
-        ClassicAssert.AreNotEqual(firstSub, secondSub);
+        Assert.That(firstSub, Is.EqualTo(firstSub));
+        Assert.That(secondSub, Is.Not.EqualTo(firstSub));
     }
 
     public class AClass { }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue225_ConfiguredValueIsUsedInSubsequentSetups.cs
@@ -1,6 +1,5 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -17,11 +16,11 @@ public class Issue225_ConfiguredValueIsUsedInSubsequentSetups
         target.Echo(Arg.Is(1)).Returns("10", "11", "12");
 
         // Assert
-        ClassicAssert.AreEqual("00", target.Echo(0));
-        ClassicAssert.AreEqual("10", target.Echo(1));
-        ClassicAssert.AreEqual("01", target.Echo(0));
-        ClassicAssert.AreEqual("11", target.Echo(1));
-        ClassicAssert.AreEqual("02", target.Echo(0));
-        ClassicAssert.AreEqual("12", target.Echo(1));
+        Assert.That(target.Echo(0), Is.EqualTo("00"));
+        Assert.That(target.Echo(1), Is.EqualTo("10"));
+        Assert.That(target.Echo(0), Is.EqualTo("01"));
+        Assert.That(target.Echo(1), Is.EqualTo("11"));
+        Assert.That(target.Echo(0), Is.EqualTo("02"));
+        Assert.That(target.Echo(1), Is.EqualTo("12"));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue271_DelegateOutArgument.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue271_DelegateOutArgument.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -16,6 +15,6 @@ public class Issue271_DelegateOutArgument
 
         foo(out bar);
 
-        ClassicAssert.AreEqual(42, bar);
+        Assert.That(bar, Is.EqualTo(42));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue282_MultipleReturnValuesParallelism.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -25,7 +24,7 @@ public class Issue282_MultipleReturnValuesParallelism
 
         var results = Task.WhenAll(runningTask1, runningTask2).Result;
 
-        ClassicAssert.Contains(ret1, results);
-        ClassicAssert.Contains(ret2, results);
+        Assert.That(results, Does.Contain(ret1));
+        Assert.That(results, Does.Contain(ret2));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue291_CannotReconfigureThrowingConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -30,7 +29,7 @@ public class Issue291_CannotReconfigureThrowingConfiguration
 
         // Assert
         Assert.Throws<InvalidOperationException>(() => deliver.Send(new Message1()));
-        ClassicAssert.AreSame(response, deliver.Send(new Message2()));
+        Assert.That(deliver.Send(new Message2()), Is.SameAs(response));
     }
 
     [Test]
@@ -45,6 +44,6 @@ public class Issue291_CannotReconfigureThrowingConfiguration
 
         // Assert
         Assert.Throws<InvalidOperationException>(() => something.Echo(100));
-        ClassicAssert.AreEqual("42", something.Echo(42));
+        Assert.That(something.Echo(42), Is.EqualTo("42"));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue372_InterfaceSameNameOfMethods.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue372_InterfaceSameNameOfMethods.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -23,6 +22,6 @@ public class Issue372_InterfaceSameNameOfMethods
     public void Should_create_substitute()
     {
         var sut = Substitute.For<X>();
-        ClassicAssert.NotNull(sut);
+        Assert.That(sut, Is.Not.Null);
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue59_ArgDoWithReturns.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue59_ArgDoWithReturns.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -22,9 +21,9 @@ public class Issue59_ArgDoWithReturns
         sub.Say("hello").Returns("world");
         var resultOfHowdy = sub.Say("howdy");
 
-        ClassicAssert.AreEqual("", resultOfHowdy);
-        ClassicAssert.AreEqual("howdy", lastArgUsedInCallToSayMethod);
-        ClassicAssert.AreEqual("world", sub.Say("hello"));
+        Assert.That(resultOfHowdy, Is.Empty);
+        Assert.That(lastArgUsedInCallToSayMethod, Is.EqualTo("howdy"));
+        Assert.That(sub.Say("hello"), Is.EqualTo("world"));
     }
 
     [Test]
@@ -37,8 +36,8 @@ public class Issue59_ArgDoWithReturns
         sub.Name = "Jane";
         sub.Name.Returns("Bob");
 
-        ClassicAssert.AreEqual("Jane", name);
-        ClassicAssert.AreEqual("Bob", sub.Name);
+        Assert.That(name, Is.EqualTo("Jane"));
+        Assert.That(sub.Name, Is.EqualTo("Bob"));
     }
 
     [Test]
@@ -52,7 +51,7 @@ public class Issue59_ArgDoWithReturns
 
         sub.Name.Returns("Bob");
 
-        ClassicAssert.AreEqual("Jane", name);
-        ClassicAssert.AreEqual("Bob", sub.Name);
+        Assert.That(name, Is.EqualTo("Jane"));
+        Assert.That(sub.Name, Is.EqualTo("Bob"));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue61_ArgAnyStringRegression.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue61_ArgAnyStringRegression.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs.FieldReports;
 
@@ -13,6 +12,6 @@ public class ArgAnyStringRegression
         var foo = Substitute.For<IFoo>();
         foo.Bar(Arg.Any<string>(), Arg.Any<double>()).ReturnsForAnyArgs("hello");
 
-        ClassicAssert.AreEqual("hello", foo.Bar(null, 0));
+        Assert.That(foo.Bar(null, 0), Is.EqualTo("hello"));
     }
 }

--- a/tests/NSubstitute.Acceptance.Specs/OutAndRefParameters.cs
+++ b/tests/NSubstitute.Acceptance.Specs/OutAndRefParameters.cs
@@ -1,6 +1,5 @@
 using NSubstitute.Exceptions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -245,8 +244,8 @@ public class OutAndRefParameters
         //Assert that message is like "Expected '98765', but received '12345'".
         key = "98765";
         var exception = Assert.Throws<ReceivedCallsException>(() => lookup.Received().GetWithRef(ref key));
-        StringAssert.Contains("98765", exception.Message);
-        StringAssert.Contains("12345", exception.Message);
+        Assert.That(exception.Message, Does.Contain("98765"));
+        Assert.That(exception.Message, Does.Contain("12345"));
     }
 
     private class Something(ILookupStrings lookup)

--- a/tests/NSubstitute.Acceptance.Specs/PartialSubs.cs
+++ b/tests/NSubstitute.Acceptance.Specs/PartialSubs.cs
@@ -2,7 +2,6 @@
 using NSubstitute.Exceptions;
 using NSubstitute.Extensions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -32,7 +31,7 @@ public class PartialSubs
         var testAbstractClass = Substitute.ForPartsOf<TestAbstractClass>();
         testAbstractClass.VoidAbstractMethod();
         var result = testAbstractClass.AbstractMethodReturnsSameInt(123);
-        ClassicAssert.AreEqual(0, result);
+        Assert.That(result, Is.EqualTo(0));
     }
 
     [Test]
@@ -91,7 +90,7 @@ public class PartialSubs
     public void ReturnDefaultForUnimplementedAbstractMethod()
     {
         var testAbstractClass = Substitute.ForPartsOf<TestAbstractClass>();
-        ClassicAssert.AreEqual(default(int), testAbstractClass.AbstractMethodReturnsSameInt(1));
+        Assert.That(testAbstractClass.AbstractMethodReturnsSameInt(1), Is.EqualTo(default(int)));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReceivedCalls.cs
@@ -1,7 +1,6 @@
 using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -280,7 +279,7 @@ public class ReceivedCalls
         var ex = Assert.Throws<ReceivedCallsException>(() =>
             _car.Received(Quantity.Within(2, 5)).Idle()
         );
-        StringAssert.Contains("between 2 and 5 (inclusive) calls", ex.Message);
+        Assert.That(ex.Message, Does.Contain("between 2 and 5 (inclusive) calls"));
     }
 
     [Test]
@@ -291,7 +290,7 @@ public class ReceivedCalls
         var ex = Assert.Throws<ReceivedCallsException>(() =>
             _car.Received(Quantity.Within(0, 1)).Idle()
         );
-        StringAssert.Contains("between 0 and 1 (inclusive) call", ex.Message);
+        Assert.That(ex.Message, Does.Contain("between 0 and 1 (inclusive) call"));
     }
 
     [Test]
@@ -302,7 +301,7 @@ public class ReceivedCalls
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
             _car.Received(Quantity.Within(3, 2)).Idle()
         );
-        StringAssert.Contains("maxInclusive must be greater than minInclusive (was 2, required > 3).", ex.Message);
+        Assert.That(ex.Message, Does.Contain("maxInclusive must be greater than minInclusive (was 2, required > 3)."));
     }
 
     [Test]
@@ -313,7 +312,7 @@ public class ReceivedCalls
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
             _car.Received(Quantity.Within(-1, 1)).Idle()
         );
-        StringAssert.Contains("minInclusive must be >= 0, but was -1.", ex.Message);
+        Assert.That(ex.Message, Does.Contain("minInclusive must be >= 0, but was -1."));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ReturnsAndDoes.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ReturnsAndDoes.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -45,8 +44,8 @@ public class ReturnsAndDoes
         var result2 = sub.GetBar(9999);
         Assert.That(wasCalled, Is.True);
         Assert.That(argsUsed, Is.EquivalentTo(new[] { 42, 9999 }));
-        ClassicAssert.AreSame(result1, bar);
-        ClassicAssert.AreSame(result2, bar);
+        Assert.That(bar, Is.SameAs(result1));
+        Assert.That(bar, Is.SameAs(result2));
     }
 
     [Test]
@@ -60,7 +59,7 @@ public class ReturnsAndDoes
         sub.When(x => x.GetBar(2)).Do(x => calledViaWhenDo = true);
         sub.GetBar(Arg.Do<int>(x => calledViaArgDo = true));
 
-        ClassicAssert.False(calledViaAndDoes && calledViaArgDo && calledViaWhenDo);
+        Assert.That(calledViaAndDoes && calledViaArgDo && calledViaWhenDo, Is.False);
 
         sub.GetBar(2);
 

--- a/tests/NSubstitute.Acceptance.Specs/SubbingForConcreteTypesAndMultipleInterfaces.cs
+++ b/tests/NSubstitute.Acceptance.Specs/SubbingForConcreteTypesAndMultipleInterfaces.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -39,9 +38,9 @@ public class SubbingForConcreteTypesAndMultipleInterfaces
         var substitute = Substitute.For([typeof(IFirst), typeof(ISecond), typeof(ClassWithCtorArgs)],
             ["hello world", 5]);
 
-        ClassicAssert.IsInstanceOf<IFirst>(substitute);
-        ClassicAssert.IsInstanceOf<ISecond>(substitute);
-        ClassicAssert.IsInstanceOf<ClassWithCtorArgs>(substitute);
+        Assert.That(substitute, Is.InstanceOf<IFirst>());
+        Assert.That(substitute, Is.InstanceOf<ISecond>());
+        Assert.That(substitute, Is.InstanceOf<ClassWithCtorArgs>());
     }
 
     [Test]
@@ -51,9 +50,9 @@ public class SubbingForConcreteTypesAndMultipleInterfaces
         var substitute = Substitute.For([typeof(IFirst), typeof(ISecond), typeof(ConcreteClassWithCtorArgs)],
             ["hello world", 5]);
 
-        ClassicAssert.IsInstanceOf<IFirst>(substitute);
-        ClassicAssert.IsInstanceOf<ISecond>(substitute);
-        ClassicAssert.IsInstanceOf<ConcreteClassWithCtorArgs>(substitute);
+        Assert.That(substitute, Is.InstanceOf<IFirst>());
+        Assert.That(substitute, Is.InstanceOf<ISecond>());
+        Assert.That(substitute, Is.InstanceOf<ConcreteClassWithCtorArgs>());
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/SubstitutingForDelegates.cs
+++ b/tests/NSubstitute.Acceptance.Specs/SubstitutingForDelegates.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -37,7 +36,7 @@ public class SubstitutingForDelegates
     {
         var func = Substitute.For<Func<int>>();
         func().Returns(10);
-        ClassicAssert.AreEqual(10, func());
+        Assert.That(func(), Is.EqualTo(10));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ThrowingAsyncExceptions.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ThrowingAsyncExceptions.cs
@@ -1,7 +1,6 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -37,7 +36,7 @@ public class ThrowingAsyncExceptions
             _something.Async().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.Async());
-            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            Assert.That(exceptionThrown.Message, Is.EqualTo(exceptionMessage));
         }
 
         [Test]
@@ -48,8 +47,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.Async());
 
-            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
-            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            Assert.That(exceptionThrown.InnerException, Is.Not.Null);
+            Assert.That(exceptionThrown.InnerException, Is.InstanceOf<ArgumentException>());
         }
 
         [Test]
@@ -137,7 +136,7 @@ public class ThrowingAsyncExceptions
             _something.CountAsync().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.CountAsync());
-            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            Assert.That(exceptionThrown.Message, Is.EqualTo(exceptionMessage));
         }
 
         [Test]
@@ -148,8 +147,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.CountAsync());
 
-            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
-            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            Assert.That(exceptionThrown.InnerException, Is.Not.Null);
+            Assert.That(exceptionThrown.InnerException, Is.InstanceOf<ArgumentException>());
         }
 
         [Test]
@@ -237,7 +236,7 @@ public class ThrowingAsyncExceptions
             _something.CountValueTaskAsync().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<int, Exception>(() => _something.CountValueTaskAsync());
-            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            Assert.That(exceptionThrown.Message, Is.EqualTo(exceptionMessage));
         }
 
         [Test]
@@ -248,8 +247,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<int, Exception>(() => _something.CountValueTaskAsync());
 
-            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
-            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            Assert.That(exceptionThrown.InnerException, Is.Not.Null);
+            Assert.That(exceptionThrown.InnerException, Is.InstanceOf<ArgumentException>());
         }
 
         [Test]
@@ -319,7 +318,7 @@ public class ThrowingAsyncExceptions
             _something.VoidValueTaskAsync().ThrowsAsync(new Exception(exceptionMessage));
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.VoidValueTaskAsync());
-            ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
+            Assert.That(exceptionThrown.Message, Is.EqualTo(exceptionMessage));
         }
 
         [Test]
@@ -330,8 +329,8 @@ public class ThrowingAsyncExceptions
 
             Exception exceptionThrown = AssertFaultedTaskException<Exception>(() => _something.VoidValueTaskAsync());
 
-            ClassicAssert.IsNotNull(exceptionThrown.InnerException);
-            ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+            Assert.That(exceptionThrown.InnerException, Is.Not.Null);
+            Assert.That(exceptionThrown.InnerException, Is.InstanceOf<ArgumentException>());
         }
 
         [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ThrowingExceptions.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ThrowingExceptions.cs
@@ -1,7 +1,6 @@
 ﻿using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace NSubstitute.Acceptance.Specs;
 
@@ -42,7 +41,7 @@ public class ThrowingExceptions
         _something.Count().Throws(new Exception(exceptionMessage));
 
         Exception exceptionThrown = Assert.Catch<Exception>(() => _something.Count());
-        ClassicAssert.AreEqual(exceptionMessage, exceptionThrown.Message);
+        Assert.That(exceptionThrown.Message, Is.EqualTo(exceptionMessage));
     }
 
     [Test]
@@ -53,8 +52,8 @@ public class ThrowingExceptions
 
         Exception exceptionThrown = Assert.Catch<Exception>(() => _something.Count());
 
-        ClassicAssert.IsNotNull(exceptionThrown.InnerException);
-        ClassicAssert.IsInstanceOf<ArgumentException>(exceptionThrown.InnerException);
+        Assert.That(exceptionThrown.InnerException, Is.Not.Null);
+        Assert.That(exceptionThrown.InnerException, Is.InstanceOf<ArgumentException>());
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
+++ b/tests/NSubstitute.Acceptance.Specs/WhenCalledDo.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using NSubstitute.Acceptance.Specs.Infrastructure;
 using NSubstitute.Core;
 using NUnit.Framework;

--- a/tests/NSubstitute.Documentation.Tests.Generator/DocumentationTestsGenerator.cs
+++ b/tests/NSubstitute.Documentation.Tests.Generator/DocumentationTestsGenerator.cs
@@ -56,7 +56,6 @@ public sealed class DocumentationTestsGenerator : IIncrementalGenerator
             using NUnit.Framework;
             using System.ComponentModel;
             using NSubstitute.Extensions;
-            using NSubstitute.Compatibility;
             using NSubstitute.ExceptionExtensions;
 
             namespace NSubstitute.Documentation.Tests.Generated;

--- a/tests/NSubstitute.Documentation.Tests/NSubstitute.Documentation.Tests.csproj
+++ b/tests/NSubstitute.Documentation.Tests/NSubstitute.Documentation.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Changes:
- Migrate documentation samples to NUnit4
- Update readme
- Update acknowledgements
- Remove NUnit.Framework.Legacy from tests
- Enable NRE for ProtectedExtensions.cs