### PR TITLE
fix: Stop using return-type assignability for generic call matching

### DIFF
--- a/src/NSubstitute/Core/CallSpecification.cs
+++ b/src/NSubstitute/Core/CallSpecification.cs
@@ -50,8 +50,8 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
     {
         return
                AreEquivalentDefinitions(a, b)
-            && TypesAreAllEquivalent(ParameterTypes(a), ParameterTypes(b))
-            && TypesAreAllEquivalent(a.GetGenericArguments(), b.GetGenericArguments());
+            && TypesAreAllEquivalent(ParameterTypes(a), ParameterTypes(b), allowAssignableTypes: true)
+            && TypesAreAllEquivalent(a.GetGenericArguments(), b.GetGenericArguments(), allowAssignableTypes: true);
     }
 
     private static Type[] ParameterTypes(MethodInfo info)
@@ -59,7 +59,7 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
         return info.GetParameters().Select(p => p.ParameterType).ToArray();
     }
 
-    internal static bool TypesAreAllEquivalent(Type[] aArgs, Type[] bArgs)
+    internal static bool TypesAreAllEquivalent(Type[] aArgs, Type[] bArgs, bool allowAssignableTypes)
     {
         if (aArgs.Length != bArgs.Length) return false;
         for (var i = 0; i < aArgs.Length; i++)
@@ -80,20 +80,21 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
                 && first.GetGenericTypeDefinition() == second.GetGenericTypeDefinition())
             {
                 // both are the same generic type. If their GenericTypeArguments match then they are equivalent
-                if (!TypesAreAllEquivalent(first.GenericTypeArguments, second.GenericTypeArguments))
+                if (!TypesAreAllEquivalent(first.GenericTypeArguments, second.GenericTypeArguments, allowAssignableTypes))
                 {
                     return false;
                 }
                 continue;
             }
 
-            var areAssignable = first.IsAssignableFrom(second) || second.IsAssignableFrom(first);
+            var areIdentical = first == second;
+            var areAssignable = allowAssignableTypes && (first.IsAssignableFrom(second) || second.IsAssignableFrom(first));
             var areAnyTypeAssignable = typeof(Arg.AnyType).IsAssignableFrom(first) ||
                                        typeof(Arg.AnyType).IsAssignableFrom(second);
             var areByRefAnyTypeAssignable = first.IsByRef && second.IsByRef &&
                                             (typeof(Arg.AnyType).IsAssignableFrom(first.GetElementType()) ||
                                              typeof(Arg.AnyType).IsAssignableFrom(second.GetElementType()));
-            var areEquivalent = areAssignable || areAnyTypeAssignable || areByRefAnyTypeAssignable;
+            var areEquivalent = areIdentical || areAssignable || areAnyTypeAssignable || areByRefAnyTypeAssignable;
             if (!areEquivalent) return false;
         }
         return true;
@@ -102,7 +103,7 @@ public class CallSpecification(MethodInfo methodInfo, IEnumerable<IArgumentSpeci
     private static bool AreEquivalentDefinitions(MethodInfo a, MethodInfo b)
     {
         return a.IsGenericMethod == b.IsGenericMethod
-               && TypesAreAllEquivalent([a.ReturnType], [b.ReturnType])
+               && TypesAreAllEquivalent([a.ReturnType], [b.ReturnType], allowAssignableTypes: false)
                && a.Name.Equals(b.Name, StringComparison.Ordinal);
     }
 

--- a/src/NSubstitute/Core/Extensions.cs
+++ b/src/NSubstitute/Core/Extensions.cs
@@ -36,7 +36,7 @@ internal static class Extensions
                     aCompatibleInstanceType.GetGenericTypeDefinition() == genericTypeDefinition)
                 {
                     // both are the same generic type. If their GenericTypeArguments match then they are equivalent
-                    var typesAreAllEquivalent = CallSpecification.TypesAreAllEquivalent(aCompatibleInstanceType.GenericTypeArguments, type.GenericTypeArguments);
+                    var typesAreAllEquivalent = CallSpecification.TypesAreAllEquivalent(aCompatibleInstanceType.GenericTypeArguments, type.GenericTypeArguments, allowAssignableTypes: true);
                     if (typesAreAllEquivalent)
                         return true;
                 }

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue974_ReturnsForGenericMethodWithRelatedReturnTypes.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue974_ReturnsForGenericMethodWithRelatedReturnTypes.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports;
+
+public class Issue974_ReturnsForGenericMethodWithRelatedReturnTypes
+{
+    // Based on: https://github.com/nsubstitute/NSubstitute/issues/974
+
+    public interface IResult { }
+    public interface IResult<T> : IResult { }
+
+    public interface IRequest<TResponse> { }
+    public class NonGenericRequest : IRequest<IResult> { }
+    public class GenericRequest : IRequest<IResult<int>> { }
+
+    public interface ISender
+    {
+        TResponse Send<TResponse>(IRequest<TResponse> request);
+    }
+
+    [Test]
+    public void ShouldNotThrowWhenConfiguringReturnsForClosedGenericMethodsWithRelatedReturnTypes()
+    {
+        // Arrange
+        var sender = Substitute.For<ISender>();
+        var firstResult = Substitute.For<IResult>();
+        var secondResult = Substitute.For<IResult<int>>();
+
+        // Act
+        sender.Send(Arg.Any<NonGenericRequest>()).Returns(firstResult);
+        sender.Send(Arg.Any<GenericRequest>()).Returns(secondResult);
+
+        // Assert
+        Assert.That(sender.Send(new NonGenericRequest()), Is.SameAs(firstResult));
+        Assert.That(sender.Send(new GenericRequest()), Is.SameAs(secondResult));
+    }
+}


### PR DESCRIPTION
Fixes #974
Closes #977

This is the proper fix to the original issue. We have a plenty of scenarios when we have to see if return types are cross-compatible. That makes sense for parameters, but not for the return types. For the return types we don't need to support assignable types and that breaks the scenario in the issue. Fix it by passing an explicit flag and disable equivalency test for return types, while keeping it for parameters.

I will also make a follow up PR to name assignability check more strict (to better cater for in/out and be safer).