### PR TITLE
Revert nullability changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 6.1.0 (August 2026)
+
+* [UPDATE] Revert nullability support from 6.0. This change caused a number of problems for callers (#973, #976), and
+  trying to resolve these (#976) revealed the need for more fundamental changes to NSubstitute to effectively support this.
+  As a result, nullability is again disabled for public API.
+  Huge thanks to @jdb0123, @Romfos, and @Moha-sami for their PRs addressing this, and thanks for all those who raised
+  issues. We also humbly award @zvirja with one unlimited "I told you so" pass to use as he sees fit.
+
 ### 6.0.0 (July 2026)
 
 No changes from Release Candidate 1.

--- a/src/NSubstitute/Arg.cs
+++ b/src/NSubstitute/Arg.cs
@@ -1,5 +1,9 @@
-using NSubstitute.Core.Arguments;
 using System.Linq.Expressions;
+using NSubstitute.Core.Arguments;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+#pragma warning disable CS0419
 
 namespace NSubstitute;
 
@@ -39,7 +43,7 @@ public static partial class Arg
     /// Match argument that satisfies <paramref name="predicate"/>.
     /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
     /// </summary>
-    public static ref T Is<T>(Expression<Predicate<T?>> predicate)
+    public static ref T Is<T>(Expression<Predicate<T>> predicate)
     {
         return ref ArgumentMatcher.Enqueue<T>(new ExpressionArgumentMatcher<T>(predicate));
     }
@@ -48,7 +52,7 @@ public static partial class Arg
     /// Match argument that satisfies <paramref name="predicate"/>.
     /// If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
     /// </summary>
-    public static ref T Is<T>(Expression<Predicate<object?>> predicate) where T : AnyType
+    public static ref T Is<T>(Expression<Predicate<object>> predicate) where T : AnyType
     {
         return ref ArgumentMatcher.Enqueue<T>(new ExpressionArgumentMatcher<object>(predicate));
     }
@@ -141,8 +145,8 @@ public static partial class Arg
         return ref ArgumentMatcher.Enqueue<T>(new AnyArgumentMatcher(typeof(AnyType)), x => useArgument(x!));
     }
 
-    private static Action<object?> InvokeDelegateAction(params object?[] arguments)
+    private static Action<object> InvokeDelegateAction(params object[] arguments)
     {
-        return x => ((Delegate)x!).DynamicInvoke(arguments);
+        return x => ((Delegate)x).DynamicInvoke(arguments);
     }
 }

--- a/src/NSubstitute/Callback.cs
+++ b/src/NSubstitute/Callback.cs
@@ -2,6 +2,9 @@
 using NSubstitute.Core;
 using System.Collections.Concurrent;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 /// <summary>

--- a/src/NSubstitute/Callbacks/ConfiguredCallback.cs
+++ b/src/NSubstitute/Callbacks/ConfiguredCallback.cs
@@ -1,5 +1,8 @@
 ﻿using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.Callbacks;
 
 public class ConfiguredCallback : EndCallbackChain

--- a/src/NSubstitute/Core/Arguments/ArgumentMatchInfo.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatchInfo.cs
@@ -1,18 +1,10 @@
 ﻿namespace NSubstitute.Core.Arguments;
 
-public record ArgumentMatchInfo
+public class ArgumentMatchInfo(int index, object? argument, IArgumentSpecification specification)
 {
-    private readonly object? _argument;
-    private readonly IArgumentSpecification _specification;
-
-    public int Index { get; }
-
-    public ArgumentMatchInfo(int index, object? argument, IArgumentSpecification specification)
-    {
-        _argument = argument;
-        _specification = specification;
-        Index = index;
-    }
+    private readonly object? _argument = argument;
+    private readonly IArgumentSpecification _specification = specification;
+    public int Index { get; } = index;
 
     public bool IsMatch => _specification.IsSatisfiedBy(_argument);
 
@@ -22,5 +14,31 @@ public record ArgumentMatchInfo
         if (string.IsNullOrEmpty(describeNonMatch)) return string.Empty;
         var argIndexPrefix = "arg[" + Index + "]: ";
         return string.Format("{0}{1}", argIndexPrefix, describeNonMatch.Replace("\n", "\n".PadRight(argIndexPrefix.Length + 1)));
+    }
+
+    public bool Equals(ArgumentMatchInfo? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return other.Index == Index && Equals(other._argument, _argument) && Equals(other._specification, _specification);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != typeof(ArgumentMatchInfo)) return false;
+        return Equals((ArgumentMatchInfo)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int result = Index;
+            result = (result * 397) ^ (_argument != null ? _argument.GetHashCode() : 0);
+            result = (result * 397) ^ _specification.GetHashCode();
+            return result;
+        }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentMatcher.cs
@@ -9,7 +9,7 @@ public static class ArgumentMatcher
     /// Enqueues a matcher for the method argument in current position and returns the value which should be
     /// passed back to the method you invoke.
     /// </summary>
-    public static ref T Enqueue<T>(IArgumentMatcher<T> argumentMatcher)
+    public static ref T? Enqueue<T>(IArgumentMatcher<T> argumentMatcher)
     {
         if (argumentMatcher == null) throw new ArgumentNullException(nameof(argumentMatcher));
 
@@ -22,16 +22,16 @@ public static class ArgumentMatcher
         return ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), nonGenericMatcher));
     }
 
-    internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher) =>
+    internal static ref T? Enqueue<T>(IArgumentMatcher argumentMatcher) =>
         ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher));
 
-    internal static ref T Enqueue<T>(IArgumentMatcher argumentMatcher, Action<object?> action) =>
+    internal static ref T? Enqueue<T>(IArgumentMatcher argumentMatcher, Action<object?> action) =>
         ref EnqueueArgSpecification<T>(new ArgumentSpecification(typeof(T), argumentMatcher, action));
 
-    private static ref T EnqueueArgSpecification<T>(IArgumentSpecification specification)
+    private static ref T? EnqueueArgSpecification<T>(IArgumentSpecification specification)
     {
         SubstitutionContext.Current.ThreadContext.EnqueueArgumentSpecification(specification);
-        return ref new DefaultValueContainer<T>().Value!;
+        return ref new DefaultValueContainer<T>().Value;
     }
 
     private class GenericToNonGenericMatcherProxy<T>(IArgumentMatcher<T> matcher) : IArgumentMatcher

--- a/src/NSubstitute/Core/Arguments/ExpressionArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ExpressionArgumentMatcher.cs
@@ -7,7 +7,7 @@ public class ExpressionArgumentMatcher<T>(Expression<Predicate<T?>> predicate) :
     private readonly string _predicateDescription = predicate.ToString();
     private readonly Predicate<T?> _predicate = predicate.Compile();
 
-    public bool IsSatisfiedBy(object? argument) => _predicate((T?)argument);
+    public bool IsSatisfiedBy(object? argument) => _predicate((T?)argument!);
 
     public override string ToString() => _predicateDescription;
 }

--- a/src/NSubstitute/Core/CallInfo.cs
+++ b/src/NSubstitute/Core/CallInfo.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using NSubstitute.Exceptions;
 
+// Disable nullability for entry-point API
+#nullable disable annotations
+
 namespace NSubstitute.Core;
 
 public class CallInfo(Argument[] callArguments, Type[] genericArguments)
@@ -11,7 +14,7 @@ public class CallInfo(Argument[] callArguments, Type[] genericArguments)
     /// </summary>
     /// <param name="index">Index of argument</param>
     /// <returns>The value of the argument at the given index</returns>
-    public object? this[int index]
+    public object this[int index]
     {
         get => callArguments[index].Value;
         set
@@ -22,7 +25,7 @@ public class CallInfo(Argument[] callArguments, Type[] genericArguments)
         }
     }
 
-    private void EnsureArgIsSettable(Argument argument, int index, object? value)
+    private void EnsureArgIsSettable(Argument argument, int index, object value)
     {
         if (!argument.IsByRef)
         {
@@ -45,7 +48,7 @@ public class CallInfo(Argument[] callArguments, Type[] genericArguments)
     /// Get the arguments passed to this call.
     /// </summary>
     /// <returns>Array of all arguments passed to this call</returns>
-    public object?[] Args() => callArguments.Select(x => x.Value).ToArray();
+    public object[] Args() => callArguments.Select(x => x.Value).ToArray();
 
     /// <summary>
     /// Gets the types of all the arguments passed to this call.
@@ -59,15 +62,15 @@ public class CallInfo(Argument[] callArguments, Type[] genericArguments)
     /// </summary>
     /// <typeparam name="T">The type of the argument to retrieve</typeparam>
     /// <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
-    public T? Arg<T>()
+    public T Arg<T>()
     {
-        T? arg;
+        T arg;
         if (TryGetArg(x => x.IsDeclaredTypeEqualToOrByRefVersionOf(typeof(T)), out arg)) return arg;
         if (TryGetArg(x => x.IsValueAssignableTo(typeof(T)), out arg)) return arg;
         throw new ArgumentNotFoundException("Can not find an argument of type " + typeof(T).FullName + " to this call.");
     }
 
-    private bool TryGetArg<T>(Func<Argument, bool> condition, [MaybeNullWhen(false)] out T? value)
+    private bool TryGetArg<T>(Func<Argument, bool> condition, [MaybeNullWhen(false)] out T value)
     {
         value = default;
 
@@ -75,7 +78,7 @@ public class CallInfo(Argument[] callArguments, Type[] genericArguments)
         if (!matchingArgs.Any()) return false;
         ThrowIfMoreThanOne<T>(matchingArgs);
 
-        value = (T?)matchingArgs.First().Value!;
+        value = (T)matchingArgs.First().Value!;
         return true;
     }
 

--- a/src/NSubstitute/Core/ConfiguredCall.cs
+++ b/src/NSubstitute/Core/ConfiguredCall.cs
@@ -1,4 +1,7 @@
-﻿namespace NSubstitute.Core;
+﻿// Disable nullability for entry-point API
+#nullable disable annotations
+
+namespace NSubstitute.Core;
 
 public class ConfiguredCall(Action<Action<CallInfo>> addAction)
 {

--- a/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
+++ b/src/NSubstitute/Core/Events/DelegateEventWrapper.cs
@@ -6,11 +6,14 @@ public class DelegateEventWrapper<T>(params object?[] arguments) : RaiseEventWra
 {
     protected override string RaiseMethodName => "Raise.Event";
 
-    public static implicit operator T?(DelegateEventWrapper<T> wrapper)
+    // Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+    public static implicit operator T(DelegateEventWrapper<T> wrapper)
     {
         RaiseEvent(wrapper);
         return default;
     }
+#nullable restore annotations
 
     protected override object?[] WorkOutRequiredArguments(ICall call)
     {

--- a/src/NSubstitute/Core/Events/EventHandlerWrapper.cs
+++ b/src/NSubstitute/Core/Events/EventHandlerWrapper.cs
@@ -10,18 +10,20 @@ public class EventHandlerWrapper<TEventArgs>(object? sender, EventArgs? eventArg
 
     public EventHandlerWrapper(EventArgs? eventArgs) : this(null, eventArgs) { }
 
-
-    public static implicit operator EventHandler?(EventHandlerWrapper<TEventArgs> wrapper)
+    // Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+    public static implicit operator EventHandler(EventHandlerWrapper<TEventArgs> wrapper)
     {
         RaiseEvent(wrapper);
         return null;
     }
 
-    public static implicit operator EventHandler<TEventArgs>?(EventHandlerWrapper<TEventArgs> wrapper)
+    public static implicit operator EventHandler<TEventArgs>(EventHandlerWrapper<TEventArgs> wrapper)
     {
         RaiseEvent(wrapper);
         return null;
     }
+#nullable restore annotations
 
     protected override object[] WorkOutRequiredArguments(ICall call)
     {

--- a/src/NSubstitute/Core/WhenCalled.cs
+++ b/src/NSubstitute/Core/WhenCalled.cs
@@ -1,5 +1,8 @@
 using NSubstitute.Routing;
 
+// Disable nullability for entry-point API
+#nullable disable annotations
+
 namespace NSubstitute.Core;
 
 public class WhenCalled<T>(ISubstitutionContext context, T substitute, Action<T> call, MatchArgs matchArgs)

--- a/src/NSubstitute/Extensions/ClearExtensions.cs
+++ b/src/NSubstitute/Extensions/ClearExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.ClearExtensions;
 
 public static class ClearExtensions

--- a/src/NSubstitute/Extensions/ConfigurationExtensions.cs
+++ b/src/NSubstitute/Extensions/ConfigurationExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.Extensions;
 
 public static class ConfigurationExtensions

--- a/src/NSubstitute/Extensions/ExceptionExtensions.cs
+++ b/src/NSubstitute/Extensions/ExceptionExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using System.Reflection;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.ExceptionExtensions;
 
 public static class ExceptionExtensions
@@ -339,7 +342,7 @@ public static class ExceptionExtensions
         {
             var fromExceptionMethodInfo = typeof(Task).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(m => m.Name == "FromException" && m.ContainsGenericParameters);
             var specificFromExceptionMethod = fromExceptionMethodInfo.MakeGenericMethod(valueType.GenericTypeArguments);
-            return specificFromExceptionMethod.Invoke(null, [exception])!;
+            return specificFromExceptionMethod.Invoke(null, [exception]);
         }
 
         return Task.FromException(exception);

--- a/src/NSubstitute/Extensions/ReceivedExtensions.cs
+++ b/src/NSubstitute/Extensions/ReceivedExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.ReceivedExtensions;
 
 public static class ReceivedExtensions
@@ -45,7 +48,7 @@ public static class ReceivedExtensions
 /// <summary>
 /// Represents a quantity. Primarily used for specifying a required amount of calls to a member.
 /// </summary>
-public abstract record Quantity
+public abstract class Quantity
 {
     public static Quantity Exactly(int number) { return number == 0 ? None() : new ExactQuantity(number); }
     public static Quantity AtLeastOne() { return new AnyNonZeroQuantity(); }
@@ -84,14 +87,9 @@ public abstract record Quantity
     /// <returns>A string describing the required quantity of items identified by the provided noun forms.</returns>
     public abstract string Describe(string singularNoun, string pluralNoun);
 
-    private record ExactQuantity : Quantity
+    private class ExactQuantity(int number) : Quantity
     {
-        private readonly int _number;
-
-        public ExactQuantity(int number)
-        {
-            _number = number;
-        }
+        private readonly int _number = number;
 
         public override bool Matches<T>(IEnumerable<T> items) { return _number == items.Count(); }
         public override bool RequiresMoreThan<T>(IEnumerable<T> items) { return _number > items.Count(); }
@@ -99,9 +97,26 @@ public abstract record Quantity
         {
             return string.Format("exactly {0} {1}", _number, _number == 1 ? singularNoun : pluralNoun);
         }
+
+        public bool Equals(ExactQuantity other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return other._number == _number;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(ExactQuantity)) return false;
+            return Equals((ExactQuantity)obj);
+        }
+
+        public override int GetHashCode() { return _number; }
     }
 
-    private record AnyNonZeroQuantity : Quantity
+    private class AnyNonZeroQuantity : Quantity
     {
         public override bool Matches<T>(IEnumerable<T> items) { return items.Any(); }
         public override bool RequiresMoreThan<T>(IEnumerable<T> items) { return !items.Any(); }
@@ -110,9 +125,27 @@ public abstract record Quantity
         {
             return string.Format("a {0}", singularNoun);
         }
+
+        public bool Equals(AnyNonZeroQuantity other)
+        {
+            return !ReferenceEquals(null, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(AnyNonZeroQuantity)) return false;
+            return Equals((AnyNonZeroQuantity)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return 0;
+        }
     }
 
-    private record NoneQuantity : Quantity
+    private class NoneQuantity : Quantity
     {
         public override bool Matches<T>(IEnumerable<T> items) { return !items.Any(); }
         public override bool RequiresMoreThan<T>(IEnumerable<T> items) { return false; }
@@ -120,13 +153,27 @@ public abstract record Quantity
         {
             return "no " + pluralNoun;
         }
+
+        public bool Equals(NoneQuantity other)
+        {
+            return !ReferenceEquals(null, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(NoneQuantity)) return false;
+            return Equals((NoneQuantity)obj);
+        }
+
+        public override int GetHashCode() { return 0; }
     }
 
-    private record RangeQuantity : Quantity
+    private class RangeQuantity : Quantity
     {
         private readonly int minInclusive;
         private readonly int maxInclusive;
-
         public RangeQuantity(int minInclusive, int maxInclusive)
         {
             if (minInclusive < 0)

--- a/src/NSubstitute/Extensions/ReturnsExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute.ReturnsExtensions;
 

--- a/src/NSubstitute/Extensions/ReturnsForAllExtensions.cs
+++ b/src/NSubstitute/Extensions/ReturnsForAllExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute.Extensions;
 
 public static class ReturnsForAllExtensions

--- a/src/NSubstitute/Raise.cs
+++ b/src/NSubstitute/Raise.cs
@@ -1,6 +1,9 @@
+using System.Reflection;
 using NSubstitute.Core;
 using NSubstitute.Core.Events;
-using System.Reflection;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute;
 

--- a/src/NSubstitute/Received.cs
+++ b/src/NSubstitute/Received.cs
@@ -1,6 +1,9 @@
 ﻿using NSubstitute.Core;
 using NSubstitute.Core.SequenceChecking;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public class Received

--- a/src/NSubstitute/Substitute.cs
+++ b/src/NSubstitute/Substitute.cs
@@ -1,5 +1,8 @@
-using NSubstitute.Core;
 using System.Diagnostics.Contracts;
+using NSubstitute.Core;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
 
 namespace NSubstitute;
 

--- a/src/NSubstitute/SubstituteExtensions.Received.cs
+++ b/src/NSubstitute/SubstituteExtensions.Received.cs
@@ -1,7 +1,11 @@
+// Disable nullability for client API, so it does not affect clients.
+
 using NSubstitute.ClearExtensions;
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
 using NSubstitute.ReceivedExtensions;
+
+#nullable disable annotations
 
 namespace NSubstitute;
 

--- a/src/NSubstitute/SubstituteExtensions.Returns.Task.cs
+++ b/src/NSubstitute/SubstituteExtensions.Returns.Task.cs
@@ -1,6 +1,9 @@
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions
@@ -11,7 +14,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return. Will be wrapped in a Task</param>
     /// <param name="returnThese">Optionally use these values next</param>
-    public static ConfiguredCall Returns<T>(this Task<T> value, T? returnThis, params T[] returnThese)
+    public static ConfiguredCall Returns<T>(this Task<T> value, T returnThis, params T[] returnThese)
     {
         ReThrowOnNSubstituteFault(value);
 
@@ -43,7 +46,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return</param>
     /// <param name="returnThese">Optionally return these values next</param>
-    public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, T? returnThis, params T[] returnThese)
+    public static ConfiguredCall ReturnsForAnyArgs<T>(this Task<T> value, T returnThis, params T[] returnThese)
     {
         ReThrowOnNSubstituteFault(value);
 
@@ -69,7 +72,8 @@ public static partial class SubstituteExtensions
         return ConfigureReturn(MatchArgs.Any, wrappedFunc, wrappedReturnThese);
     }
 
-    private static void ReThrowOnNSubstituteFault<T>(Task<T> task)
+#nullable restore
+    private static void ReThrowOnNSubstituteFault<T>(Task<T?> task)
     {
         if (task.IsFaulted && task.Exception!.InnerExceptions.FirstOrDefault() is SubstituteException)
         {

--- a/src/NSubstitute/SubstituteExtensions.Returns.ValueTask.cs
+++ b/src/NSubstitute/SubstituteExtensions.Returns.ValueTask.cs
@@ -1,6 +1,9 @@
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions
@@ -11,7 +14,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return. Will be wrapped in a ValueTask</param>
     /// <param name="returnThese">Optionally use these values next</param>
-    public static ConfiguredCall Returns<T>(this ValueTask<T> value, T? returnThis, params T[] returnThese)
+    public static ConfiguredCall Returns<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
     {
         ReThrowOnNSubstituteFault(value);
 
@@ -43,7 +46,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return</param>
     /// <param name="returnThese">Optionally return these values next</param>
-    public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, T? returnThis, params T[] returnThese)
+    public static ConfiguredCall ReturnsForAnyArgs<T>(this ValueTask<T> value, T returnThis, params T[] returnThese)
     {
         ReThrowOnNSubstituteFault(value);
 
@@ -69,7 +72,8 @@ public static partial class SubstituteExtensions
         return ConfigureReturn(MatchArgs.Any, wrappedFunc, wrappedReturnThese);
     }
 
-    private static void ReThrowOnNSubstituteFault<T>(ValueTask<T> task)
+#nullable restore
+    private static void ReThrowOnNSubstituteFault<T>(ValueTask<T?> task)
     {
         if (task.IsFaulted && task.AsTask().Exception!.InnerExceptions.FirstOrDefault() is SubstituteException)
         {

--- a/src/NSubstitute/SubstituteExtensions.Returns.cs
+++ b/src/NSubstitute/SubstituteExtensions.Returns.cs
@@ -1,5 +1,8 @@
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions
@@ -10,7 +13,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return</param>
     /// <param name="returnThese">Optionally return these values next</param>
-    public static ConfiguredCall Returns<T>(this T value, T? returnThis, params T?[] returnThese) =>
+    public static ConfiguredCall Returns<T>(this T value, T returnThis, params T[] returnThese) =>
         ConfigureReturn(MatchArgs.AsSpecifiedInCall, returnThis, returnThese);
 
     /// <summary>
@@ -28,7 +31,7 @@ public static partial class SubstituteExtensions
     /// <param name="value"></param>
     /// <param name="returnThis">Value to return</param>
     /// <param name="returnThese">Optionally return these values next</param>
-    public static ConfiguredCall ReturnsForAnyArgs<T>(this T value, T returnThis, params T?[] returnThese) =>
+    public static ConfiguredCall ReturnsForAnyArgs<T>(this T value, T returnThis, params T[] returnThese) =>
         ConfigureReturn(MatchArgs.Any, returnThis, returnThese);
 
     /// <summary>
@@ -41,6 +44,7 @@ public static partial class SubstituteExtensions
     public static ConfiguredCall ReturnsForAnyArgs<T>(this T value, Func<CallInfo, T> returnThis, params Func<CallInfo, T>[] returnThese) =>
         ConfigureReturn(MatchArgs.Any, returnThis, returnThese);
 
+#nullable restore
     private static ConfiguredCall ConfigureReturn<T>(MatchArgs matchArgs, T? returnThis, T?[]? returnThese)
     {
         IReturn returnValue;

--- a/src/NSubstitute/SubstituteExtensions.When.Task.cs
+++ b/src/NSubstitute/SubstituteExtensions.When.Task.cs
@@ -1,5 +1,8 @@
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions

--- a/src/NSubstitute/SubstituteExtensions.When.ValueTask.cs
+++ b/src/NSubstitute/SubstituteExtensions.When.ValueTask.cs
@@ -1,5 +1,8 @@
 using NSubstitute.Core;
 
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions

--- a/src/NSubstitute/SubstituteExtensions.When.cs
+++ b/src/NSubstitute/SubstituteExtensions.When.cs
@@ -1,5 +1,9 @@
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
+
+// Disable nullability for client API, so it does not affect clients.
+#nullable disable annotations
+
 namespace NSubstitute;
 
 public static partial class SubstituteExtensions
@@ -22,6 +26,7 @@ public static partial class SubstituteExtensions
         return MakeWhenCalled(substitute, substituteCall, MatchArgs.Any);
     }
 
+#nullable restore
     private static WhenCalled<TSubstitute> MakeWhenCalled<TSubstitute>(TSubstitute? substitute,
         Action<TSubstitute> action, MatchArgs matchArgs)
     {

--- a/testNet60.sh
+++ b/testNet60.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+dotnet test -f net6.0

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatchingCompat.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatchingCompat.cs
@@ -2,8 +2,6 @@
 using NSubstitute.Exceptions;
 using NUnit.Framework;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 namespace NSubstitute.Acceptance.Specs;
 
 [TestFixture]


### PR DESCRIPTION
This reverts commit 6c37da9f0c7da3b5328233fc18692b52116094fa from PR #856, reversing changes made to ee11ef006ad368dc5c49f844c960f58e11ab4243.

#976 has demonstrated that we need more fundamental lib changes to effectively support nullability, so we'll revert to the pre v6.0 behaviour and revisit later.
```
# Conflicts:
#	BreakingChanges.md
#	CHANGELOG.md
#	src/NSubstitute/Compatibility/Arg.Compat.cs
#	src/NSubstitute/Core/CallInfo.cs
```