### PR TITLE
fix: Use bash to expand glob in NuGet push step

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -38,6 +38,7 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Push packages to NuGet.org
+        shell: bash
         run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json
         env:
           NUGET_API_KEY: ${{ steps.nugetLogin.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
Follow up on #987.

I didn't have a chance to test it and apparently there are issues with globbing and powershell. Let's try this change and see if it helps. You'll have to re-create the tag. Just delete the tag and then go to releases and create it one more time :)