### PR TITLE
Fix typo in return value documentation

### DIFF
--- a/docs/help/set-return-value/index.md
+++ b/docs/help/set-return-value/index.md
@@ -51,4 +51,4 @@ Assert.That("HEX", Is.EqualTo(calculator.Mode));
 
 
 ## More ways of setting return values
-This covers the very basics of setting a return value, but NSubstitute can do much more. Read on for other approachs, including [matching specific arguments](/help/return-for-args), [ignoring arguments](/help/return-for-any-args), using [functions to calculate return values](/help/return-from-function) and returning [multiple results](/help/multiple-returns).
+This covers the very basics of setting a return value, but NSubstitute can do much more. Read on for other approaches, including [matching specific arguments](/help/return-for-args), [ignoring arguments](/help/return-for-any-args), using [functions to calculate return values](/help/return-from-function) and returning [multiple results](/help/multiple-returns).


### PR DESCRIPTION
This:

> Read on for other **approachs**...

Should read:

> Read on for other **approaches**...