### PR TITLE
Remove TestingPlatformDotnetTestSupport for test projects

### DIFF
--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net10.0;net9.0;net8.0;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NSubstitute.Documentation.Tests/NSubstitute.Documentation.Tests.csproj
+++ b/tests/NSubstitute.Documentation.Tests/NSubstitute.Documentation.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net10.0;net9.0;net8.0;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes:
- Remove `TestingPlatformDotnetTestSupport` for test projects

Why?
- NUnit3TestAdapter version 6.0.0+ support MTP mode, vstest mode adapter no longer needed