### PR TITLE
Support C# 13 params collections in argument matching

### DIFF
--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationFactory.cs
@@ -30,7 +30,7 @@ public class ArgumentSpecificationFactory : IArgumentSpecificationFactory
 
     private IArgumentSpecification CreateSpecFromParamsArg(object? argument, IParameterInfo parameterInfo, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)
     {
-        // Next specification is for the whole params array.
+        // Next specification is for the whole params argument.
         if (suppliedArgumentSpecifications.IsNextFor(argument, parameterInfo.ParameterType))
         {
             return suppliedArgumentSpecifications.Dequeue();
@@ -43,21 +43,16 @@ public class ArgumentSpecificationFactory : IArgumentSpecificationFactory
             throw new AmbiguousArgumentsException();
         }
 
-        // User passed "null" as the params array value.
+        // User passed "null" as the params value.
         if (argument == null)
         {
             return new ArgumentSpecification(parameterInfo.ParameterType, new EqualsArgumentMatcher(null));
         }
 
         // User specified arguments using the native params syntax.
-        var arrayArg = argument as Array;
-        if (arrayArg == null)
-        {
-            throw new SubstituteInternalException($"Expected to get array argument, but got argument of '{argument.GetType().FullName}' type.");
-        }
-
-        var arrayArgumentSpecifications = UnwrapParamsArguments(arrayArg.Cast<object?>(), parameterInfo.ParameterType.GetElementType()!, suppliedArgumentSpecifications);
-        return new ArgumentSpecification(parameterInfo.ParameterType, new ArrayContentsArgumentMatcher(arrayArgumentSpecifications));
+        var elementType = ParamsSupport.GetElementType(parameterInfo.ParameterType);
+        var argumentValueSpecifications = UnwrapParamsArguments(ParamsSupport.UnwrapArgument(argument), elementType, suppliedArgumentSpecifications);
+        return new ArgumentSpecification(parameterInfo.ParameterType, new ParamsContentsArgumentMatcher(argumentValueSpecifications));
     }
 
     private IEnumerable<IArgumentSpecification> UnwrapParamsArguments(IEnumerable<object?> args, Type paramsElementType, ISuppliedArgumentSpecifications suppliedArgumentSpecifications)

--- a/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ArrayContentsArgumentMatcher.cs
@@ -2,6 +2,7 @@
 
 namespace NSubstitute.Core.Arguments;
 
+[Obsolete("Use ParamsContentsArgumentMatcher instead. This api will be removed in future versions of product.")]
 public class ArrayContentsArgumentMatcher(IEnumerable<IArgumentSpecification> argumentSpecifications) : IArgumentMatcher, IArgumentFormatter
 {
     private readonly IArgumentSpecification[] _argumentSpecifications = argumentSpecifications.ToArray();

--- a/src/NSubstitute/Core/Arguments/ParamsContentsArgumentMatcher.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsContentsArgumentMatcher.cs
@@ -1,0 +1,44 @@
+﻿namespace NSubstitute.Core.Arguments;
+
+public class ParamsContentsArgumentMatcher(IEnumerable<IArgumentSpecification> argumentSpecifications) : IArgumentMatcher, IArgumentFormatter
+{
+    private readonly IArgumentSpecification[] _argumentSpecifications = argumentSpecifications.ToArray();
+
+    public bool IsSatisfiedBy(object? argument)
+    {
+        if (argument != null)
+        {
+            var argumentValues = ParamsSupport.UnwrapArgument(argument).ToArray();
+            if (argumentValues.Length == _argumentSpecifications.Length)
+            {
+                return _argumentSpecifications
+                    .Select((spec, index) => spec.IsSatisfiedBy(argumentValues[index]))
+                    .All(x => x);
+            }
+        }
+
+        return false;
+    }
+
+    public override string ToString() => string.Join(", ", _argumentSpecifications.Select(x => x.ToString()));
+
+    public string Format(object? argument, bool highlight)
+    {
+        ParamsSupport.TryUnwrapArgument(argument, out var argumentSequence);
+        var argumentValues = argumentSequence.ToArray();
+        return Format(argumentValues, _argumentSpecifications).Join(", ");
+    }
+
+    private IEnumerable<string> Format(object?[] argumentValues, IArgumentSpecification[] specs)
+    {
+        if (specs.Any() && !argumentValues.Any())
+        {
+            return new[] { "**" };
+        }
+        return argumentValues.Select((arg, index) =>
+        {
+            var hasSpecForThisArg = index < specs.Length;
+            return hasSpecForThisArg ? specs[index].FormatArgument(arg) : ArgumentFormatter.Default.Format(arg, true);
+        });
+    }
+}

--- a/src/NSubstitute/Core/Arguments/ParamsSupport.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsSupport.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using NSubstitute.Exceptions;
+
+namespace NSubstitute.Core.Arguments;
+
+internal static class ParamsSupport
+{
+    public static bool IsParams(ParameterInfo parameterInfo)
+    {
+        return parameterInfo.IsDefined(typeof(ParamArrayAttribute), inherit: false)
+               || HasParamCollectionAttribute(parameterInfo);
+
+        // Needed because attribute is available in .NET 9+ only
+        static bool HasParamCollectionAttribute(ParameterInfo parameterInfo)
+        {
+            const string paramCollectionAttributeFullName = "System.Runtime.CompilerServices.ParamCollectionAttribute";
+
+            foreach (var attributeData in parameterInfo.GetCustomAttributesData())
+            {
+                if (attributeData.AttributeType.FullName == paramCollectionAttributeFullName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static Type GetElementType(Type paramsParameterType)
+    {
+        if (paramsParameterType.IsArray)
+        {
+            return paramsParameterType.GetElementType()!;
+        }
+
+        if (TryGetEnumerableElementType(paramsParameterType, out var elementType))
+        {
+            return elementType;
+        }
+
+        // The parameter type implements only the non-generic IEnumerable (e.g. ArrayList, or a custom
+        // collection-initializer-pattern type without IEnumerable<T>). There's no "T" to read off an
+        // interface in that case - the compiler itself falls back to whatever single-argument Add the
+        // type exposes, so mirror that here.
+        if (TryGetAddMethodParameterType(paramsParameterType, out elementType))
+        {
+            return elementType;
+        }
+
+        throw new SubstituteInternalException($"Could not determine params element type for parameter of type '{paramsParameterType.FullName}'.");
+
+        static bool TryGetEnumerableElementType(Type type, [NotNullWhen(true)] out Type? elementType)
+        {
+            var enumerableOfT = type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                ? type
+                : type.GetInterfaces().FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+            elementType = enumerableOfT?.GetGenericArguments()[0];
+            return elementType != null;
+        }
+
+        static bool TryGetAddMethodParameterType(Type type, [NotNullWhen(true)] out Type? elementType)
+        {
+            var addMethod = type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(m => m.Name == "Add" && m.GetParameters().Length == 1);
+
+            elementType = addMethod?.GetParameters()[0].ParameterType;
+            return elementType != null;
+        }
+    }
+
+    public static IEnumerable<object?> UnwrapArgument(object argument)
+    {
+        if (TryUnwrapArgument(argument, out var result))
+        {
+            return result;
+        }
+
+        throw new SubstituteInternalException($"Expected to get collection argument, but got argument of '{argument.GetType().FullName}' type.");
+    }
+
+    public static bool TryUnwrapArgument(object? argument, out IEnumerable<object?> result)
+    {
+        if (argument is IEnumerable enumerable)
+        {
+            result = enumerable.Cast<object?>();
+            return true;
+        }
+
+        result = [];
+        return false;
+    }
+}

--- a/src/NSubstitute/Core/Arguments/ParamsSupport.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsSupport.cs
@@ -9,24 +9,11 @@ internal static class ParamsSupport
 {
     public static bool IsParams(ParameterInfo parameterInfo)
     {
+        const string paramCollectionAttributeFullName = "System.Runtime.CompilerServices.ParamCollectionAttribute";
+
         return parameterInfo.IsDefined(typeof(ParamArrayAttribute), inherit: false)
-               || HasParamCollectionAttribute(parameterInfo);
-
-        // Needed because attribute is available in .NET 9+ only
-        static bool HasParamCollectionAttribute(ParameterInfo parameterInfo)
-        {
-            const string paramCollectionAttributeFullName = "System.Runtime.CompilerServices.ParamCollectionAttribute";
-
-            foreach (var attributeData in parameterInfo.GetCustomAttributesData())
-            {
-                if (attributeData.AttributeType.FullName == paramCollectionAttributeFullName)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+               // Needed because attribute is available in .NET 9+ only
+               || parameterInfo.GetCustomAttributesData().Any(x => x.AttributeType.FullName == paramCollectionAttributeFullName);
     }
 
     public static Type GetElementType(Type paramsParameterType)

--- a/src/NSubstitute/Core/ReflectionExtensions.cs
+++ b/src/NSubstitute/Core/ReflectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using NSubstitute.Core.Arguments;
 
 namespace NSubstitute.Core;
 
@@ -25,7 +26,7 @@ public static class ReflectionExtensions
 
     public static bool IsParams(this ParameterInfo parameterInfo)
     {
-        return parameterInfo.IsDefined(typeof(ParamArrayAttribute), inherit: false);
+        return ParamsSupport.IsParams(parameterInfo);
     }
 
     private static bool CanBePropertySetterCall(MethodInfo call)

--- a/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
+++ b/src/NSubstitute/Core/SequenceChecking/SequenceFormatter.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Reflection;
 using NSubstitute.Core.Arguments;
 
@@ -113,7 +112,7 @@ public class SequenceFormatter
             var argsWithParamsExpanded =
                 arguments
                     .SelectMany(a => a.ParamInfo.IsParams()
-                                      ? ((IEnumerable)a.Argument!).Cast<object>()
+                                      ? ParamsSupport.UnwrapArgument(a.Argument!)
                                       : ToEnumerable(a.Argument))
                     .Select(x => ArgumentFormatter.Default.Format(x, false))
                     .ToArray();

--- a/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Reflection;
 using System.Text;
 using NSubstitute.Core;
@@ -44,14 +43,14 @@ public class AmbiguousArgumentsException : SubstituteException
         string? matchedSpecificationsInfo = null;
         if (CallFormatter.Default.CanFormat(method))
         {
-            var argsWithInlinedParamsArray = invocationArguments.ToArray();
+            var argsWithInlinedParamsCollection = invocationArguments.ToArray();
             // If last argument is `params`, we inline the value.
             if (method.GetParameters().Last().IsParams()
-                && argsWithInlinedParamsArray.Last() is IEnumerable paramsArray)
+                && argsWithInlinedParamsCollection.Last() is { } paramsArgument)
             {
-                argsWithInlinedParamsArray = argsWithInlinedParamsArray
-                    .Take(argsWithInlinedParamsArray.Length - 1)
-                    .Concat(paramsArray.Cast<object>())
+                argsWithInlinedParamsCollection = argsWithInlinedParamsCollection
+                    .Take(argsWithInlinedParamsCollection.Length - 1)
+                    .Concat(ParamsSupport.UnwrapArgument(paramsArgument))
                     .ToArray();
             }
 
@@ -61,11 +60,11 @@ public class AmbiguousArgumentsException : SubstituteException
 
             methodArgsWithHighlightedPossibleArgSpecs = CallFormatter.Default.Format(
                 method,
-                FormatMethodArguments(argsWithInlinedParamsArray));
+                FormatMethodArguments(argsWithInlinedParamsCollection));
 
             matchedSpecificationsInfo = CallFormatter.Default.Format(
                 method,
-                PadNonMatchedSpecifications(matchedSpecifications, argsWithInlinedParamsArray));
+                PadNonMatchedSpecifications(matchedSpecifications, argsWithInlinedParamsCollection));
         }
 
         var message = new StringBuilder();

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.Params.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.Params.cs
@@ -1,0 +1,169 @@
+using System.Collections;
+using NSubstitute.Exceptions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs;
+
+public partial class ArgumentMatching
+{
+    public interface IMethodsWithParams
+    {
+        int GetValue(int primary, params int[] others);
+        string WithParams(int i, params string[] labels);
+        void WithArrayParams(params object[] args);
+        void WithEnumerableParams(params IEnumerable<object> values);
+        void WithListParams(params List<object> values);
+        void WithArrayListParams(params ArrayList values);
+        void WithCustomCollectionParams(params CustomParamsCollection values);
+    }
+
+    // Implements only the non-generic IEnumerable (no IEnumerable<T>) - still a valid params
+    // collection type per the language, since the compiler falls back to the single-argument
+    // Add overload to determine the element type.
+    public class CustomParamsCollection : IEnumerable
+    {
+        private readonly ArrayList _items = new();
+        public void Add(object item) => _items.Add(item);
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+    }
+
+    [Test]
+    public void Received_should_compare_elements_for_params_arguments()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        const string first = "first";
+        const string second = "second";
+        target.WithParams(1, first, second);
+
+        target.Received().WithParams(1, first, second);
+        target.Received().WithParams(1, Arg.Any<string>(), second);
+        target.Received().WithParams(1, first, Arg.Any<string>());
+        target.Received().WithParams(1, [first, second]);
+        target.Received().WithParams(1, Arg.Any<string[]>());
+        target.Received().WithParams(1, Arg.Is<string[]>(x => x.Length == 2));
+        target.DidNotReceive().WithParams(2, first, second);
+        target.DidNotReceive().WithParams(2, first, Arg.Any<string>());
+        target.DidNotReceive().WithParams(1, first, first);
+        target.DidNotReceive().WithParams(1, null);
+        target.DidNotReceive().WithParams(1, Arg.Is<string[]>(x => x.Length > 3));
+    }
+
+    [Test]
+    public void Returns_should_work_with_params()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        target.WithParams(Arg.Any<int>(), Arg.Is<string>(x => x == "one")).Returns("fred");
+
+        Assert.That(target.WithParams(1, "one"), Is.EqualTo("fred"));
+    }
+
+    [Test]
+    public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_1()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+
+        Assert.Throws<AmbiguousArgumentsException>(() =>
+        {
+            target.GetValue(0, Arg.Any<int>()).Returns(42);
+        });
+    }
+
+    [Test]
+    public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_2()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+
+        Assert.Throws<AmbiguousArgumentsException>(() =>
+        {
+            target.GetValue(Arg.Any<int>(), 0).Returns(42);
+        });
+    }
+
+    [Test]
+    public void Should_correctly_use_matchers_crossing_the_params_boundary()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        target.GetValue(Arg.Is(0), Arg.Any<int>()).Returns(42);
+
+        var result = target.GetValue(0, 100);
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Should_match_array_params_the_same_way_as_a_baseline()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg = new object();
+
+        target.WithArrayParams(arg);
+
+        target.Received().WithArrayParams(arg);
+    }
+
+    [Test]
+    public void Should_match_received_call_with_single_element_params_collection()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg = new object();
+
+        target.WithEnumerableParams(arg);
+
+        target.Received().WithEnumerableParams(arg);
+    }
+
+    [Test]
+    public void Should_match_received_call_with_multi_element_params_collection()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg1 = new object();
+        var arg2 = new object();
+
+        target.WithEnumerableParams(arg1, arg2);
+
+        target.Received().WithEnumerableParams(arg1, arg2);
+    }
+
+    [Test]
+    public void Should_not_match_received_call_with_different_params_collection_contents()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+
+        target.WithEnumerableParams(new object());
+
+        Assert.Throws<ReceivedCallsException>(() => target.Received().WithEnumerableParams(new object()));
+    }
+
+    [Test]
+    public void Should_match_received_call_with_params_collection_declared_as_concrete_list_type()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg = new object();
+
+        target.WithListParams(arg);
+
+        target.Received().WithListParams(arg);
+    }
+
+    [Test]
+    public void Should_match_received_call_with_params_collection_declared_as_non_generic_bcl_collection()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg = new object();
+
+        target.WithArrayListParams(arg);
+
+        target.Received().WithArrayListParams(arg);
+    }
+
+    [Test]
+    public void Should_match_received_call_with_params_collection_declared_as_custom_non_generic_collection()
+    {
+        var target = Substitute.For<IMethodsWithParams>();
+        var arg = new object();
+
+        target.WithCustomCollectionParams(arg);
+
+        target.Received().WithCustomCollectionParams(arg);
+    }
+}

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -10,7 +10,7 @@ using static NSubstitute.ArgMatchers;
 namespace NSubstitute.Acceptance.Specs;
 
 [TestFixture]
-public class ArgumentMatching
+public partial class ArgumentMatching
 {
     private ISomething _something;
 
@@ -200,26 +200,6 @@ public class ArgumentMatching
     }
 
     [Test]
-    public void Received_should_compare_elements_for_params_arguments()
-    {
-        const string first = "first";
-        const string second = "second";
-        _something.WithParams(1, first, second);
-
-        _something.Received().WithParams(1, first, second);
-        _something.Received().WithParams(1, Arg.Any<string>(), second);
-        _something.Received().WithParams(1, first, Arg.Any<string>());
-        _something.Received().WithParams(1, [first, second]);
-        _something.Received().WithParams(1, Arg.Any<string[]>());
-        _something.Received().WithParams(1, Arg.Is<string[]>(x => x.Length == 2));
-        _something.DidNotReceive().WithParams(2, first, second);
-        _something.DidNotReceive().WithParams(2, first, Arg.Any<string>());
-        _something.DidNotReceive().WithParams(1, first, first);
-        _something.DidNotReceive().WithParams(1, null);
-        _something.DidNotReceive().WithParams(1, Arg.Is<string[]>(x => x.Length > 3));
-    }
-
-    [Test]
     public void Should_allow_to_specify_any_for_ref_argument()
     {
         _something.MethodWithRefParameter(Arg.Any<int>(), ref Arg.Any<int>()).Returns(42);
@@ -360,14 +340,6 @@ public class ArgumentMatching
     }
 
     [Test]
-    public void Returns_should_work_with_params()
-    {
-        _something.WithParams(Arg.Any<int>(), Arg.Is<string>(x => x == "one")).Returns("fred");
-
-        Assert.That(_something.WithParams(1, "one"), Is.EqualTo("fred"));
-    }
-
-    [Test]
     public void Resolve_setter_arg_matcher_with_more_specific_type_than_member_signature()
     {
         const string value = "some string";
@@ -418,44 +390,6 @@ public class ArgumentMatching
         _something.WithNullableArg(Arg.Any<int?>()).ReturnsForAnyArgs(123);
 
         Assert.That(_something.WithNullableArg(234), Is.EqualTo(123));
-    }
-
-    public interface IMethodsWithParamsArgs
-    {
-        int GetValue(int primary, params int[] others);
-    }
-
-    [Test]
-    public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_1()
-    {
-        var target = Substitute.For<IMethodsWithParamsArgs>();
-
-        Assert.Throws<AmbiguousArgumentsException>(() =>
-        {
-            target.GetValue(0, Arg.Any<int>()).Returns(42);
-        });
-    }
-
-    [Test]
-    public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_2()
-    {
-        var target = Substitute.For<IMethodsWithParamsArgs>();
-
-        Assert.Throws<AmbiguousArgumentsException>(() =>
-        {
-            target.GetValue(Arg.Any<int>(), 0).Returns(42);
-        });
-    }
-
-    [Test]
-    public void Should_correctly_use_matchers_crossing_the_params_boundary()
-    {
-        var target = Substitute.For<IMethodsWithParamsArgs>();
-        target.GetValue(Arg.Is(0), Arg.Any<int>()).Returns(42);
-
-        var result = target.GetValue(0, 100);
-
-        Assert.That(result, Is.EqualTo(42));
     }
 
     [Test]

--- a/tests/NSubstitute.Acceptance.Specs/ArrayContentsArgumentMatcherCompat.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArrayContentsArgumentMatcherCompat.cs
@@ -1,0 +1,19 @@
+using NSubstitute.Core.Arguments;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs;
+
+[TestFixture]
+public class ArrayContentsArgumentMatcherCompat
+{
+    [Test]
+    [Obsolete]
+    public void Should_still_work_now_it_is_deprecated()
+    {
+        var spec = new ArgumentSpecification(typeof(int), new EqualsArgumentMatcher(1));
+        var matcher = new ArrayContentsArgumentMatcher([spec]);
+
+        Assert.That(matcher.IsSatisfiedBy(new[] { 1 }), Is.True);
+        Assert.That(matcher.IsSatisfiedBy(new[] { 2 }), Is.False);
+    }
+}

--- a/tests/NSubstitute.Specs/Arguments/ParamsContentsArgumentMatcherSpecs.cs
+++ b/tests/NSubstitute.Specs/Arguments/ParamsContentsArgumentMatcherSpecs.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace NSubstitute.Specs.Arguments
 {
-    public class ArrayContentsArgumentMatcherSpecs : ConcernFor<ArrayContentsArgumentMatcher>
+    public class ParamsContentsArgumentMatcherSpecs : ConcernFor<ParamsContentsArgumentMatcher>
     {
         private IArgumentSpecification[] _argumentSpecifications;
         private string[] _argument;
@@ -109,9 +109,9 @@ namespace NSubstitute.Specs.Arguments
             return new ArgumentFormatter().Format(text, highlight);
         }
 
-        public override ArrayContentsArgumentMatcher CreateSubjectUnderTest()
+        public override ParamsContentsArgumentMatcher CreateSubjectUnderTest()
         {
-            return new ArrayContentsArgumentMatcher(_argumentSpecifications);
+            return new ParamsContentsArgumentMatcher(_argumentSpecifications);
         }
     }
 }


### PR DESCRIPTION
Fixes #905

Currently we support `params` for arrays only, while since C# 13 we could have many more types here. This PR adds support for that. I deprecated some of the code instead of deleting it just to play safe.

I tried to keep all params syntax knowledge in one class, so it's easy to maintain our interop with language. I also extracted all tests into a partial class - so it's easier to maintain it, as argument matching spec is growing quite a lot.

Notice, we still don't support `Span/ReadOnlySpan` primarily due to luck of support by the proxy library. I mentioned that in #992 so it's not lost.