### PR TITLE
Add CAUTION section in `Compatibility argument matchers` documentation

### DIFF
--- a/docs/help/compat-args/index.md
+++ b/docs/help/compat-args/index.md
@@ -2,6 +2,10 @@
 title: Compatibility argument matchers
 ---
 
+> [!CAUTION]
+> This functionalitiy is obsolete and will be removed in next major release. <br>
+> It is recommended to update your C# compiler to version 7.3 or later and use the standard `Arg` matchers instead.
+
 NSubstitute [argument matchers](/help/argument-matchers) depend on having C# 7.0 or later (as of NSubstitute 4.0). This lets them be used with `out` and `ref` parameters, but it also means that if you are stuck on an earlier version of C# you may get an error like the following when trying to use a matcher like `Arg.Is(123)`:
 
 > `CS7085: By-reference return type 'ref T' is not supported.`

--- a/docs/help/compat-args/index.md
+++ b/docs/help/compat-args/index.md
@@ -3,7 +3,7 @@ title: Compatibility argument matchers
 ---
 
 > [!CAUTION]
-> This functionalitiy is obsolete and will be removed in next major release. <br>
+> This functionalitiy is obsolete and will be removed in version 7 or later. <br>
 > It is recommended to update your C# compiler to version 7.3 or later and use the standard `Arg` matchers instead.
 
 NSubstitute [argument matchers](/help/argument-matchers) depend on having C# 7.0 or later (as of NSubstitute 4.0). This lets them be used with `out` and `ref` parameters, but it also means that if you are stuck on an earlier version of C# you may get an error like the following when trying to use a matcher like `Arg.Is(123)`:


### PR DESCRIPTION
Changes:
- Add CAUTION section in `Compatibility argument matchers` documentation

<img width="3162" height="980" alt="image" src="https://github.com/user-attachments/assets/8ef2768a-a431-4dca-b6f5-f1f861b905de" />

Related: https://github.com/nsubstitute/NSubstitute/issues/830, https://github.com/nsubstitute/NSubstitute/issues/953
