### PR TITLE
Remove skip-duplicate option from NuGet push command

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -38,7 +38,7 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Push packages to NuGet.org
-        run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json
         env:
           NUGET_API_KEY: ${{ steps.nugetLogin.outputs.NUGET_API_KEY }}
 


### PR DESCRIPTION
Follow up on #987. Remove `skip-duplicate` options, as I realized it would be nicer to fail and make it explicit. A new thought next morning :)