### PR TITLE
Added test for DefaultInterfacesImplementation

### DIFF
--- a/tests/NSubstitute.Acceptance.Specs/DefaultInterfacesImplementations.cs
+++ b/tests/NSubstitute.Acceptance.Specs/DefaultInterfacesImplementations.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NSubstitute.Acceptance.Specs;
+
+#if NET8_0_OR_GREATER
+
+[TestFixture]
+public class DefaultInterfacesImplementations
+{
+    [Test]
+    public void DefaultInterface_SetupReturns_UsesReturns()
+    {
+        // Arrange
+        var for1 = Substitute.For<IMyInterface>();
+        for1.GetText().Returns("new text");
+
+        // Act
+        var result = for1.GetText();
+
+        // Assert
+        Assert.That(result, Is.EqualTo("new text"));
+    }
+
+    public interface IMyInterface
+    {
+        string GetText()
+        {
+            return "default text";
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Added a test for default interface implementations

Please note, this test fails with Castle.Core 5.2.1, see https://github.com/castleproject/Core/issues/684:
```
  Message: 
System.ArgumentNullException : Value cannot be null. (Parameter 'type')

  Stack Trace: 
InvocationHelper.GetMethodOnType(Type type, MethodInfo proxiedMethod)
InheritanceInvocation.get_MethodInvocationTarget()
CastleInvocationMapper.Map(IInvocation castleInvocation) line 11
CastleForwardingInterceptor.Intercept(IInvocation invocation) line 12
AbstractInvocation.Proceed()
ProxyIdInterceptor.Intercept(IInvocation invocation) line 20
AbstractInvocation.Proceed()
ObjectProxy.GetText()
DefaultInterfacesImplementations.DefaultInterface_SetupReturns_UsesReturns() line 18
MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
1)    at Castle.DynamicProxy.Internal.InvocationHelper.GetMethodOnType(Type type, MethodInfo proxiedMethod)
InheritanceInvocation.get_MethodInvocationTarget()
CastleInvocationMapper.Map(IInvocation castleInvocation) line 11
CastleForwardingInterceptor.Intercept(IInvocation invocation) line 12
AbstractInvocation.Proceed()
ProxyIdInterceptor.Intercept(IInvocation invocation) line 20
AbstractInvocation.Proceed()
ObjectProxy.GetText()
DefaultInterfacesImplementations.DefaultInterface_SetupReturns_UsesReturns() line 18
MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```