### PR TITLE
Add new argument matcher for comparing objects by reference

### DIFF
--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -66,6 +66,15 @@ public static partial class Arg
         ref ArgumentMatcher.Enqueue(matcher);
 
     /// <summary>
+    /// Match argument that has the same reference as <paramref name="value"/>.
+    /// </summary>
+    public static ref T Same<T>(T value)
+        where T : class
+    {
+        return ref ArgumentMatcher.Enqueue(new ReferenceArgumentMatcher<T>(value));
+    }
+
+    /// <summary>
     /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
     /// </summary>
     public static ref Action Invoke()

--- a/src/NSubstitute/Compatibility/Arg.Compat.cs
+++ b/src/NSubstitute/Compatibility/Arg.Compat.cs
@@ -60,6 +60,13 @@ public static partial class Arg
         public static T Is<T>(IArgumentMatcher<T> matcher) => ArgumentMatcher.Enqueue(matcher);
 
         /// <summary>
+        /// Match argument that has the same reference as <paramref name="value"/>.
+        /// This is provided for compatibility with older compilers --
+        /// if possible use <see cref="Arg.Same{T}(T)" /> instead.
+        /// </summary>
+        public static T Same<T>(T value) where T : class => Arg.Same(value);
+
+        /// <summary>
         /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
         /// This is provided for compatibility with older compilers --
         /// if possible use <see cref="Arg.Invoke" /> instead.

--- a/src/NSubstitute/Compatibility/CompatArg.cs
+++ b/src/NSubstitute/Compatibility/CompatArg.cs
@@ -69,6 +69,13 @@ public class CompatArg
     public static T Is<T>(IArgumentMatcher<T> matcher) => ArgumentMatcher.Enqueue(matcher);
 
     /// <summary>
+    /// Match argument that has the same reference as <paramref name="value"/>.
+    /// This is provided for compatibility with older compilers --
+    /// if possible use <see cref="Arg.Same{T}(T)" /> instead.
+    /// </summary>
+    public T Same<T>(T value) where T : class => Arg.Same(value);
+
+    /// <summary>
     /// Invoke any <see cref="Action"/> argument whenever a matching call is made to the substitute.
     /// This is provided for compatibility with older compilers --
     /// if possible use <see cref="Arg.Invoke" /> instead.

--- a/src/NSubstitute/Core/Arguments/ReferenceArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ReferenceArgumentMatcher.cs
@@ -1,0 +1,17 @@
+﻿namespace NSubstitute.Core.Arguments;
+
+public class ReferenceArgumentMatcher<T>(T value) : IArgumentMatcher<T>, IDescribeNonMatches
+    where T : class
+{
+    public override string ToString() => ArgumentFormatter.Default.Format(value, false);
+
+    public string DescribeFor(object? argument)
+    {
+        var expected = ArgumentFormatter.Default.Format(value, false);
+        var actual = ArgumentFormatter.Default.Format(argument, false);
+
+        return $"Reference of {expected} does not match reference of {actual}.";
+    }
+
+    public bool IsSatisfiedBy(T? argument) => ReferenceEquals(argument, value);
+}

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -351,6 +351,15 @@ public class ArgumentMatching
     }
 
     [Test]
+    public void Should_match_identical_objects()
+    {
+        var obj = new object();
+        _something.Anything(Arg.Same(obj)).Returns(1);
+        Assert.That(_something.Anything(obj), Is.EqualTo(1));
+        Assert.That(_something.Anything(new object()), Is.EqualTo(0));
+    }
+
+    [Test]
     public void Returns_should_work_with_params()
     {
         _something.WithParams(Arg.Any<int>(), Arg.Is<string>(x => x == "one")).Returns("fred");

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatchingCompat.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatchingCompat.cs
@@ -176,6 +176,15 @@ public class ArgumentMatchingCompat
     }
 
     [Test]
+    public void Should_match_identical_objects()
+    {
+        var obj = new object();
+        _something.Anything(Arg.Compat.Same(obj)).Returns(1);
+        Assert.That(_something.Anything(obj), Is.EqualTo(1));
+        Assert.That(_something.Anything(new object()), Is.EqualTo(0));
+    }
+
+    [Test]
     public void Returns_should_work_with_params()
     {
         _something.WithParams(Arg.Compat.Any<int>(), Arg.Compat.Is<string>(x => x == "one")).Returns("fred");


### PR DESCRIPTION
Sometimes users want to compare objects based on references instead of equality. Add a new argument matcher and the necessary plumbing to allow users to easily do this.