### PR TITLE
Document that Received.InOrder does not track property getters

### DIFF
--- a/docs/help/received-in-order/index.md
+++ b/docs/help/received-in-order/index.md
@@ -39,6 +39,8 @@ public void SubscribeToEventBeforeOpeningConnection() {
 }
 ```
 
+**Note:** `Received.InOrder` does not track calls to property getters; only method calls (and event subscriptions) are checked. This is by design: a getter is often accessed just to reach a nested substitute (e.g. `a.Nested.Call()`), and requiring that access to happen in an exact position in the sequence would make many legitimate tests painful to write. If you need to assert on a property value, use [`Received()`](/help/received-calls/) or [`Returns`](/help/set-return-value/) separately, outside of `Received.InOrder`.
+
 <!--
 ```requiredcode
 public class Controller {

--- a/src/NSubstitute/Received.cs
+++ b/src/NSubstitute/Received.cs
@@ -11,7 +11,9 @@ public class Received
     /// <summary>
     /// Asserts the calls to the substitutes contained in the given Action were
     /// received by these substitutes in the same order. Calls to property getters are not included
-    /// in the assertion.
+    /// in the assertion. This is by design: getters are often accessed just to reach a nested
+    /// substitute (e.g. <c>a.Nested.Call()</c>), and requiring that access to happen in an exact
+    /// position in the sequence would make many legitimate tests painful to write.
     /// </summary>
     /// <param name="calls">Action containing calls to substitutes in the expected order</param>
     public static void InOrder(Action calls)


### PR DESCRIPTION
## Summary
Closes the documentation gap identified in #839. `Received.InOrder` intentionally excludes property getter calls from order verification — this is by-design behavior, confirmed by @dtchepak in the issue, not a bug.

- Expanded the XML doc comment on `Received.InOrder` with the reasoning (getters are often accessed just to reach a nested substitute, e.g. `a.Nested.Call()`, and requiring exact-position tracking of those accesses would make many legitimate tests painful to write).
- Added a note to the `docs/help/received-in-order` help page explaining the same, with a pointer to `Received()` for asserting on property values instead.

No behavior change — docs only.

## Test plan
- [x] Docs-only change; no code behavior affected.
- [x] Built `docs/` mentally against existing markdown conventions in the same file (no new links/tools required).