### PR TITLE
Add trusted nuget publish

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -14,13 +14,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Calculate version
+        id: version
+        shell: bash
+        run: |
+          # Fails if HEAD is not exactly on the tag (e.g. more commits were pushed after tagging).
+          VERSION=$(git describe --tags --exact-match)
+          echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
       - name: Build package
-        run: dotnet pack src/NSubstitute/NSubstitute.csproj -o bin -p:CI=true
+        run: dotnet pack src/NSubstitute/NSubstitute.csproj -o bin -p:CI=true -p:Version=${{ steps.version.outputs.version }}
 
         # Read more: https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/
       - name: NuGet login (OIDC → temp API key)

--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -5,6 +5,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+
+    environment: nuget-push
+    permissions:
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -16,6 +21,18 @@ jobs:
 
       - name: Build package
         run: dotnet pack src/NSubstitute/NSubstitute.csproj -o bin -p:CI=true
+
+        # Read more: https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: nugetLogin
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push packages to NuGet.org
+        run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ steps.nugetLogin.outputs.NUGET_API_KEY }}
 
       - name: Upload packages
         uses: actions/upload-artifact@v7

--- a/src/NSubstitute/NSubstitute.csproj
+++ b/src/NSubstitute/NSubstitute.csproj
@@ -13,7 +13,6 @@
 
   <PropertyGroup>
     <Description>NSubstitute is a friendly substitute for .NET mocking libraries. It has a simple, succinct syntax to help developers write clearer tests. NSubstitute is designed for Arrange-Act-Assert (AAA) testing and with Test Driven Development (TDD) in mind.</Description>
-    <Version>6.1.0</Version>
     <Authors>Anthony Egerton;David Tchepak;Alexandr Nikitin;Oleksandr Povar</Authors>
     <AssemblyName>NSubstitute</AssemblyName>
     <PackageId>NSubstitute</PackageId>


### PR DESCRIPTION
Closes #958

Introduce trusted NuGet publish and push to NuGet when we run `release_packages.yml` pipeline. I configured the NuGet part and also added new environment in our configuration (is needed to make sure that API key could be only retrieved for this specific pipeline). I use this approach in other places so it shall all work fine without us updating anything going forward.


Packages will appear pushed under my name (not visible outside, but will appear e.g. in emails). If you have objections, you could re-configure the environment and put your own user name (you'll have to make sure to add proper record under the "Trusted Publishing" section on NuGet):

<img width="1966" height="490" alt="image" src="https://github.com/user-attachments/assets/0aebecde-3089-419b-8cf4-cb3dda31884d" />


I also removed `Version` from csproj and instead calculate it based on the current tag value. Therefore `release_packages.yml` shall be run on tag only. This way it's a bit easier to maintain the product.

I kept triggering the pipeline manually. That's the part we could discuss. My suggestion is to add tags trigger - so if you push a tag, it's run automatically. But I leave this decision up to you @dtchepak.